### PR TITLE
Friendly error message for `rake docker:*` tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -87,11 +87,25 @@ namespace :docker do
   end
 
   def analyzer
-    ENV.fetch('ANALYZER')
+    key = 'ANALYZER'
+    ENV.fetch(key).tap do |value|
+      abort <<~MSG if value.empty?
+        Error: `#{key}` environment variable must be required. For example, run as follow:
+
+            $ #{key}=rubocop bundle exec rake docker:build
+      MSG
+    end
   end
 
   def tag
-    ENV.fetch('TAG').tap { |value| raise 'Environment variable `TAG` must not be an empty string.' if value.empty? }
+    key = 'TAG'
+    ENV.fetch(key).tap do |value|
+      abort <<~MSG if value.empty?
+        Error: `#{key}` environment variable must be required. For example, run as follow:
+
+            $ #{key}=dev bundle exec rake docker:build
+      MSG
+    end
   end
 
   def docker_user


### PR DESCRIPTION
Before:

```
$ bundle exec rake docker:build
docker build -t sider/runner_:dev -f images/Dockerfile .
invalid argument "sider/runner_:dev" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
rake aborted!
```

After:

```
$ bundle exec rake docker:build
Error: `ANALYZER` environment variable must be required. For example, run as follow:

    $ ANALYZER=rubocop bundle exec rake docker:build
```