### PR TITLE
Install PHP_CodeSniffer and its dependencies via Composer

### DIFF
--- a/images/Dockerfile.php.erb
+++ b/images/Dockerfile.php.erb
@@ -1,0 +1,4 @@
+<% analyzer = ENV.fetch('ANALYZER') %>
+# Install PHP packages via Composer
+COPY images/<%= analyzer %>/composer.json images/<%= analyzer %>/composer.lock ${COMPOSER_HOME}/
+RUN composer global install

--- a/images/code_sniffer/Dockerfile
+++ b/images/code_sniffer/Dockerfile
@@ -4,6 +4,17 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM sider/devon_rex_php:2.4.0
 
+
+# Install PHP packages via Composer
+COPY images/code_sniffer/composer.json images/code_sniffer/composer.lock ${COMPOSER_HOME}/
+RUN composer global install
+
+# Set install paths
+RUN basepath=${COMPOSER_HOME}/vendor && \
+    phpcs --config-set installed_paths \
+      ${basepath}/cakephp/cakephp-codesniffer,${basepath}/escapestudios/symfony2-coding-standard,${basepath}/wp-coding-standards/wpcs && \
+    phpcs -i
+
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
@@ -17,45 +28,6 @@ RUN cd ${RUNNERS_DIR} && \
     bundle config && \
     bundle install --without='development test'
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
-
-ENV PHPCS3_VERSION="3.4.2" \
-    CAKEPHP_CS3_VERSION="3.1.1" \
-    SYMFONY_CS3_VERSION="3.4.1" \
-    WORDPRESS_CS3_VERSION="2.0.0"
-
-# Installation requires root permission
-USER root
-
-# Install PHP_CodeSniffer 3.x from GitHub releases (It is good to use pear, But it does not support multiple versions)
-RUN wget https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${PHPCS3_VERSION}/phpcs.phar \
-  && mv phpcs.phar phpcs3 \
-  && chmod +x phpcs3 \
-  && mv phpcs3 /usr/bin \
-  && mkdir -p /usr/share/php/PHP/CodeSniffer3/Standards
-
-# Install CakePHP Coding Standards for PHPCS3
-RUN wget https://github.com/cakephp/cakephp-codesniffer/archive/${CAKEPHP_CS3_VERSION}.zip \
-  && unzip ${CAKEPHP_CS3_VERSION}.zip \
-  && mv cakephp-codesniffer-${CAKEPHP_CS3_VERSION}/CakePHP /usr/share/php/PHP/CodeSniffer3/Standards \
-  && rm -rf ${CAKEPHP_CS3_VERSION}.zip cakephp-codesniffer-${CAKEPHP_CS3_VERSION}/
-
-# Install Symfony Coding Standards for PHPCS3
-RUN wget https://github.com/djoos/Symfony-coding-standard/archive/${SYMFONY_CS3_VERSION}.zip \
-  && unzip ${SYMFONY_CS3_VERSION}.zip \
-  && mv Symfony-coding-standard-${SYMFONY_CS3_VERSION}/Symfony /usr/share/php/PHP/CodeSniffer3/Standards \
-  && rm -rf ${SYMFONY_CS3_VERSION}.zip Symfony2-coding-standard-${SYMFONY_CS3_VERSION}/
-
-# Install WordPress Coding Standards for PHPCS3
-RUN wget https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/${WORDPRESS_CS3_VERSION}.zip \
-  && unzip ${WORDPRESS_CS3_VERSION}.zip \
-  && mv WordPress-Coding-Standards-${WORDPRESS_CS3_VERSION} /usr/share/php/PHP/CodeSniffer3/Standards/wpcs \
-  && rm ${WORDPRESS_CS3_VERSION}.zip
-
-# Set install paths
-RUN phpcs3 --config-set installed_paths /usr/share/php/PHP/CodeSniffer3/Standards,/usr/share/php/PHP/CodeSniffer3/Standards/wpcs
-
-USER $RUNNER_USER
-
 # Copy the main source code
 COPY bin ${RUNNERS_DIR}/bin
 COPY lib ${RUNNERS_DIR}/lib

--- a/images/code_sniffer/Dockerfile.erb
+++ b/images/code_sniffer/Dockerfile.erb
@@ -1,43 +1,12 @@
 FROM sider/devon_rex_php:2.4.0
 
