### PR TITLE
Add release task and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+[Full diff](https://github.com/sider/runners/compare/0.0.5...HEAD)
+
+- Bump devon_rex images from 2.0.3 to 2.1.0 [#75](https://github.com/sider/runners/pull/75)

--- a/Rakefile
+++ b/Rakefile
@@ -116,8 +116,8 @@ desc "Release"
 task :release, [:version] do |_task, args|
   new_version = args[:version] or abort "Required version!"
 
-  sh "git pull origin master --quiet"
   sh "git checkout master --quiet"
+  sh "git pull origin master --quiet"
 
   current_version = `git describe --abbrev=0 --tags`.chomp
   unless Gem::Version.new(current_version) < Gem::Version.new(new_version)

--- a/Rakefile
+++ b/Rakefile
@@ -111,3 +111,24 @@ namespace :docker do
     sh "docker push #{image_name_latest}"
   end
 end
+
+desc "Release"
+task :release, [:version] do |_task, args|
+  new_version = args[:version] or abort "Required version!"
+
+  sh "git pull origin master --quiet"
+  sh "git checkout master --quiet"
+
+  current_version = `git describe --abbrev=0 --tags`.chomp
+  unless Gem::Version.new(current_version) < Gem::Version.new(new_version)
+    abort "Invalid version! current=#{current_version} new=#{new_version}"
+  end
+
+  sh "git diff --exit-code --quiet" do |ok|
+    abort "Uncommitted changes found!" unless ok
+  end
+
+  sh "git --no-pager log --oneline #{current_version}...HEAD"
+  sh "git tag -a #{new_version} -m 'Version #{new_version}'"
+  puts "The tag '#{new_version}' is added. Run 'git push --follow-tags'."
+end

--- a/Rakefile
+++ b/Rakefile
@@ -128,6 +128,10 @@ task :release, [:version] do |_task, args|
     abort "Uncommitted changes found!" unless ok
   end
 
+  unless File.readlines("CHANGELOG.md", chomp: true).include? "## #{new_version}"
+    abort "No entry of version #{new_version} in CHANGELOG.md!"
+  end
+
   sh "git --no-pager log --oneline #{current_version}...HEAD"
   sh "git tag -a #{new_version} -m 'Version #{new_version}'"
   puts "The tag '#{new_version}' is added. Run 'git push --follow-tags'."


### PR DESCRIPTION
```
$ rake --tasks
rake docker:build         # Run docker build
rake docker:push          # Run docker push
rake docker:smoke         # Run smoke test on Docker
rake dockerfile:generate  # Generate Dockerfile from a template
rake dockerfile:verify    # Verify Dockerfile is committed
rake release[version]     # Release
rake test                 # Run tests
```

Usage:

```
$ rake release'[0.0.6]'
```

Fix #72