### PR TITLE
[Refactor] Simplify `Nodejs` module about getting analyzer version

### DIFF
--- a/lib/node_harness/nodejs.rb
+++ b/lib/node_harness/nodejs.rb
@@ -32,31 +32,8 @@ module NodeHarness
       nodejs_analyzer_locally_installed? ? nodejs_analyzer_local_command : nodejs_analyzer_command
     end
 
-    # Return `true` if the analyzer is locally installed.
-    def nodejs_analyzer_locally_installed?
-      (current_dir / nodejs_analyzer_local_command).exist?
-    end
-
-    # Return the analyzer version by using a given command.
-    # This is a default implementation. Please override this method if you need.
-    def nodejs_analyzer_version_via(command)
-      stdout, _ = capture3! command, "--version"
-      /v?(\d+\.\d+\.\d+)/.match(stdout) { |m| m[1] } or raise "Not found version for '#{command}'"
-    end
-
-    # Return the globally installed analyzer version.
-    def nodejs_analyzer_global_version
-      @nodejs_analyzer_global_version ||= nodejs_analyzer_version_via(nodejs_analyzer_command)
-    end
-
-    # Return the locally installed analyzer version.
-    def nodejs_analyzer_local_version
-      @nodejs_analyzer_local_version ||= nodejs_analyzer_version_via(nodejs_analyzer_local_command)
-    end
-
-    # Return the analyzer version which will actually be ran.
-    def nodejs_analyzer_version
-      nodejs_analyzer_locally_installed? ? nodejs_analyzer_local_version : nodejs_analyzer_global_version
+    def analyzer_version
+      @analyzer_version ||= nodejs_analyzer_locally_installed? ? nodejs_analyzer_local_version : nodejs_analyzer_global_version
     end
 
     # Return the actual file path of `package.json`.
@@ -101,6 +78,18 @@ module NodeHarness
     end
 
     private
+
+    def nodejs_analyzer_locally_installed?
+      (current_dir / nodejs_analyzer_local_command).exist?
+    end
+
+    def nodejs_analyzer_global_version
+      @nodejs_analyzer_global_version ||= extract_version!(nodejs_analyzer_command)
+    end
+
+    def nodejs_analyzer_local_version
+      @nodejs_analyzer_local_version ||= extract_version!(nodejs_analyzer_local_command)
+    end
 
     def check_nodejs_default_deps(defaults, constraints)
       defaults.all.each do |dependency|

--- a/lib/node_harness/runners/coffeelint/processor.rb
+++ b/lib/node_harness/runners/coffeelint/processor.rb
@@ -34,7 +34,7 @@ module NodeHarness
         end
 
         def analyzer
-          @analyzer ||= NodeHarness::Analyzer.new(name: 'CoffeeLint', version: nodejs_analyzer_version)
+          @analyzer ||= NodeHarness::Analyzer.new(name: 'CoffeeLint', version: analyzer_version)
         end
 
         def setup

--- a/lib/node_harness/runners/eslint/processor.rb
+++ b/lib/node_harness/runners/eslint/processor.rb
@@ -45,7 +45,7 @@ module NodeHarness
         end
 
         def analyzer
-          @analyzer ||= NodeHarness::Analyzer.new(name: 'ESLint', version: nodejs_analyzer_version)
+          @analyzer ||= NodeHarness::Analyzer.new(name: 'ESLint', version: analyzer_version)
         end
 
         def setup

--- a/lib/node_harness/runners/stylelint/processor.rb
+++ b/lib/node_harness/runners/stylelint/processor.rb
@@ -69,7 +69,7 @@ module NodeHarness
         end
 
         def analyzer
-          @analyzer ||= NodeHarness::Analyzer.new(name: 'stylelint', version: nodejs_analyzer_version)
+          @analyzer ||= NodeHarness::Analyzer.new(name: 'stylelint', version: analyzer_version)
         end
 
         def analyze(changes)
@@ -217,7 +217,7 @@ module NodeHarness
           # The `--allow-empty-input` option breaks with v10.0.0. Fixed with v10.0.1.
           # @see https://github.com/stylelint/stylelint/releases/tag/10.0.1
           # @see https://github.com/stylelint/stylelint/pull/4029
-          if Gem::Version.new(nodejs_analyzer_version) >= Gem::Version.new("10.0.1")
+          if Gem::Version.new(analyzer_version) >= Gem::Version.new("10.0.1")
             default_options << '--allow-empty-input'
           end
 

--- a/lib/node_harness/runners/tslint/processor.rb
+++ b/lib/node_harness/runners/tslint/processor.rb
@@ -58,7 +58,7 @@ module NodeHarness
         end
 
         def analyzer
-          @analyzer ||= NodeHarness::Analyzer.new(name: 'TSLint', version: nodejs_analyzer_version)
+          @analyzer ||= NodeHarness::Analyzer.new(name: 'TSLint', version: analyzer_version)
         end
 
         def analyze(_changes)

--- a/sig/node_harness.rbi
+++ b/sig/node_harness.rbi
@@ -380,11 +380,6 @@ module NodeHarness::Nodejs : Processor
   def nodejs_analyzer_command: -> String
   def nodejs_analyzer_local_command: -> String
   def nodejs_analyzer_bin: -> String
-  def nodejs_analyzer_locally_installed?: -> bool
-  def nodejs_analyzer_version_via: (String) -> String
-  def nodejs_analyzer_global_version: -> String
-  def nodejs_analyzer_local_version: -> String
-  def nodejs_analyzer_version: -> String
   def package_json_path: -> Pathname
   def package_json: -> Hash<Symbol, any>
   def package_lock_json_path: -> Pathname
@@ -393,6 +388,9 @@ module NodeHarness::Nodejs : Processor
                             install_option: npm_install_option | nil) -> void
 
   # private
+  def nodejs_analyzer_locally_installed?: -> bool
+  def nodejs_analyzer_global_version: -> String
+  def nodejs_analyzer_local_version: -> String
   def check_nodejs_runtime: -> void
   def check_nodejs_default_deps: (DefaultDependencies, Hash<String, Constraint>) -> void
   def check_duplicate_lockfiles: -> void


### PR DESCRIPTION
- Replace `nodejs_analyzer_version` method with `analyzer_version` method.
- Make some methods private.