-<%= render_erb 'images/Dockerfile.base.erb' %>
-
-ENV PHPCS3_VERSION="3.4.2" \
-    CAKEPHP_CS3_VERSION="3.1.1" \
-    SYMFONY_CS3_VERSION="3.4.1" \
-    WORDPRESS_CS3_VERSION="2.0.0"
-
-# Installation requires root permission
-USER root
-
-# Install PHP_CodeSniffer 3.x from GitHub releases (It is good to use pear, But it does not support multiple versions)
-RUN wget https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${PHPCS3_VERSION}/phpcs.phar \
-  && mv phpcs.phar phpcs3 \
-  && chmod +x phpcs3 \
-  && mv phpcs3 /usr/bin \
-  && mkdir -p /usr/share/php/PHP/CodeSniffer3/Standards
-
-# Install CakePHP Coding Standards for PHPCS3
-RUN wget https://github.com/cakephp/cakephp-codesniffer/archive/${CAKEPHP_CS3_VERSION}.zip \
-  && unzip ${CAKEPHP_CS3_VERSION}.zip \
-  && mv cakephp-codesniffer-${CAKEPHP_CS3_VERSION}/CakePHP /usr/share/php/PHP/CodeSniffer3/Standards \
-  && rm -rf ${CAKEPHP_CS3_VERSION}.zip cakephp-codesniffer-${CAKEPHP_CS3_VERSION}/
-
-# Install Symfony Coding Standards for PHPCS3
-RUN wget https://github.com/djoos/Symfony-coding-standard/archive/${SYMFONY_CS3_VERSION}.zip \
-  && unzip ${SYMFONY_CS3_VERSION}.zip \
-  && mv Symfony-coding-standard-${SYMFONY_CS3_VERSION}/Symfony /usr/share/php/PHP/CodeSniffer3/Standards \
-  && rm -rf ${SYMFONY_CS3_VERSION}.zip Symfony2-coding-standard-${SYMFONY_CS3_VERSION}/
-
-# Install WordPress Coding Standards for PHPCS3
-RUN wget https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/${WORDPRESS_CS3_VERSION}.zip \
-  && unzip ${WORDPRESS_CS3_VERSION}.zip \
-  && mv WordPress-Coding-Standards-${WORDPRESS_CS3_VERSION} /usr/share/php/PHP/CodeSniffer3/Standards/wpcs \
-  && rm ${WORDPRESS_CS3_VERSION}.zip
+<%= render_erb 'images/Dockerfile.php.erb' %>
 
 # Set install paths
-RUN phpcs3 --config-set installed_paths /usr/share/php/PHP/CodeSniffer3/Standards,/usr/share/php/PHP/CodeSniffer3/Standards/wpcs
+RUN basepath=${COMPOSER_HOME}/vendor && \
+    phpcs --config-set installed_paths \
+      ${basepath}/cakephp/cakephp-codesniffer,${basepath}/escapestudios/symfony2-coding-standard,${basepath}/wp-coding-standards/wpcs && \
+    phpcs -i
 
-USER $RUNNER_USER
-
+<%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.end.erb' %>

--- a/images/code_sniffer/composer.json
+++ b/images/code_sniffer/composer.json
@@ -1,0 +1,8 @@
+{
+  "require": {
+    "squizlabs/php_codesniffer": "3.4.2",
+    "cakephp/cakephp-codesniffer": "3.1.1",
+    "escapestudios/symfony2-coding-standard": "3.4.1",
+    "wp-coding-standards/wpcs": "2.0.0"
+  }
+}

--- a/images/code_sniffer/composer.lock
+++ b/images/code_sniffer/composer.lock
@@ -1,0 +1,210 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "4fd252f0d26bdd40004734aced386c75",
+    "packages": [
+        {
+            "name": "cakephp/cakephp-codesniffer",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/cakephp-codesniffer.git",
+                "reference": "682e79fda294c4383e094a2a881e16dcf1130750"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/cakephp-codesniffer/zipball/682e79fda294c4383e094a2a881e16dcf1130750",
+                "reference": "682e79fda294c4383e094a2a881e16dcf1130750",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "squizlabs/php_codesniffer": "^3.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "<6.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "CakePHP\\": "CakePHP"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/cakephp-codesniffer/graphs/contributors"
+                }
+            ],
+            "description": "CakePHP CodeSniffer Standards",
+            "homepage": "http://cakephp.org",
+            "keywords": [
+                "codesniffer",
+                "framework"
+            ],
+            "time": "2018-11-30T16:04:05+00:00"
+        },
+        {
+            "name": "escapestudios/symfony2-coding-standard",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/djoos/Symfony-coding-standard.git",
+                "reference": "4bbb23250bbfef2020e2fd7aebf94a0007fdfb5a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/djoos/Symfony-coding-standard/zipball/4bbb23250bbfef2020e2fd7aebf94a0007fdfb5a",
+                "reference": "4bbb23250bbfef2020e2fd7aebf94a0007fdfb5a",
+                "shasum": ""
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "<3 || >=4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0",
+                "squizlabs/php_codesniffer": "3.*"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Joos",
+                    "email": "iam@davidjoos.com"
+                },
+                {
+                    "name": "Community contributors",
+                    "homepage": "https://github.com/djoos/Symfony-coding-standard/graphs/contributors"
+                }
+            ],
+            "description": "CodeSniffer ruleset for the Symfony 2+ coding standard",
+            "homepage": "https://github.com/djoos/Symfony-coding-standard",
+            "keywords": [
+                "Coding Standard",
+                "Symfony2",
+                "phpcs",
+                "symfony"
+            ],
+            "time": "2018-05-29T08:52:19+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-04-10T23:49:02+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "c9eaadaafefce36b3cb7e06eb15305b8c4cae9ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/c9eaadaafefce36b3cb7e06eb15305b8c4cae9ce",
+                "reference": "c9eaadaafefce36b3cb7e06eb15305b8c4cae9ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2019-01-16T10:13:16+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/images/phinder/Dockerfile
+++ b/images/phinder/Dockerfile
@@ -4,6 +4,10 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM sider/devon_rex_php:2.4.0
 
