### PR TITLE
Fix smoke test diff

### DIFF
--- a/lib/node_harness/testing/smoke.rb
+++ b/lib/node_harness/testing/smoke.rb
@@ -82,13 +82,13 @@ module NodeHarness
             unless a.match?(b)
               ok = false
               out.puts "❌ Pattern matching failed at #{path}:"
-              out.puts diff(a, b)
+              out.puts diff(b, a)
             end
           else
             unless a == b
               ok = false
               out.puts "❌ Pattern matching failed at #{path}:"
-              out.puts diff(a, b)
+              out.puts diff(b, a)
             end
           end
         end


### PR DESCRIPTION
Replace 'expected' and 'actual' order.

Related to #90 

---

An incorrect example:

<img width="547" alt="image" src="https://user-images.githubusercontent.com/473530/65017785-80a79700-d962-11e9-97a6-805e766db523.png">

https://circleci.com/gh/sider/runners/6358