### PR TITLE
Set timeout for Runners

### DIFF
--- a/bin/runners
+++ b/bin/runners
@@ -5,6 +5,7 @@ require "pathname"
 $LOAD_PATH << Pathname(__dir__).parent + "lib"
 
 require "bugsnag"
+require "timeout"
 require "runners"
 require "runners/cli"
 
@@ -18,4 +19,10 @@ at_exit do
   end
 end
 
-Runners::CLI.new(argv: ARGV, stdout: STDOUT, stderr: STDERR).validate_options!.run
+pid = fork do
+  Runners::CLI.new(argv: ARGV, stdout: STDOUT, stderr: STDERR).validate_options!.run
+end
+
+Timeout.timeout(ENV['RUNNERS_TIMEOUT'] || 1_800) do
+  Process.waitpid(pid)
+end


### PR DESCRIPTION
Currently, Runners don't stop the process until the analysis stops
successfully/unsuccessfully. I want to introduce the timeout feature to forcefully stop a long-running process.

Runners basically depend on `Open3.capture3`, and it uses `Process.detach` and makes the returned thread `join` in its internal implementation. So, we cannot just wrap `run` with `Timeout.timeout` because `Timeout.timeout` kills only the thread which it creates from the passed block. In other words, the thread which is generated by `Open3.capture3` (Actually, `Open3.popen_run` generates the thread) still remains and waits for the subprocess exit.
That's why just wrapping with `Timeout.timeout` does not provide the timeout feature.

Instead, I decided to fork the `run` process. In this case, wrapping `Process.wait` with `Timeout.timeout` forcefully stop the process. ~This generates a zombie process, but I think it's OK because the parent process exits immediately after `Timeout.timeout` dispatches.~