### PR TITLE
Show deprecation warning for too old ESLint

### DIFF
--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -214,6 +214,14 @@ module Runners
       @warnings << {message: message, file: file}
     end
 
+    def add_warning_if_deprecated_version(minimum:, file: nil)
+      unless Gem::Version.create(minimum) <= Gem::Version.create(analyzer_version)
+        add_warning <<~MSG.strip, file: file
+          The version `#{analyzer_version}` is deprecated on Sider. `>= #{minimum}` is required. Please consider upgrading to a new version.
+        MSG
+      end
+    end
+
     # Prohibit directory traversal attack, e.g.
     # - '../../etc/passwd'
     # - 'config/../../../etc/passwd'

--- a/lib/runners/processor/eslint.rb
+++ b/lib/runners/processor/eslint.rb
@@ -33,6 +33,7 @@ module Runners
     CONSTRAINTS = {
       "eslint" => Constraint.new(">= 3.19.0", "< 7.0.0")
     }.freeze
+    RECOMMENDED_MINIMUM_VERSION = "4.19.1".freeze
 
     def self.ci_config_section_name
       'eslint'
@@ -50,6 +51,7 @@ module Runners
           return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
         end
         analyzer
+        add_warning_if_deprecated_version(minimum: RECOMMENDED_MINIMUM_VERSION, file: "package.json")
         yield
       end
     end
@@ -197,7 +199,6 @@ module Runners
       # NOTE: ESLint v5 returns 2 as exit status when fatal error is occurred.
       #       However, this runner doesn't depends on this behavior because it also supports ESLint v4
       output = working_dir + 'output.json'
-
 
       stdout, stderr, status = capture3(
         nodejs_analyzer_bin,

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -189,7 +189,8 @@ class Runners::Processor
   def env_hash: -> Hash<String, String?>
 
   def delete_unchanged_files: (Changes, ?except: Array<String>, ?only: Array<String>) -> void
-  def add_warning: (String, ?file: String?) -> any
+  def add_warning: (String, ?file: String?) -> void
+  def add_warning_if_deprecated_version: (minimum: String, ?file: String?) -> void
   def self.ci_config_section_name: () -> String
   def with_analyzer: <'x> (Analyzer?) { () -> 'x } -> 'x
   def analyzer: -> Analyzer?

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -22,8 +22,7 @@ Smoke.add_test(
   }
 )
 
-Smoke.add_test(
-  'sideci_valid_npm_install_option',
+Smoke.add_test('sideci_valid_npm_install_option', {
   guid: 'test-guid',
   timestamp: :_,
   type: 'success',
@@ -51,7 +50,9 @@ Smoke.add_test(
     name: 'ESLint',
     version: '3.19.0'
   }
-)
+}, {
+  warnings: [{ message: /The version `3.19.0` is deprecated on Sider. `>= 4.19.1` is required/, file: "package.json" }],
+})
 
 # This test case's .eslintrc includes ESLint plugin, thus Sider fails because of the plugin unavailable.
 Smoke.add_test(
@@ -66,8 +67,7 @@ Smoke.add_test(
   }
 )
 
-Smoke.add_test(
-  'dir_option_is_array',
+Smoke.add_test('dir_option_is_array', {
   guid: 'test-guid',
   timestamp: :_,
   type: 'success',
@@ -101,10 +101,11 @@ Smoke.add_test(
     name: 'ESLint',
     version: '3.19.0'
   }
-)
+}, {
+  warnings: [{ message: /The version `3.19.0` is deprecated on Sider. `>= 4.19.1` is required/, file: "package.json" }],
+})
 
-Smoke.add_test(
-  'dir_option_is_string',
+Smoke.add_test('dir_option_is_string', {
   guid: 'test-guid',
   timestamp: :_,
   type: 'success',
@@ -124,10 +125,11 @@ Smoke.add_test(
     name: 'ESLint',
     version: '3.19.0'
   }
-)
+}, {
+  warnings: [{ message: /The version `3.19.0` is deprecated on Sider. `>= 4.19.1` is required/, file: "package.json" }],
+})
 
-Smoke.add_test(
-  'pinned_eslint',
+Smoke.add_test('pinned_eslint', {
   guid: 'test-guid',
   timestamp: :_,
   type: 'success',
@@ -154,7 +156,9 @@ Smoke.add_test(
       location: { start_line: 2 } }
   ],
   analyzer: { name: 'ESLint', version: '4.0.0'}
-)
+}, {
+  warnings: [{ message: /The version `4.0.0` is deprecated on Sider. `>= 4.19.1` is required/, file: "package.json" }],
+})
 
 Smoke.add_test("no_files", {
   guid: 'test-guid',


### PR DESCRIPTION
This aims to promote upgrading for users which are using too old ESLint versions (The latest version is `6.4.0`).
When I examine our statistics, the oldest ESLint used on Sider is `3.19.1` (the latest of 3.x series).
The next is `4.19.1` (the latest of 4.x series).

I think that such work is common for other tools, so I add `Processor#add_warning_if_deprecated_version` method.