### PR TITLE
Fix Checkstyle output XML parse error

### DIFF
--- a/test/smokes/checkstyle/expectations.rb
+++ b/test/smokes/checkstyle/expectations.rb
@@ -85,10 +85,9 @@ Smoke.add_test("config", {
 Smoke.add_test("failure", {
   guid: "test-guid",
   timestamp: :_,
-  type: "error",
-  class: :_,
-  backtrace: :_,
-  inspect: :_
+  type: "failure",
+  message: "Could not find config XML file 'custom.xml'.",
+  analyzer: { name: "checkstyle", version: "8.25" },
 })
 
 Smoke.add_test("broken_sideci_yml", {
@@ -138,4 +137,12 @@ Smoke.add_test("properties", {
     },
   ],
   analyzer: {name: 'checkstyle', version: '8.25'}
+})
+
+Smoke.add_test("syntax_error", {
+  guid: "test-guid",
+  timestamp: :_,
+  type: "failure",
+  message: "com.puppycrawl.tools.checkstyle.api.CheckstyleException: Exception was thrown while processing ./Foo.java",
+  analyzer: { name: "checkstyle", version: "8.25" },
 })

--- a/test/smokes/checkstyle/syntax_error/Foo.java
+++ b/test/smokes/checkstyle/syntax_error/Foo.java
@@ -1,0 +1,1 @@
+package


### PR DESCRIPTION
Checkstyle can output non-XML when some error occurs.
In the case, this change aims to handle the error correctly.

NOTE: `REXML::Document#root` returns `nil` instead of raising an exception as follows:

```ruby
require "rexml/document"
REXML::Document.new("invalid XML").root #=> nil
```