### PR TITLE
Set Bundler config: `jobs`, `retry`

### DIFF
--- a/images/Dockerfile.base.erb
+++ b/images/Dockerfile.base.erb
@@ -6,6 +6,10 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}

--- a/images/Dockerfile.end.erb
+++ b/images/Dockerfile.end.erb
@@ -1,0 +1,5 @@
+USER root
+RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
+USER $RUNNER_USER
+
+ENTRYPOINT ["runners", "--analyzer=<%= ENV.fetch('ANALYZER') %>"]

--- a/images/brakeman/Dockerfile
+++ b/images/brakeman/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/checkstyle/Dockerfile
+++ b/images/checkstyle/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/code_sniffer/Dockerfile
+++ b/images/code_sniffer/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/coffeelint/Dockerfile
+++ b/images/coffeelint/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/cppcheck/Dockerfile
+++ b/images/cppcheck/Dockerfile
@@ -16,7 +16,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/eslint/Dockerfile
+++ b/images/eslint/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/flake8/Dockerfile
+++ b/images/flake8/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/go_vet/Dockerfile
+++ b/images/go_vet/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/golint/Dockerfile
+++ b/images/golint/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/gometalinter/Dockerfile
+++ b/images/gometalinter/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/goodcheck/Dockerfile
+++ b/images/goodcheck/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/haml_lint/Dockerfile
+++ b/images/haml_lint/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/javasee/Dockerfile
+++ b/images/javasee/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/jshint/Dockerfile
+++ b/images/jshint/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/misspell/Dockerfile
+++ b/images/misspell/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/phinder/Dockerfile
+++ b/images/phinder/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/phpmd/Dockerfile
+++ b/images/phpmd/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/pmd_java/Dockerfile
+++ b/images/pmd_java/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/querly/Dockerfile
+++ b/images/querly/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/rails_best_practices/Dockerfile
+++ b/images/rails_best_practices/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/reek/Dockerfile
+++ b/images/reek/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/rubocop/Dockerfile
+++ b/images/rubocop/Dockerfile
@@ -23,7 +23,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/scss_lint/Dockerfile
+++ b/images/scss_lint/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/stylelint/Dockerfile
+++ b/images/stylelint/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/swiftlint/Dockerfile
+++ b/images/swiftlint/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/tslint/Dockerfile
+++ b/images/tslint/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 

--- a/images/tyscan/Dockerfile
+++ b/images/tyscan/Dockerfile
@@ -12,7 +12,11 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNERS_DIR}
 USER $RUNNER_USER
 
-RUN cd ${RUNNERS_DIR} && bundle install --without development test
+RUN cd ${RUNNERS_DIR} && \
+    bundle config --global jobs 4 && \
+    bundle config --global retry 3 && \
+    bundle config && \
+    bundle install --without='development test'
 ENV BUNDLE_GEMFILE ${RUNNERS_DIR}/Gemfile
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 


### PR DESCRIPTION
See <https://bundler.io/v2.0/man/bundle-config.1.html>

The reasons not to use environment variables like `BUNDLE_GEMFILE`:
- Prevent unexpected behaviors raised by environment variables.
- Mark that the analyzer code does not use environment variables.