### PR TITLE
Make timeout(1) call SIGUSR2 and trap it in bin/runners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - run: bundle exec rake typecheck
       - run: bundle exec rake dockerfile:generate
       - run: bundle exec rake dockerfile:verify
-  test-timeout:
+  timeout_test:
     docker:
       - image: circleci/ruby:2.6.4
     steps:
@@ -62,10 +62,6 @@ jobs:
       - install_gems
       - setup_remote_docker
       - run: bundle exec rake docker:timeout_test
-    environment:
-      # NOTE: Either analyzer is fine, I chose it because of its lightness.
-      ANALYZER: code_sniffer
-      TAG: dev
   runner_rubocop:
     environment:
       ANALYZER: rubocop
@@ -188,7 +184,7 @@ workflows:
   build:
     jobs:
       - test-base
-      - test-timeout
+      - timeout_test
       - runner_rubocop: { filters: { tags: { only: /.*/ } } }
       - runner_rails_best_practices: { filters: { tags: { only: /.*/ } } }
       - runner_reek: { filters: { tags: { only: /.*/ } } }

--- a/bin/runners
+++ b/bin/runners
@@ -8,17 +8,27 @@ require "bugsnag"
 require "runners"
 require "runners/cli"
 
+class RunnersTimeoutError < StandardError; end
+
 Bugsnag.configure do |config|
   config.app_version = ENV["RUNNERS_VERSION"]
 end
 
-at_exit do
-  if $!
-    Bugsnag.notify($!)
+def notify_with_bugsnag(exception)
+  Bugsnag.notify(exception) do |report|
+    report.add_tab(:task_guid, ENV["TASK_GUID"]) if ENV["TASK_GUID"]
   end
+end
+
+trap('SIGUSR2') do
+  notify_with_bugsnag(RunnersTimeoutError.new)
+end
+
+at_exit do
+  notify_with_bugsnag($!) if $!
 end
 
 result = Runners::CLI.new(argv: ARGV, stdout: STDOUT, stderr: STDERR).validate_options!.run
 if result.instance_of?(Runners::Results::Error)
-  Bugsnag.notify(result.exception)
+  notify_with_bugsnag(result.exception)
 end

--- a/images/Dockerfile.end.erb
+++ b/images/Dockerfile.end.erb
@@ -7,4 +7,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "<%= ENV.fetch('RUNNERS_TIMEOUT', '30m') %>", "runners", "--analyzer=<%= ENV.fetch('ANALYZER') %>"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "<%= ENV.fetch('RUNNERS_TIMEOUT', '30m') %>", "runners", "--analyzer=<%= ENV.fetch('ANALYZER') %>"]

--- a/images/brakeman/Dockerfile
+++ b/images/brakeman/Dockerfile
@@ -38,4 +38,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=brakeman"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=brakeman"]

--- a/images/checkstyle/Dockerfile
+++ b/images/checkstyle/Dockerfile
@@ -43,4 +43,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=checkstyle"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=checkstyle"]

--- a/images/code_sniffer/Dockerfile
+++ b/images/code_sniffer/Dockerfile
@@ -37,4 +37,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=code_sniffer"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=code_sniffer"]

--- a/images/coffeelint/Dockerfile
+++ b/images/coffeelint/Dockerfile
@@ -41,4 +41,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=coffeelint"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=coffeelint"]

--- a/images/cppcheck/Dockerfile
+++ b/images/cppcheck/Dockerfile
@@ -47,4 +47,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=cppcheck"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=cppcheck"]

--- a/images/eslint/Dockerfile
+++ b/images/eslint/Dockerfile
@@ -46,4 +46,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=eslint"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=eslint"]

--- a/images/flake8/Dockerfile
+++ b/images/flake8/Dockerfile
@@ -46,4 +46,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=flake8"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=flake8"]

--- a/images/go_vet/Dockerfile
+++ b/images/go_vet/Dockerfile
@@ -39,4 +39,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=go_vet"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=go_vet"]

--- a/images/golint/Dockerfile
+++ b/images/golint/Dockerfile
@@ -39,4 +39,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=golint"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=golint"]

--- a/images/gometalinter/Dockerfile
+++ b/images/gometalinter/Dockerfile
@@ -41,4 +41,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=gometalinter"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=gometalinter"]

--- a/images/goodcheck/Dockerfile
+++ b/images/goodcheck/Dockerfile
@@ -38,4 +38,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=goodcheck"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=goodcheck"]

--- a/images/haml_lint/Dockerfile
+++ b/images/haml_lint/Dockerfile
@@ -41,4 +41,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=haml_lint"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=haml_lint"]

--- a/images/javasee/Dockerfile
+++ b/images/javasee/Dockerfile
@@ -37,4 +37,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=javasee"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=javasee"]

--- a/images/jshint/Dockerfile
+++ b/images/jshint/Dockerfile
@@ -44,4 +44,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=jshint"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=jshint"]

--- a/images/ktlint/Dockerfile
+++ b/images/ktlint/Dockerfile
@@ -43,4 +43,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=ktlint"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=ktlint"]

--- a/images/misspell/Dockerfile
+++ b/images/misspell/Dockerfile
@@ -34,4 +34,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=misspell"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=misspell"]

--- a/images/phinder/Dockerfile
+++ b/images/phinder/Dockerfile
@@ -30,4 +30,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=phinder"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=phinder"]

