### PR TITLE
Fix `stylelint-config-recommended` version

### DIFF
--- a/images/stylelint/Dockerfile
+++ b/images/stylelint/Dockerfile
@@ -22,7 +22,7 @@ ARG STYLELINT_CONFIG_RECOMMENDED_VERSION=2.2.0
 
 # Install stylelint globally
 USER root
-RUN npm install -g stylelint@${STYLELINT_VERSION} stylelint-config-recommended@${STYLELINT_CONFIG_STANDARD_VERSION}
+RUN npm install -g stylelint@${STYLELINT_VERSION} stylelint-config-recommended@${STYLELINT_CONFIG_RECOMMENDED_VERSION}
 USER $RUNNER_USER
 
 COPY images/stylelint/sider_recommended_config.yaml images/stylelint/sider_recommended_stylelintignore $RUNNER_USER_HOME/

--- a/images/stylelint/Dockerfile.erb
+++ b/images/stylelint/Dockerfile.erb
@@ -7,7 +7,7 @@ ARG STYLELINT_CONFIG_RECOMMENDED_VERSION=2.2.0
 
 # Install stylelint globally
 USER root
-RUN npm install -g stylelint@${STYLELINT_VERSION} stylelint-config-recommended@${STYLELINT_CONFIG_STANDARD_VERSION}
+RUN npm install -g stylelint@${STYLELINT_VERSION} stylelint-config-recommended@${STYLELINT_CONFIG_RECOMMENDED_VERSION}
 USER $RUNNER_USER
 
 COPY images/stylelint/sider_recommended_config.yaml images/stylelint/sider_recommended_stylelintignore $RUNNER_USER_HOME/


### PR DESCRIPTION
`STYLELINT_CONFIG_STANDARD_VERSION` is not defined, so the latest version (`3.0.0`) of `stylelint-config-recommended` is unexpectedly installed instead of `stylelint-config-recommended@2.2.0`.