### PR TITLE
Fix PHPMD target files with `suffixes` option

### DIFF
--- a/test/processor/phpmd_test.rb
+++ b/test/processor/phpmd_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class Runners::Processor::PhpmdTest < Minitest::Test
+  Phpmd = Runners::Processor::Phpmd
+
+  def trace_writer
+    @trace_writer ||= Runners::TraceWriter.new(writer: [])
+  end
+
+  def subject
+    Phpmd.new(guid: SecureRandom.uuid, working_dir: Pathname(__dir__), git_ssh_path: nil, trace_writer: trace_writer)
+  end
+
+  def test_target_files
+    assert_equal ["*.php"], subject.send(:target_files, {})
+    assert_equal ["*.php"], subject.send(:target_files, { suffixes: "php" })
+    assert_equal ["*.php", "*.phtml"], subject.send(:target_files, { suffixes: "php,phtml" })
+    assert_equal ["*.a", "*.b"], subject.send(:target_files, { suffixes: "a,b" })
+  end
+end

--- a/test/smokes/phpmd/expectations.rb
+++ b/test/smokes/phpmd/expectations.rb
@@ -34,12 +34,19 @@ Smoke.add_test("valid_options", {
   type: "success",
   issues: [
     { path: "app/index.php",
-      location: { :start_line => 20, :end_line => 20 },
+      location: { start_line: 20, end_line: 20 },
       id: "UnusedLocalVariable",
       message: "Avoid unused local variables such as '$hoge'.",
       links: ["https://phpmd.org/rules/unusedcode.html#unusedlocalvariable"],
       object: nil,
-    }
+    },
+    { path: "foo.phtml",
+      location: { start_line: 5, end_line: 5 },
+      id: "UnusedLocalVariable",
+      message: "Avoid unused local variables such as '$var'.",
+      links: ["https://phpmd.org/rules/unusedcode.html#unusedlocalvariable"],
+      object: nil,
+    },
   ],
   analyzer: {
     name: "phpmd",

--- a/test/smokes/phpmd/valid_options/foo.phtml
+++ b/test/smokes/phpmd/valid_options/foo.phtml
@@ -1,0 +1,9 @@
+<html>
+  <body>
+    <?php
+    function foo() {
+      $var = "bar";
+    }
+    ?>
+  </body>
+</html>

--- a/test/smokes/phpmd/valid_options/sideci.yml
+++ b/test/smokes/phpmd/valid_options/sideci.yml
@@ -2,3 +2,4 @@ linter:
   phpmd:
     exclude: app/Controller/
     strict: true
+    suffixes: php,phtml


### PR DESCRIPTION
When specifying the `linter.phpmd.suffixes` option (e.g. `php,phtml`),
Sider should analyze `*.php` and `*.phtml` files but actually has analyzed `*.php` files.

This fixes the behavior.

See also <https://help.sider.review/tools/php/phpmd#suffixes>.