### PR TITLE
Fix type-check errors due to CLI module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs:
       - install_gems
       - install_npm_and_yarn
       - run: bundle exec rake test
+      - run: bundle exec rake typecheck
       - run: bundle exec rake dockerfile:generate
       - run: bundle exec rake dockerfile:verify
   runner_rubocop:

--- a/sig/node_harness.rbi
+++ b/sig/node_harness.rbi
@@ -275,12 +275,14 @@ class NodeHarness::CLI
   attr_reader ssh_key: String
   attr_reader working_dir: String?
   attr_reader guid: String
-  @encryption_key: nil
+  attr_reader analyzer: String
 
   def initialize: (argv: Array<String>, stdout: IO, stderr: IO) -> any
 
   def with_working_dir: <'x> { (Pathname) -> 'x } -> 'x
+  def processor_class: () -> Processor.class
   def validate_options!: () -> self
+  def validate_analyzer!: () -> void
   def run: () -> void
 end
 


### PR DESCRIPTION
```
lib/node_harness/cli.rb:71:6: NoMethodError: type=::NodeHarness::CLI, method=validate_analyzer! (validate_analyzer!)
lib/node_harness/cli.rb:76:44: NoMethodError: type=::NodeHarness::CLI, method=analyzer (analyzer)
lib/node_harness/cli.rb:77:61: NoMethodError: type=::NodeHarness::CLI, method=processor_class (processor_class)
lib/node_harness/cli.rb:109:8: NoMethodError: type=::NodeHarness::CLI, method=analyzer (analyzer)
lib/node_harness/cli.rb:118:61: NoMethodError: type=::NodeHarness::CLI, method=processor_class (processor_class)
```

Also, this enables type-checking on CI.

See #46 #55 