### PR TITLE
Set ConnectTimeout for ssh(1) to avoid waiting for a long time

### DIFF
--- a/lib/runners/workspace.rb
+++ b/lib/runners/workspace.rb
@@ -57,8 +57,9 @@ module Runners
 
           File.write(config_path, <<~SSH_CONFIG)
             Host *
-              CheckHostIP=no
-              StrictHostKeyChecking=no
+              CheckHostIP no
+              ConnectTimeout 30
+              StrictHostKeyChecking no
               IdentitiesOnly yes
               IdentityFile #{key_path}
           SSH_CONFIG


### PR DESCRIPTION
Runners try to install private dependencies via SSH. If the remote host of an SSH server does not refuse connections but opens TCP port, SSH clients have to wait until the system TCP timeout reaches.

The system TCP timeout is typically longer than `ConnectTimeout`.