### PR TITLE
Refactor Processor to use `#delegate`

### DIFF
--- a/lib/runners.rb
+++ b/lib/runners.rb
@@ -27,6 +27,7 @@ require "active_support/core_ext/hash/deep_merge"
 require "active_support/core_ext/hash/indifferent_access"
 require "active_support/core_ext/module/attribute_accessors"
 require "active_support/core_ext/string/filters"
+require "active_support/core_ext/module/delegation"
 
 require "runners/location"
 require "runners/results"

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -10,6 +10,9 @@ module Runners
     attr_reader :ci_config_for_collect
     attr_reader :shell
 
+    delegate :push_dir, :current_dir, :capture3, :capture3!, :capture3_trace, :capture3_with_retry!, to: :shell
+    delegate :env_hash, :push_env_hash, to: :shell
+
     def initialize(guid:, working_dir:, git_ssh_path:, trace_writer:)
       @guid = guid
       @working_dir = working_dir
@@ -200,44 +203,12 @@ module Runners
       path.to_s.sub('$', "$.linter.#{self.class.ci_config_section_name}")
     end
 
-    def push_dir(path, &block)
-      shell.push_dir(path, &block)
-    end
-
-    def current_dir
-      shell.current_dir
-    end
-
-    def capture3(command, *args)
-      shell.capture3(command, *args)
-    end
-
-    def capture3!(command, *args)
-      shell.capture3!(command, *args)
-    end
-
-    def capture3_trace(command, *args)
-      shell.capture3_trace(command, *args)
-    end
-
-    def capture3_with_retry!(command, *args, tries: 3)
-      shell.capture3_with_retry!(command, *args, tries: tries)
-    end
-
     def delete_unchanged_files(changes, except: [], only: [])
       trace_writer.message "Deleting unchanged files from working copy..." do
         changes.delete_unchanged(dir: working_dir, except: except, only: only) do |path|
           trace_writer.message "Deleted #{path}"
         end
       end
-    end
-
-    def env_hash
-      shell.env_hash
-    end
-
-    def push_env_hash(env, &block)
-      shell.push_env_hash(env, &block)
     end
 
     def add_warning(message, file: nil)

--- a/sig/polyfills/active_support.rbi
+++ b/sig/polyfills/active_support.rbi
@@ -1,3 +1,7 @@
 extension Class (ActiveSupport)
   def subclasses: -> Array<Class>
 end
+
+extension Module (ActiveSupport)
+  def delegate: (*(String | Symbol), to: (String | Symbol), ?prefix: (String | Symbol), ?allow_nil: bool) -> void
+end


### PR DESCRIPTION
As I see the code, some methods of `Processor` look delegated to the `Shell` instance. I will change the implementation of `Shell` to add a feature, but I want to refactor it before doing that.