### PR TITLE
Improve ShellCheck build image time

### DIFF
--- a/images/shellcheck/Dockerfile
+++ b/images/shellcheck/Dockerfile
@@ -2,20 +2,29 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_haskell:2.4.0
+FROM sider/devon_rex_base:2.4.0
 
 USER root
 RUN apt-get update && \
     apt-get install -y --no-install-recommends file && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-USER $RUNNER_USER
 
 ARG SHELLCHECK_VERSION=0.7.0
-RUN cabal update && \
-    cabal install ShellCheck-${SHELLCHECK_VERSION} --jobs --verbose=0 && \
-    ~/.cabal/bin/shellcheck --version
-ENV PATH ${RUNNER_USER_HOME}/.cabal/bin:${PATH}
+
+# NOTE: Compiling via Cabal is too slow. See #296.
+RUN cd /tmp && \
+    baseurl="https://storage.googleapis.com/shellcheck/shellcheck-v${SHELLCHECK_VERSION}" && \
+    curl -sSL "${baseurl}.linux.x86_64.tar.xz" | tar -xJ && \
+    curl -sSL "${baseurl}.linux-x86_64.sha512sum" | \
+      awk '{ print $1 }' | \
+      xargs -I {} echo "{} *shellcheck-v${SHELLCHECK_VERSION}/shellcheck" | \
+      sha512sum --check --strict && \
+    cp "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/ && \
+    shellcheck --version && \
+    rm -r "shellcheck-v${SHELLCHECK_VERSION}"
+
+USER $RUNNER_USER
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/shellcheck/Dockerfile.erb
+++ b/images/shellcheck/Dockerfile.erb
@@ -1,17 +1,26 @@
-FROM sider/devon_rex_haskell:2.4.0
+FROM sider/devon_rex_base:2.4.0
 
 USER root
 RUN apt-get update && \
     apt-get install -y --no-install-recommends file && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-USER $RUNNER_USER
 
 ARG SHELLCHECK_VERSION=0.7.0
-RUN cabal update && \
-    cabal install ShellCheck-${SHELLCHECK_VERSION} --jobs --verbose=0 && \
-    ~/.cabal/bin/shellcheck --version
-ENV PATH ${RUNNER_USER_HOME}/.cabal/bin:${PATH}
+
+# NOTE: Compiling via Cabal is too slow. See #296.
+RUN cd /tmp && \
+    baseurl="https://storage.googleapis.com/shellcheck/shellcheck-v${SHELLCHECK_VERSION}" && \
+    curl -sSL "${baseurl}.linux.x86_64.tar.xz" | tar -xJ && \
+    curl -sSL "${baseurl}.linux-x86_64.sha512sum" | \
+      awk '{ print $1 }' | \
+      xargs -I {} echo "{} *shellcheck-v${SHELLCHECK_VERSION}/shellcheck" | \
+      sha512sum --check --strict && \
+    cp "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/ && \
+    shellcheck --version && \
+    rm -r "shellcheck-v${SHELLCHECK_VERSION}"
+
+USER $RUNNER_USER
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.end.erb' %>


### PR DESCRIPTION
Download the pre-compiled binary file instead of compiling via Cabal.

See <https://github.com/koalaman/shellcheck#installing-a-pre-compiled-binary>

Fix #296