### PR TITLE
Remove NodeHarness::VERSION

### DIFF
--- a/lib/node_harness.rb
+++ b/lib/node_harness.rb
@@ -1,5 +1,3 @@
-require "node_harness/version"
-
 require "bundler"
 require "pathname"
 require "open3"

--- a/lib/node_harness/cli.rb
+++ b/lib/node_harness/cli.rb
@@ -96,7 +96,6 @@ module NodeHarness
           ci_config = harness.ci_config
           json = {
             result: result.as_json,
-            "harness-version": VERSION,
             warnings: warnings,
             ci_config: ci_config,
           }

--- a/lib/node_harness/schema/result.rb
+++ b/lib/node_harness/schema/result.rb
@@ -26,7 +26,7 @@ module NodeHarness
       let :missing_file_failure, object(guid: string, timestamp: string, type: literal("missing_files"), files: array(string))
       let :error, object(guid: string, timestamp: string, type: literal("error"), class: string, backtrace: array(string), inspect: string)
 
-      let :envelope, object(result: enum(success, failure, missing_file_failure, error), "harness-version": string, warnings: array(warning), ci_config: any?)
+      let :envelope, object(result: enum(success, failure, missing_file_failure, error), warnings: array(warning), ci_config: any?)
     end
   end
 end

--- a/lib/node_harness/testing/smoke.rb
+++ b/lib/node_harness/testing/smoke.rb
@@ -115,7 +115,6 @@ module NodeHarness
       @configs = {}
 
       def self.add_test(name, result, **others)
-        others[:'harness-version'] ||= :_
         others[:warnings] ||= []
         others[:ci_config] ||= :_
 

--- a/lib/node_harness/version.rb
+++ b/lib/node_harness/version.rb
@@ -1,3 +1,0 @@
-module NodeHarness
-  VERSION = "3.0.1"
-end

--- a/sig/node_harness.rbi
+++ b/sig/node_harness.rbi
@@ -272,8 +272,6 @@ end
 module NodeHarness
 end
 
-NodeHarness::VERSION: String
-
 type NodeHarness::gems_item = {
   "name" => String,
   "version" => String?,

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -84,7 +84,6 @@ class CLITest < Minitest::Test
       assert objects.find {|hash| hash[:trace] == 'command_line' && hash[:command_line] == ["test", "command"] }
       assert objects.find {|hash| hash[:trace] == 'status' && hash[:status] == 31 }
       assert objects.find {|hash| hash[:trace] == 'warning' && hash[:message] == 'hogehogewarn' }
-      assert objects.find {|hash| hash[:"harness-version"] && hash[:result] }
       assert objects.find {|hash| hash[:warnings] == [{message: 'hogehogewarn', file: nil}]}
       assert objects.find {|hash| hash[:ci_config] == sider_yml}
     end
@@ -104,7 +103,6 @@ class CLITest < Minitest::Test
       objects = reader.each_object.to_a
 
       assert objects.find {|hash| hash[:trace] == 'error' && hash[:message].match?(/Parse error occurred/) }
-      assert objects.find {|hash| hash[:"harness-version"] && hash[:result] }
       assert objects.find {|hash| hash[:warnings] == []}
       assert objects.find {|hash| hash[:ci_config] == nil}
     end

--- a/test/node_harness_test.rb
+++ b/test/node_harness_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class NodeHarnessTest < Minitest::Test
-  def test_that_it_has_a_version_number
-    refute_nil ::NodeHarness::VERSION
-  end
-end


### PR DESCRIPTION
Fix #60 
NodeHarness is no longer Ruby gem, so `NodeHarness::VERSION` is unnecessary.