+
+# Install PHP packages via Composer
+COPY images/phinder/composer.json images/phinder/composer.lock ${COMPOSER_HOME}/
+RUN composer global install
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
@@ -17,10 +21,6 @@ RUN cd ${RUNNERS_DIR} && \
     bundle config && \
     bundle install --without='development test'
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
-
-COPY images/phinder/composer.json images/phinder/composer.lock $COMPOSER_HOME/
-RUN composer global install
-
 # Copy the main source code
 COPY bin ${RUNNERS_DIR}/bin
 COPY lib ${RUNNERS_DIR}/lib

--- a/images/phinder/Dockerfile.erb
+++ b/images/phinder/Dockerfile.erb
@@ -1,8 +1,5 @@
 FROM sider/devon_rex_php:2.4.0
 
+<%= render_erb 'images/Dockerfile.php.erb' %>
 <%= render_erb 'images/Dockerfile.base.erb' %>
-
-COPY images/phinder/composer.json images/phinder/composer.lock $COMPOSER_HOME/
-RUN composer global install
-
 <%= render_erb 'images/Dockerfile.end.erb' %>

--- a/images/phpmd/Dockerfile
+++ b/images/phpmd/Dockerfile
@@ -4,6 +4,10 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM sider/devon_rex_php:2.4.0
 
+
+# Install PHP packages via Composer
+COPY images/phpmd/composer.json images/phpmd/composer.lock ${COMPOSER_HOME}/
+RUN composer global install
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
@@ -18,9 +22,7 @@ RUN cd ${RUNNERS_DIR} && \
     bundle install --without='development test'
 ENV PATH ${RUNNERS_DIR}/bin:${PATH}
 
-COPY images/phpmd/composer.json images/phpmd/composer.lock $COMPOSER_HOME/
-COPY images/phpmd/sider_config.xml $RUNNER_USER_HOME/
-RUN composer global install
+COPY images/phpmd/sider_config.xml ${RUNNER_USER_HOME}/
 
 # Copy the main source code
 COPY bin ${RUNNERS_DIR}/bin

--- a/images/phpmd/Dockerfile.erb
+++ b/images/phpmd/Dockerfile.erb
@@ -1,9 +1,8 @@
 FROM sider/devon_rex_php:2.4.0
 
+<%= render_erb 'images/Dockerfile.php.erb' %>
 <%= render_erb 'images/Dockerfile.base.erb' %>
 
-COPY images/phpmd/composer.json images/phpmd/composer.lock $COMPOSER_HOME/
-COPY images/phpmd/sider_config.xml $RUNNER_USER_HOME/
-RUN composer global install
+COPY images/phpmd/sider_config.xml ${RUNNER_USER_HOME}/
 
 <%= render_erb 'images/Dockerfile.end.erb' %>

--- a/lib/runners/processor/code_sniffer.rb
+++ b/lib/runners/processor/code_sniffer.rb
@@ -52,7 +52,7 @@ module Runners
     end
 
     def analyzer_bin
-      "phpcs3"
+      "phpcs"
     end
 
     def additional_options(config)


### PR DESCRIPTION
Installed packages:

- [squizlabs/php_codesniffer](https://packagist.org/packages/squizlabs/php_codesniffer)
- [cakephp/cakephp-codesniffer](https://packagist.org/packages/cakephp/cakephp-codesniffer)
- [escapestudios/symfony2-coding-standard](https://packagist.org/packages/escapestudios/symfony2-coding-standard)
- [wp-coding-standards/wpcs](https://packagist.org/packages/wp-coding-standards/wpcs)

Fix #220