### PR TITLE
Improve smoke test output

### DIFF
--- a/lib/node_harness/testing/smoke.rb
+++ b/lib/node_harness/testing/smoke.rb
@@ -7,6 +7,7 @@ require 'parallel'
 module NodeHarness
   module Testing
     class Smoke
+      include Minitest::Assertions
       include UnificationAssertion
 
       ROOT_DATA_DIR = Pathname('/data')
@@ -48,9 +49,9 @@ module NodeHarness
 
         puts "-" * 30
         if results.all?
-          puts "❤️  Smoke tests pass!"
+          puts "❤️  Smoke tests passed!"
         else
-          puts "⚠️  Smoke test failed"
+          puts "❌ Smoke tests failed! -- #{results.count(true)} passed, #{results.count(false)} failed, #{results.count} total"
           exit 1
         end
       end
@@ -80,12 +81,14 @@ module NodeHarness
           when (a.is_a?(Regexp) && !b.is_a?(Regexp)) || (!a.is_a?(Regexp) && b.is_a?(Regexp))
             unless a.match?(b)
               ok = false
-              out.puts "Pattern matching failed: #{path}, #{a.inspect}, #{b.inspect}"
+              out.puts "❌ Pattern matching failed at #{path}:"
+              out.puts diff(a, b)
             end
           else
             unless a == b
               ok = false
-              out.puts "Pattern matching failed: #{path}, #{a.inspect}, #{b.inspect}"
+              out.puts "❌ Pattern matching failed at #{path}:"
+              out.puts diff(a, b)
             end
           end
         end

--- a/sig/node_harness/testing.rbi
+++ b/sig/node_harness/testing.rbi
@@ -1,4 +1,5 @@
 class NodeHarness::Testing::Smoke
+  include Minitest::Assertions
   include UnificationAssertion
 
   attr_reader argv: Array<String>

--- a/sig/polyfills/minitest.rbi
+++ b/sig/polyfills/minitest.rbi
@@ -1,0 +1,6 @@
+module Minitest
+end
+
+module Minitest::Assertions
+  def diff: (any, any) -> String
+end


### PR DESCRIPTION
- More understandable diff output via [`MiniTest::Assertions#diff`](https://github.com/seattlerb/minitest/blob/v5.11.3/lib/minitest/assertions.rb#L59).
- Add emoji to each failed test.
- Output summary on tests failed.

---

Success:

```
------------------------------
❤️  Smoke tests passed!
```

Failure:

```
------------------------------
❌ Smoke tests failed! -- 9 passed, 1 failed, 10 total
```

Each failure:

```
❌ Pattern matching failed at [:result][:inspect]:
--- expected
+++ actual
@@ -1 +1 @@
-"#<JSON::ParserError: 767: unexpected token at ''>"
+"#<JSON::ParserError: 76: unexpected token at ''>"
```