### PR TITLE
Fix stylelint smoke tests

### DIFF
--- a/test/smokes/stylelint/only_stylelint_in_package_json/package.json
+++ b/test/smokes/stylelint/only_stylelint_in_package_json/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "stylelint": "^8.3.1"
+    "stylelint": "8.3.1"
   }
 }


### PR DESCRIPTION
Lock version to prevent unexpected results when stylelint will ship new versions.