### PR TITLE
Bump devon_rex images from 2.1.0 to 2.2.0

### DIFF
--- a/images/brakeman/Dockerfile
+++ b/images/brakeman/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/brakeman/Dockerfile.erb
+++ b/images/brakeman/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/checkstyle/Dockerfile
+++ b/images/checkstyle/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:2.1.0
+FROM sider/devon_rex_java:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/checkstyle/Dockerfile.erb
+++ b/images/checkstyle/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_java:2.1.0
+FROM sider/devon_rex_java:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/code_sniffer/Dockerfile
+++ b/images/code_sniffer/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_php:2.1.0
+FROM sider/devon_rex_php:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/code_sniffer/Dockerfile.erb
+++ b/images/code_sniffer/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_php:2.1.0
+FROM sider/devon_rex_php:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/coffeelint/Dockerfile
+++ b/images/coffeelint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.1.0
+FROM sider/devon_rex_npm:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/coffeelint/Dockerfile.erb
+++ b/images/coffeelint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:2.1.0
+FROM sider/devon_rex_npm:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/cppcheck/Dockerfile
+++ b/images/cppcheck/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_python:2.1.0
+FROM sider/devon_rex_python:2.2.0
 
 # NOTE: The reason using Python image: when setting `MATCHCOMPILER=yes`, Python is used to optimise cppcheck.
 #

--- a/images/cppcheck/Dockerfile.erb
+++ b/images/cppcheck/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_python:2.1.0
+FROM sider/devon_rex_python:2.2.0
 
 # NOTE: The reason using Python image: when setting `MATCHCOMPILER=yes`, Python is used to optimise cppcheck.
 #

