### PR TITLE
Bump default stylelint and stylelint-config-recommended

### DIFF
--- a/images/stylelint/Dockerfile
+++ b/images/stylelint/Dockerfile
@@ -31,7 +31,14 @@ ENV PATH ${RUNNER_USER_HOME}/stylelint/node_modules/.bin:${PATH}
 # See https://nodejs.org/api/cli.html#cli_node_path_path
 ENV NODE_PATH ${RUNNER_USER_HOME}/stylelint/node_modules:${NODE_PATH}
 
-COPY images/stylelint/sider_recommended_config.yaml images/stylelint/sider_recommended_stylelintignore $RUNNER_USER_HOME/
+# NOTE: Install the older version to run `stylelint-config-recommended` with stylelint v8.
+RUN cd ${RUNNER_USER_HOME} && \
+    mkdir stylelint-config-recommended.old && \
+    cd stylelint-config-recommended.old && \
+    npm install --no-package-lock --ignore-scripts stylelint-config-recommended@2
+COPY images/stylelint/sider_recommended_config.old.yaml ${RUNNER_USER_HOME}/
+
+COPY images/stylelint/sider_recommended_config.yaml images/stylelint/sider_recommended_stylelintignore ${RUNNER_USER_HOME}/
 
 USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}

--- a/images/stylelint/Dockerfile.erb
+++ b/images/stylelint/Dockerfile.erb
@@ -3,6 +3,13 @@ FROM sider/devon_rex_npm:2.2.2
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.npm.erb' %>
 
-COPY images/stylelint/sider_recommended_config.yaml images/stylelint/sider_recommended_stylelintignore $RUNNER_USER_HOME/
+# NOTE: Install the older version to run `stylelint-config-recommended` with stylelint v8.
+RUN cd ${RUNNER_USER_HOME} && \
+    mkdir stylelint-config-recommended.old && \
+    cd stylelint-config-recommended.old && \
+    npm install --no-package-lock --ignore-scripts stylelint-config-recommended@2
+COPY images/stylelint/sider_recommended_config.old.yaml ${RUNNER_USER_HOME}/
+
+COPY images/stylelint/sider_recommended_config.yaml images/stylelint/sider_recommended_stylelintignore ${RUNNER_USER_HOME}/
 
 <%= render_erb 'images/Dockerfile.end.erb' %>

--- a/images/stylelint/package.json
+++ b/images/stylelint/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "stylelint": "10.1.0",
-    "stylelint-config-recommended": "2.2.0"
+    "stylelint": "11.0.0",
+    "stylelint-config-recommended": "3.0.0"
   }
 }

--- a/images/stylelint/sider_recommended_config.old.yaml
+++ b/images/stylelint/sider_recommended_config.old.yaml
@@ -1,0 +1,1 @@
+extends: "/home/analyzer_runner/stylelint-config-recommended.old/node_modules/stylelint-config-recommended"

--- a/lib/runners/processor/stylelint.rb
+++ b/lib/runners/processor/stylelint.rb
@@ -27,14 +27,14 @@ module Runners
     end
 
     DEFAULT_DEPS = DefaultDependencies.new(
-      main: Dependency.new(name: "stylelint", version: "10.1.0"),
+      main: Dependency.new(name: "stylelint", version: "11.0.0"),
       extras: [
-        Dependency.new(name: "stylelint-config-recommended", version: "2.2.0"),
+        Dependency.new(name: "stylelint-config-recommended", version: "3.0.0"),
       ],
     )
 
     CONSTRAINTS = {
-      "stylelint" => Constraint.new(">= 8.3.0", "< 11.0.0"),
+      "stylelint" => Constraint.new(">= 8.3.0", "< 12.0.0"),
     }.freeze
 
     DEFAULT_TARGET_FILE_EXTENSIONS = ["css", "less", "sass", "scss", "sss"].freeze
@@ -153,7 +153,13 @@ module Runners
 
     def prepare_config_file(config)
       return if config_file_path(config)
-      src = (Pathname(Dir.home) / 'sider_recommended_config.yaml').realpath
+
+      # NOTE: `stylelint-config-recommended@2` does not work with `stylelint@11`.
+      src = if Gem::Version.create(analyzer_version) >= Gem::Version.create("11.0.0")
+              (Pathname(Dir.home) / 'sider_recommended_config.yaml').realpath
+            else
+              (Pathname(Dir.home) / 'sider_recommended_config.old.yaml').realpath
+            end
       dst = current_dir.join('.stylelintrc.yaml')
       FileUtils.copy(src, dst)
     end

