### PR TITLE
Fix failures on skipped in smoke tests

### DIFF
--- a/sig/runners/testing.rbi
+++ b/sig/runners/testing.rbi
@@ -11,7 +11,7 @@ class Runners::Testing::Smoke
   def expectations: -> Pathname
   def initialize: (Array<String>) -> any
   def run: () -> void
-  def run_test: (String, any, IO) -> bool
+  def run_test: (String, any, IO) -> String
   def unify_result: (any, any, IO) -> bool
   def with_data_container: <'x> { () -> 'x } -> 'x
   def command_line: (String, Configuration) -> String


### PR DESCRIPTION
This bug occurs only when specifying the `ONLY` environment variable.