### PR TITLE
Notify exception if the result is "error"

### DIFF
--- a/bin/runners
+++ b/bin/runners
@@ -18,4 +18,7 @@ at_exit do
   end
 end
 
-Runners::CLI.new(argv: ARGV, stdout: STDOUT, stderr: STDERR).validate_options!.run
+result = Runners::CLI.new(argv: ARGV, stdout: STDOUT, stderr: STDERR).validate_options!.run
+if result.instance_of?(Runners::Results::Error)
+  Bugsnag.notify(result.exception)
+end

--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -115,8 +115,10 @@ module Runners
           trace_writer.message "Writing result..." do
             writer << Schema::Result.envelope.coerce(json)
           end
+          result
         end
-        io.finalize!
+      ensure
+        io.finalize! if defined?(:@io)
       end
     end
 

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -265,7 +265,7 @@ class Runners::CLI
   def processor_class: () -> Processor.class
   def validate_options!: () -> self
   def validate_analyzer!: () -> void
-  def run: () -> void
+  def run: () -> result
   def io: () -> any
 end
 


### PR DESCRIPTION
The instance of `Runners::Results::Error` contains unhandled exceptions. I want Runners to notify them. So, I changed `Runners::CLI#run` to return a result.