### PR TITLE
Change source URL for install_from_other_source

### DIFF
--- a/test/smokes/rubocop/gem_install/install_from_other_source/sideci.yml
+++ b/test/smokes/rubocop/gem_install/install_from_other_source/sideci.yml
@@ -3,4 +3,4 @@ linter:
     gems:
       - name: rubocop
         version: 0.60.0
-        source: https://gems.ruby-china.com
+        source: https://rubygems.cae.me.uk


### PR DESCRIPTION
`install_from_other_source` sometimes fails.
I want to try the other source, https://rubygems.cae.me.uk/.

According to the mirror site, it is hosted at Bytemark.