### PR TITLE
Add helper method to extract an analyzer version

### DIFF
--- a/lib/node_harness/processor.rb
+++ b/lib/node_harness/processor.rb
@@ -84,11 +84,11 @@ module NodeHarness
       MSG
     end
 
-    def extract_version!(command, version_option = "--version", *extra_options)
+    def extract_version!(command, version_option = "--version", *extra_options, pattern: /v?(\d+\.\d+\.\d+)/)
       command_line = [command, version_option, *extra_options]
       outputs = capture3!(*command_line)
       outputs.each do |output|
-        match = /v?(\d+\.\d+\.\d+)/.match(output)
+        match = pattern.match(output)
         return match[1] if match
       end
       raise "Not found version from '#{command_line.join(' ')}'"

--- a/lib/node_harness/processor.rb
+++ b/lib/node_harness/processor.rb
@@ -74,6 +74,26 @@ module NodeHarness
       analyzer or raise "No analyzer set"
     end
 
+    def analyzer_version
+      raise NotImplementedError, <<~MSG
+        A typical implementation:
+
+        def #{__method__}
+          @#{__method__} ||= extract_version! "some_command"
+        end
+      MSG
+    end
+
+    def extract_version!(command, version_option = "--version", *extra_options)
+      command_line = [command, version_option, *extra_options]
+      outputs = capture3!(*command_line)
+      outputs.each do |output|
+        match = /v?(\d+\.\d+\.\d+)/.match(output)
+        return match[1] if match
+      end
+      raise "Not found version from '#{command_line.join(' ')}'"
+    end
+
     def self.ci_config_section_name
       self.name
     end

--- a/lib/node_harness/runners/flake8/processor.rb
+++ b/lib/node_harness/runners/flake8/processor.rb
@@ -33,7 +33,7 @@ module NodeHarness
         private
 
         def analyzer
-          NodeHarness::Analyzer.new(name: 'Flake8', version: flake8_version)
+          NodeHarness::Analyzer.new(name: 'Flake8', version: analyzer_version)
         end
 
         def prepare_config
@@ -96,8 +96,8 @@ module NodeHarness
           @python3_version ||= capture3!('pyenv', 'versions', '--bare').first.match(/^3[0-9\.]+$/m).to_s
         end
 
-        def flake8_version
-          @flake8_version ||= capture3!('flake8', '--version').first.split.first
+        def analyzer_version
+          @analyzer_version ||= extract_version! 'flake8'
         end
 
         def parse_result(output)

--- a/sig/node_harness.rbi
+++ b/sig/node_harness.rbi
@@ -211,6 +211,8 @@ class NodeHarness::Processor
   def with_analyzer: <'x> (Analyzer?) { () -> 'x } -> 'x
   def analyzer: -> Analyzer?
   def analyzer!: -> Analyzer
+  def analyzer_version: -> String
+  def extract_version!: (String, String?) -> String
   def build_field_reference_from_path: (StrongJSON::Type::ErrorPath) -> String
   def root_dir: -> Pathname
   def directory_traversal_attack?: (String) -> bool

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -389,6 +389,10 @@ class ProcessorTest < Minitest::Test
       mock(processor).capture3!("foo", "bar", "version") { ["", "7.8.20 version\n"] }
       assert_equal "7.8.20", processor.extract_version!("foo", "bar", "version")
 
+      # change pattern
+      mock(processor).capture3!("foo", "bar", "-v") { ["ver 1.2", ""] }
+      assert_equal "1.2", processor.extract_version!("foo", "bar", "-v", pattern: /ver (\d+.\d+)\b/)
+
       # not found
       mock(processor).capture3!("foo", "-v") { ["2.1", ""] }
       error = assert_raises { processor.extract_version!("foo", "-v") }


### PR DESCRIPTION
Usage:

```ruby
module NodeHarness
  class Foo::Processor < Processor
    def analyzer_version
      @analyzer_version ||= extract_version! "foo"
    end
  end
end
```

Also, this changes only Flake8 processor using the new methods.
For other processors, I will do it on other PRs.