### PR TITLE
[Refactor] Improve `Processor#extract_version!`

### DIFF
--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -87,7 +87,7 @@ module Runners
       MSG
     end
 
-    def extract_version!(command, version_option = "--version", pattern: /v?(\d+\.\d+\.\d+)/)
+    def extract_version!(command, version_option = "--version", pattern: /v?(\d+\.\d+(\.\d+)?)\b/)
       command_options = Array(version_option)
       outputs = capture3!(command, *command_options)
       outputs.each do |output|

--- a/lib/runners/processor/checkstyle.rb
+++ b/lib/runners/processor/checkstyle.rb
@@ -54,7 +54,7 @@ module Runners
     end
 
     def analyzer_version
-      @analyzer_version ||= extract_version! "java", ["-jar", jar_path, "--version"], pattern: /\s(\d+\.\d+)$/
+      @analyzer_version ||= extract_version! "java", ["-jar", jar_path, "--version"]
     end
 
     def analyzer

--- a/lib/runners/processor/cppcheck.rb
+++ b/lib/runners/processor/cppcheck.rb
@@ -35,7 +35,7 @@ module Runners
     end
 
     def analyzer_version
-      @analyzer_version ||= extract_version! cppcheck, pattern: /Cppcheck (\d+\.\d+)/
+      @analyzer_version ||= extract_version! cppcheck
     end
 
     def setup

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -423,12 +423,16 @@ class ProcessorTest < Minitest::Test
       mock(processor).capture3!("foo", "bar", "version") { ["", "7.8.20 version\n"] }
       assert_equal "7.8.20", processor.extract_version!("foo", ["bar", "version"])
 
+      # non semver
+      mock(processor).capture3!("foo", "--version") { ["Foo 1.2", ""] }
+      assert_equal "1.2", processor.extract_version!("foo")
+
       # change pattern
       mock(processor).capture3!("foo", "bar", "-v") { ["ver 1.2", ""] }
       assert_equal "1.2", processor.extract_version!("foo", ["bar", "-v"], pattern: /ver (\d+.\d+)\b/)
 
       # not found
-      mock(processor).capture3!("foo", "-v") { ["2.1", ""] }
+      mock(processor).capture3!("foo", "-v") { ["no version", ""] }
       error = assert_raises { processor.extract_version!("foo", "-v") }
       assert_equal "Not found version from 'foo -v'", error.message
     end


### PR DESCRIPTION
It can extract a non-semver version by this change. E.g. `2.90`.