### PR TITLE
Improve PHPMD custom rule support

### DIFF
--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -9,6 +9,7 @@ module Runners
                         suffixes: string?,
                         exclude: string?,
                         strict: boolean?,
+                        custom_rule: array?(string),
                         # DO NOT ADD ANY OPTIONS in `options` option.
                         options: optional(object(
                                             rule: string?,
@@ -46,7 +47,7 @@ module Runners
     end
 
     def prepare_analysis_files(changes, config)
-      delete_unchanged_files(changes, only: target_files(config))
+      delete_unchanged_files(changes, only: target_files(config), except: config[:custom_rule] || [])
 
       trace_writer.message "Changed files:" do
         changes.changed_files.each do |file|

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -9,7 +9,7 @@ module Runners
                         suffixes: string?,
                         exclude: string?,
                         strict: boolean?,
-                        custom_rule: array?(string),
+                        custom_rule_path: array?(string),
                         # DO NOT ADD ANY OPTIONS in `options` option.
                         options: optional(object(
                                             rule: string?,
@@ -47,7 +47,7 @@ module Runners
     end
 
     def prepare_analysis_files(changes, config)
-      delete_unchanged_files(changes, only: target_files(config), except: config[:custom_rule] || [])
+      delete_unchanged_files(changes, only: target_files(config), except: config[:custom_rule_path] || [])
 
       trace_writer.message "Changed files:" do
         changes.changed_files.each do |file|

--- a/test/smokes/phpmd/custom_rule/Custom_NoFunctions.php
+++ b/test/smokes/phpmd/custom_rule/Custom_NoFunctions.php
@@ -1,0 +1,10 @@
+<?php
+
+// See https://phpmd.org/documentation/writing-a-phpmd-rule.html
+class Custom_NoFunctions extends \PHPMD\AbstractRule implements \PHPMD\Rule\FunctionAware
+{
+    public function apply(\PHPMD\AbstractNode $node)
+    {
+        $this->addViolation($node);
+    }
+}

--- a/test/smokes/phpmd/custom_rule/custom/rules/NoMethods.php
+++ b/test/smokes/phpmd/custom_rule/custom/rules/NoMethods.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace custom\rules;
+
+// See https://phpmd.org/documentation/writing-a-phpmd-rule.html
+class NoMethods extends \PHPMD\AbstractRule implements \PHPMD\Rule\MethodAware
+{
+    public function apply(\PHPMD\AbstractNode $node)
+    {
+        $this->addViolation($node);
+    }
+}

--- a/test/smokes/phpmd/custom_rule/custom_ruleset.xml
+++ b/test/smokes/phpmd/custom_rule/custom_ruleset.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ruleset name="custom ruleset"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+
+  <rule name="NoFunctions"
+        message="Please do not use functions."
+        class="Custom_NoFunctions"
+        externalInfoUrl="https://example.com/phpmd/rules/no-functions">
+    <priority>1</priority>
+  </rule>
+
+  <rule name="NoMethods"
+        message="Please do not use methods."
+        class="custom\rules\NoMethods"
+        externalInfoUrl="https://example.com/phpmd/rules/no-methods">
+    <priority>1</priority>
+  </rule>
+</ruleset>

--- a/test/smokes/phpmd/custom_rule/foo.php
+++ b/test/smokes/phpmd/custom_rule/foo.php
@@ -1,0 +1,5 @@
+<?php
+
+function foo() {
+    // ...
+}

--- a/test/smokes/phpmd/custom_rule/sider.yml
+++ b/test/smokes/phpmd/custom_rule/sider.yml
@@ -1,6 +1,6 @@
 linter:
   phpmd:
     rule: custom_ruleset.xml
-    custom_rule:
+    custom_rule_path:
       - NoFunctions.php
       - custom/**/*.php

--- a/test/smokes/phpmd/custom_rule/sider.yml
+++ b/test/smokes/phpmd/custom_rule/sider.yml
@@ -1,0 +1,6 @@
+linter:
+  phpmd:
+    rule: custom_ruleset.xml
+    custom_rule:
+      - NoFunctions.php
+      - custom/**/*.php

--- a/test/smokes/phpmd/expectations.rb
+++ b/test/smokes/phpmd/expectations.rb
@@ -121,3 +121,36 @@ Smoke.add_test("broken_sideci_yml", {
   message: "Invalid configuration in `sideci.yml`: unexpected value at config: `$.linter.phpmd.minimumpriority`",
   analyzer: nil
 })
+
+Smoke.add_test("custom_rule", {
+  guid: "test-guid",
+  timestamp: :_,
+  type: "success",
+  issues: [
+    {
+      path: "foo.php",
+      location: { start_line: 3, end_line: 5 },
+      id: "NoFunctions",
+      message: "Please do not use functions.",
+      links: ["https://example.com/phpmd/rules/no-functions"],
+      object: nil,
+    },
+    {
+      path: "Custom_NoFunctions.php",
+      location: { start_line: 6, end_line: 9 },
+      id: "NoMethods",
+      message: "Please do not use methods.",
+      links: ["https://example.com/phpmd/rules/no-methods"],
+      object: nil,
+    },
+    {
+      path: "custom/rules/NoMethods.php",
+      location: { start_line: 8, end_line: 11 },
+      id: "NoMethods",
+      message: "Please do not use methods.",
+      links: ["https://example.com/phpmd/rules/no-methods"],
+      object: nil,
+    },
+  ],
+  analyzer: { name: "phpmd", version: "2.7.0" },
+})


### PR DESCRIPTION
- Added `custom_rule` option.
- This option supports *glob* format.
- Files specified by this option are **always** analyzed.
- Unless this option, analyses not including custom rule files in a PR would fail.

Usage:

```yaml
linter:
  phpmd:
    rule: custom_ruleset.xml
    custom_rule_path:
      - NoFunctions.php
      - custom/**/*.php
```