--- a/images/eslint/Dockerfile
+++ b/images/eslint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.1.0
+FROM sider/devon_rex_npm:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/eslint/Dockerfile.erb
+++ b/images/eslint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:2.1.0
+FROM sider/devon_rex_npm:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/flake8/Dockerfile
+++ b/images/flake8/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_python:2.1.0
+FROM sider/devon_rex_python:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/flake8/Dockerfile.erb
+++ b/images/flake8/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_python:2.1.0
+FROM sider/devon_rex_python:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/go_vet/Dockerfile
+++ b/images/go_vet/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_go:2.1.0
+FROM sider/devon_rex_go:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/go_vet/Dockerfile.erb
+++ b/images/go_vet/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_go:2.1.0
+FROM sider/devon_rex_go:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/golint/Dockerfile
+++ b/images/golint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_go:2.1.0
+FROM sider/devon_rex_go:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/golint/Dockerfile.erb
+++ b/images/golint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_go:2.1.0
+FROM sider/devon_rex_go:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/gometalinter/Dockerfile
+++ b/images/gometalinter/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_go:2.1.0
+FROM sider/devon_rex_go:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/gometalinter/Dockerfile.erb
+++ b/images/gometalinter/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_go:2.1.0
+FROM sider/devon_rex_go:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/goodcheck/Dockerfile
+++ b/images/goodcheck/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/goodcheck/Dockerfile.erb
+++ b/images/goodcheck/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/haml_lint/Dockerfile
+++ b/images/haml_lint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/haml_lint/Dockerfile.erb
+++ b/images/haml_lint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/javasee/Dockerfile
+++ b/images/javasee/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:2.1.0
+FROM sider/devon_rex_java:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/javasee/Dockerfile.erb
+++ b/images/javasee/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_java:2.1.0
+FROM sider/devon_rex_java:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/jshint/Dockerfile
+++ b/images/jshint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.1.0
+FROM sider/devon_rex_npm:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/jshint/Dockerfile.erb
+++ b/images/jshint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:2.1.0
+FROM sider/devon_rex_npm:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/misspell/Dockerfile
+++ b/images/misspell/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_base:2.1.0
+FROM sider/devon_rex_base:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/misspell/Dockerfile.erb
+++ b/images/misspell/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_base:2.1.0
+FROM sider/devon_rex_base:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/phinder/Dockerfile
+++ b/images/phinder/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_php:2.1.0
+FROM sider/devon_rex_php:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/phinder/Dockerfile.erb
+++ b/images/phinder/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_php:2.1.0
+FROM sider/devon_rex_php:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/phpmd/Dockerfile
+++ b/images/phpmd/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_php:2.1.0
+FROM sider/devon_rex_php:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/phpmd/Dockerfile.erb
+++ b/images/phpmd/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_php:2.1.0
+FROM sider/devon_rex_php:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/pmd_java/Dockerfile
+++ b/images/pmd_java/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:2.1.0
+FROM sider/devon_rex_java:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/pmd_java/Dockerfile.erb
+++ b/images/pmd_java/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_java:2.1.0
+FROM sider/devon_rex_java:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/querly/Dockerfile
+++ b/images/querly/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/querly/Dockerfile.erb
+++ b/images/querly/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/rails_best_practices/Dockerfile
+++ b/images/rails_best_practices/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/rails_best_practices/Dockerfile.erb
+++ b/images/rails_best_practices/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/reek/Dockerfile
+++ b/images/reek/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/reek/Dockerfile.erb
+++ b/images/reek/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/rubocop/Dockerfile
+++ b/images/rubocop/Dockerfile
@@ -2,7 +2,18 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
+
+# NOTE: RuboCop 0.60.0 does not work on Ruby 2.6, so install and use Ruby 2.5 instead.
+#       See https://github.com/sider/runners/issues/57#issuecomment-530858769
+ENV GLOBAL_RUBY_VERSION 2.5.6
+RUN rbenv install $GLOBAL_RUBY_VERSION && \
+    rbenv global $GLOBAL_RUBY_VERSION && \
+    rbenv versions && \
+    test $(ruby -e 'puts RUBY_VERSION') = "$GLOBAL_RUBY_VERSION" && \
+    gem install bundler --version $BUNDLER1_VERSION && \
+    gem install bundler --version $BUNDLER2_VERSION && \
+    bundle -v | grep -q "$BUNDLER2_VERSION"
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/rubocop/Dockerfile.erb
+++ b/images/rubocop/Dockerfile.erb
@@ -1,4 +1,15 @@
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
+
+# NOTE: RuboCop 0.60.0 does not work on Ruby 2.6, so install and use Ruby 2.5 instead.
+#       See https://github.com/sider/runners/issues/57#issuecomment-530858769
+ENV GLOBAL_RUBY_VERSION 2.5.6
+RUN rbenv install $GLOBAL_RUBY_VERSION && \
+    rbenv global $GLOBAL_RUBY_VERSION && \
+    rbenv versions && \
+    test $(ruby -e 'puts RUBY_VERSION') = "$GLOBAL_RUBY_VERSION" && \
+    gem install bundler --version $BUNDLER1_VERSION && \
+    gem install bundler --version $BUNDLER2_VERSION && \
+    bundle -v | grep -q "$BUNDLER2_VERSION"
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/scss_lint/Dockerfile
+++ b/images/scss_lint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/scss_lint/Dockerfile.erb
+++ b/images/scss_lint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.1.0
+FROM sider/devon_rex_ruby:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/stylelint/Dockerfile
+++ b/images/stylelint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.1.0
+FROM sider/devon_rex_npm:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/stylelint/Dockerfile.erb
+++ b/images/stylelint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:2.1.0
+FROM sider/devon_rex_npm:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/swiftlint/Dockerfile
+++ b/images/swiftlint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_swift:2.1.0
+FROM sider/devon_rex_swift:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/swiftlint/Dockerfile.erb
+++ b/images/swiftlint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_swift:2.1.0
+FROM sider/devon_rex_swift:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/tslint/Dockerfile
+++ b/images/tslint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.1.0
+FROM sider/devon_rex_npm:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/tslint/Dockerfile.erb
+++ b/images/tslint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:2.1.0
+FROM sider/devon_rex_npm:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/images/tyscan/Dockerfile
+++ b/images/tyscan/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.1.0
+FROM sider/devon_rex_npm:2.2.0
 
 ARG NODE_HARNESS_DIR=$RUNNER_USER_HOME/node_harness
 COPY Gemfile* Rakefile $NODE_HARNESS_DIR/

--- a/images/tyscan/Dockerfile.erb
+++ b/images/tyscan/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:2.1.0
+FROM sider/devon_rex_npm:2.2.0
 
 <%= ERB.new(File.read('images/Dockerfile.base.erb')).result %>
 

--- a/test/smokes/goodcheck/expectations.rb
+++ b/test/smokes/goodcheck/expectations.rb
@@ -66,7 +66,7 @@ NodeHarness::Testing::Smoke.add_test("invalid_config_file", {
   type: "error",
   class: "JSON::ParserError",
   backtrace: :_,
-  inspect: "#<JSON::ParserError: 765: unexpected token at ''>"
+  inspect: "#<JSON::ParserError: 767: unexpected token at ''>"
 })
 
 NodeHarness::Testing::Smoke.add_test("with_invalid_ci_config", {


### PR DESCRIPTION
The main change is "Bump Ruby from 2.5.5 to 2.6.4".
See <https://github.com/sider/devon_rex/blob/2.2.0/CHANGELOG.md>.

However, the RuboCop runner has an issue on Ruby 2.6, so we decide to use Ruby 2.5 yet on that runner.

Fixes #57 