### PR TITLE
Fix ktlint bug

### DIFF
--- a/lib/runners/processor/ktlint.rb
+++ b/lib/runners/processor/ktlint.rb
@@ -93,11 +93,11 @@ module Runners
     def run_cli
       args = ["--reporter=json"]
 
-      cli_config[:ruleset].each do |rule|
-        args.push("--ruleset", rule.to_s)
+      cli_config[:ruleset].each do |ruleset|
+        args.push("--ruleset", ruleset.to_s)
       end
       unless cli_config[:disabled_rules].empty?
-        args.push("--disabled_rules", options[:disabled_rules].join(","))
+        args.push("--disabled_rules", cli_config[:disabled_rules].join(","))
       end
       if cli_config[:experimental]
         args.push("--experimental")

--- a/test/smokes/ktlint/cli_with_options/sider.yml
+++ b/test/smokes/ktlint/cli_with_options/sider.yml
@@ -1,0 +1,14 @@
+linter:
+  ktlint:
+    cli:
+      patterns:
+        - "src/**/*.kt"
+        - "!src/**/*Test.kt"
+      ruleset: []
+        # NOTE: No way to test `ruleset` easily.
+        # - "https://example.com/ktlint/custom/ruleset.jar"
+      disabled_rules:
+        - "no-wildcard-imports"
+        - "indent"
+        - "experimental:indent"
+      experimental: true

--- a/test/smokes/ktlint/cli_with_options/src/App.kt
+++ b/test/smokes/ktlint/cli_with_options/src/App.kt
@@ -1,0 +1,7 @@
+package hoge_fuga
+
+import io.vertx.core.*
+
+fun main(args: Array<String>) {
+  println("Hello");
+}

--- a/test/smokes/ktlint/cli_with_options/src/AppTest.kt
+++ b/test/smokes/ktlint/cli_with_options/src/AppTest.kt
@@ -1,0 +1,3 @@
+fun main(args: Array<String>) {
+    println("Hello");
+}

--- a/test/smokes/ktlint/expectations.rb
+++ b/test/smokes/ktlint/expectations.rb
@@ -34,6 +34,32 @@ Smoke.add_test(
 )
 
 Smoke.add_test(
+  "cli_with_options",
+  {
+    guid: "test-guid",
+    timestamp: :_,
+    type: "success",
+    analyzer: { name: 'ktlint', version: "0.34.2" },
+    issues: [
+      {
+        id: "experimental:package-name",
+        path: "src/App.kt",
+        location: { start_line: 1 },
+        message: "Package name must not contain underscore (cannot be auto-corrected)",
+        links: []
+      },
+      {
+        id: "no-semi",
+        path: "src/App.kt",
+        location: { start_line: 6 },
+        message: "Unnecessary semicolon",
+        links: []
+      },
+    ],
+  }
+)
+
+Smoke.add_test(
   "gradle",
   {
     guid: "test-guid",


### PR DESCRIPTION
When specifying the `ktlint.cli.disabled_rules` option, the undefined error of `options` variable occurs.