--- a/images/phpmd/Dockerfile
+++ b/images/phpmd/Dockerfile
@@ -33,4 +33,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=phpmd"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=phpmd"]

--- a/images/pmd_java/Dockerfile
+++ b/images/pmd_java/Dockerfile
@@ -43,4 +43,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=pmd_java"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=pmd_java"]

--- a/images/querly/Dockerfile
+++ b/images/querly/Dockerfile
@@ -38,4 +38,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=querly"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=querly"]

--- a/images/rails_best_practices/Dockerfile
+++ b/images/rails_best_practices/Dockerfile
@@ -44,4 +44,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=rails_best_practices"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=rails_best_practices"]

--- a/images/reek/Dockerfile
+++ b/images/reek/Dockerfile
@@ -42,4 +42,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=reek"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=reek"]

--- a/images/rubocop/Dockerfile
+++ b/images/rubocop/Dockerfile
@@ -49,4 +49,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=rubocop"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=rubocop"]

--- a/images/scss_lint/Dockerfile
+++ b/images/scss_lint/Dockerfile
@@ -41,4 +41,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=scss_lint"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=scss_lint"]

--- a/images/shellcheck/Dockerfile
+++ b/images/shellcheck/Dockerfile
@@ -48,4 +48,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=shellcheck"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=shellcheck"]

--- a/images/stylelint/Dockerfile
+++ b/images/stylelint/Dockerfile
@@ -51,4 +51,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=stylelint"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=stylelint"]

--- a/images/swiftlint/Dockerfile
+++ b/images/swiftlint/Dockerfile
@@ -42,4 +42,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=swiftlint"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=swiftlint"]

--- a/images/tslint/Dockerfile
+++ b/images/tslint/Dockerfile
@@ -45,4 +45,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=tslint"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=tslint"]

--- a/images/tyscan/Dockerfile
+++ b/images/tyscan/Dockerfile
@@ -41,4 +41,4 @@ USER root
 RUN chown -R ${RUNNER_USER}: ${RUNNER_USER_HOME}
 USER $RUNNER_USER
 
-ENTRYPOINT ["/usr/bin/timeout", "--kill-after=10s", "30m", "runners", "--analyzer=tyscan"]
+ENTRYPOINT ["/usr/bin/timeout", "--signal=SIGUSR2", "--kill-after=10s", "30m", "runners", "--analyzer=tyscan"]

--- a/lib/tasks/docker/timeout_test.rb
+++ b/lib/tasks/docker/timeout_test.rb
@@ -1,0 +1,67 @@
+require "open3"
+
+namespace :docker do
+  desc 'Run timeout_test to ensure timeout(1) stops Runners'
+  task :timeout_test do
+    # NOTE: Either analyzer is fine, I chose it because of its lightness.
+    ENV['ANALYZER'] = 'code_sniffer'
+    ENV['TAG'] = 'dev'
+    ENV['RUNNERS_TIMEOUT'] = '5s'
+
+    # Build docker images with dummy code
+    Dir.mktmpdir do |dir|
+      FileUtils.cp_r('.', dir)
+      Dir.chdir(dir) do
+        File.write('lib/runners/cli.rb', runners_cli_code)
+        Rake::Task['docker:build'].invoke
+      end
+    end
+
+    # Change the Docker image and include "rr"
+    sh "docker run --name #{container_name} --entrypoint bash #{image_name} gem install rr"
+    sh "docker commit --change='ENTRYPOINT #{entrypoint}' --change='CMD []' #{container_name} #{image_name}"
+
+    _, stderr, status = Open3.capture3 "docker run --rm #{image_name}"
+    status.exitstatus == 124 or abort "Expected exit status is 124, but the actual value is #{res.exitstatus}"
+    !stderr.include?('unexpected method invocation') or abort "Bugsnag is expected to be called"
+    sh "pgrep sleep" do |ok|
+      abort "sleep(1) still remains! It's unexpected." if ok
+    end
+  ensure
+    sh "docker rm --force #{container_name}"
+  end
+
+  def container_name
+    "runners_timeout_test"
+  end
+
+  def entrypoint
+    stdout, _, _ = Open3.capture3 "docker inspect -f '{{ range $item := .Config.Entrypoint }}{{ $item }} {{ end }}' #{image_name}"
+    stdout.split.inspect
+  end
+
+  def runners_cli_code
+    <<~EOF
+      require 'rr'
+      include RR::DSL
+
+      module Runners
+        class CLI
+          def initialize(**args)
+          end
+
+          def validate_options!
+            self
+          end
+
+          def run
+            Open3.capture3('sleep 10')
+          end
+        end
+      end
+
+      mock(Bugsnag).notify.with_any_args.once
+      at_exit { verify }
+    EOF
+  end
+end


### PR DESCRIPTION
Currently, Runners process will stop without notifying to Bugsnag when timeout(1) calls a signal.
This PR makes timeout(1) to call SIGUSR2 instead of SIGTERM (the default signal of timeout(1)), and trap SIGUSR2 in `bin/runners` and notify `RunnersTimeoutError`.

I don't want Runners to trap SIGTERM because Runners cannot tell the difference whether the signal is called by timeout(1) or not. So, I chose SIGUSR2 as a signal dispatched by timeout(1).