--- a/test/smokes/stylelint/expectations.rb
+++ b/test/smokes/stylelint/expectations.rb
@@ -78,7 +78,7 @@ Smoke.add_test('success', {
 # Case: package.json が不在 && stylelintrc が不在
 # Analysis: Global にインストールされた stylelint, stylelint-config-recommended を使って解析する
 Smoke.add_test('no_config', {
-  analyzer: {name: 'stylelint', version: '10.1.0'},
+  analyzer: {name: 'stylelint', version: '11.0.0'},
   guid: 'test-guid',
   timestamp: :_,
   type: 'success',
@@ -103,7 +103,7 @@ Smoke.add_test('no_config', {
 # Case: package.json が不在 && stylelintrc が存在
 # Analysis: stylelint-config-standard が存在しないので、解析エラーになる。
 Smoke.add_test('analyse-only-css', {
-  analyzer: {name: 'stylelint', version: '10.1.0'},
+  analyzer: {name: 'stylelint', version: '11.0.0'},
   guid: 'test-guid',
   timestamp: :_,
   type: 'failure',
@@ -113,7 +113,7 @@ Smoke.add_test('analyse-only-css', {
 # Case: package.json が不在 && stylelintrc が不在
 # Analysis: Global にインストールされた stylelint, stylelint-config-recommended を使って解析する
 Smoke.add_test('without-css', {
-  analyzer: {name: 'stylelint', version: '10.1.0'},
+  analyzer: {name: 'stylelint', version: '11.0.0'},
   guid: 'test-guid',
   timestamp: :_,
   type: 'success',
@@ -163,7 +163,7 @@ Smoke.add_test('with_options', {
 # Case: package.json が不在 && stylelintrc が不在
 # Analysis: Global にインストールされた stylelint, stylelint-config-recommended を使って解析する
 Smoke.add_test('syntax-error', {
-  analyzer: {name: 'stylelint', version: '10.1.0'},
+  analyzer: {name: 'stylelint', version: '11.0.0'},
   guid: 'test-guid',
   timestamp: :_,
   type: 'success',
@@ -184,7 +184,7 @@ Smoke.add_test('syntax-error', {
 # Case: package.json が不在 && stylelintrc が存在
 # Analysis: Global にインストールされた stylelint, .stylelintrc の extends を元にインストールした stylelint-config-recommended を使って解析する
 Smoke.add_test('only_stylelintrc', {
-  analyzer: { name: 'stylelint', version: '10.1.0' },
+  analyzer: { name: 'stylelint', version: '11.0.0' },
   guid: 'test-guid',
   timestamp: :_,
   type: 'success',
@@ -211,7 +211,7 @@ Smoke.add_test('only_stylelintrc', {
 #       stylelintrc は extends や plugins などを持たず、純粋にルールのみが記載
 # Analysis: Global にインストールされた stylelint を使って解析する
 Smoke.add_test('only_stylelintrc_without_packages', {
-  analyzer: { name: 'stylelint', version: '10.1.0' },
+  analyzer: { name: 'stylelint', version: '11.0.0' },
   guid: 'test-guid',
   timestamp: :_,
   type: 'success',
@@ -288,7 +288,7 @@ Smoke.add_test('only_stylelint_in_package_json', {
 # Case: package.json が存在 && stylelintrc が存在 && npm_install: true
 # Analysis: peer dep が存在しないので、デフォルトにフォールバックする。
 Smoke.add_test('npm_install_without_stylelint', {
-  analyzer: { name: "stylelint", version: "10.1.0" },
+  analyzer: { name: "stylelint", version: "11.0.0" },
   guid: 'test-guid',
   timestamp: :_,
   type: 'success',
@@ -411,7 +411,7 @@ Smoke.add_test("mismatched_yarnlock_and_package_json", {
 })
 
 Smoke.add_test("default_glob", {
-  analyzer: { name: "stylelint", version: "10.1.0" },
+  analyzer: { name: "stylelint", version: "11.0.0" },
   guid: 'test-guid',
   timestamp: :_,
   type: 'success',


### PR DESCRIPTION
- `stylelint`: 10.1.0 -> 11.0.0
  - https://github.com/stylelint/stylelint/blob/master/CHANGELOG.md#1100
- `stylelint-config-recommended`: 2.2.0 -> 3.0.0
  - https://github.com/stylelint/stylelint-config-recommended/blob/master/CHANGELOG.md#300

`stylelint-config-recommended@3` requires `stylelint@11` as a minimum, so this adds a workaround for it.