### PR TITLE
Optimize generated Gemfile

### DIFF
--- a/lib/runners/ruby/gem_installer/source.rb
+++ b/lib/runners/ruby/gem_installer/source.rb
@@ -1,81 +1,97 @@
 module Runners
-  module Ruby::GemInstaller::Source
-    def self.create(gems_item)
-      source = gems_item["source"]
-      git = gems_item["git"]
+  class Ruby:: GemInstaller
+    module Source
+      def self.create(gems_item)
+        source = gems_item["source"]
+        git = gems_item["git"]
 
-      case
-      when source.is_a?(String)
-        # @type var source: String
-        source = source
-        Rubygems.new(source)
-      when git.is_a?(Hash)
-        # @type var git: Ruby::git_source
-        git = git
-        if git["repo"]
-          Git.new(repo: git["repo"], ref: git["ref"], branch: git["branch"], tag: git["tag"])
+        case
+        when source.is_a?(String)
+          # @type var source: String
+          source = source
+          Rubygems.new(source)
+        when git.is_a?(Hash)
+          # @type var git: Ruby::git_source
+          git = git
+          if git["repo"]
+            Git.new(repo: git["repo"], ref: git["ref"], branch: git["branch"], tag: git["tag"])
+          else
+            raise ArgumentError.new("Unexpected gem: #{gems_item.inspect}")
+          end
         else
-          raise ArgumentError.new("Unexpected gem: #{gems_item.inspect}")
+          Rubygems.new
         end
-      else
-        Rubygems.new
-      end
-    end
-
-    class Base
-      def rubygems?
-        false
       end
 
-      def git?
-        false
+      class Base
+        def rubygems?
+          false
+        end
+
+        def git?
+          false
+        end
+
+        def default?
+          false
+        end
       end
 
-      def eql?(other)
-        other.class == self.class && other.to_s == to_s
-      end
-    end
+      class Rubygems < Base
+        attr_reader :source
 
-    class Rubygems < Base
-      attr_reader :source
+        def initialize(source = DEFAULT_SOURCE)
+          @source = source
+        end
 
-      def initialize(source = Ruby::GemInstaller::DEFAULT_SOURCE)
-        @source = source
-      end
+        def rubygems?
+          true
+        end
 
-      def rubygems?
-        true
-      end
+        def default?
+          source == DEFAULT_SOURCE
+        end
 
-      def ==(other)
-        other.class == self.class && other.source == source
-      end
+        def ==(other)
+          self.class === other && source == other.source
+        end
+        alias eql? ==
 
-      def to_s
-        "source #{source.inspect}"
-      end
-    end
+        def hash
+          source.hash
+        end
 
-    class Git < Base
-      attr_reader :repo, :ref, :branch, :tag
-
-      def initialize(repo:, ref: nil, branch: nil, tag: nil)
-        @repo = repo
-        @ref = ref
-        @branch = branch
-        @tag = tag
+        def to_s
+          "source #{source.inspect}"
+        end
       end
 
-      def git?
-        true
-      end
+      class Git < Base
+        attr_reader :repo, :ref, :branch, :tag
 
-      def ==(other)
-        other.class == self.class && other.repo == repo && other.ref == ref && other.branch == branch && other.tag == tag
-      end
+        def initialize(repo:, ref: nil, branch: nil, tag: nil)
+          @repo = repo
+          @ref = ref
+          @branch = branch
+          @tag = tag
+        end
 
-      def to_s
-        "git #{repo.inspect}, ref: #{ref.inspect}, branch: #{branch.inspect}, tag: #{tag.inspect}"
+        def git?
+          true
+        end
+
+        def ==(other)
+          self.class === other && repo == other.repo && ref == other.ref && branch == other.branch && tag == other.tag
+        end
+        alias eql? ==
+
+        def hash
+          repo.hash ^ ref.hash ^ branch.hash ^ tag.hash
+        end
+
+        def to_s
+          "git #{repo.inspect}, ref: #{ref.inspect}, branch: #{branch.inspect}, tag: #{tag.inspect}"
+        end
       end
     end
   end

--- a/lib/runners/ruby/gem_installer/spec.rb
+++ b/lib/runners/ruby/gem_installer/spec.rb
@@ -6,6 +6,8 @@ module Runners
 
         attr_reader :name, :version, :source
 
+        alias versions version
+
         def initialize(name:, version:, source: Source::Rubygems.new)
           @name = name
           @version = version
@@ -13,7 +15,7 @@ module Runners
         end
 
         def ==(other)
-          other.is_a?(Spec) && other.name == name && other.version == version && other.source == source
+          other.class == self.class && other.name == name && other.version == version && other.source == source
         end
 
         __skip__ = begin

--- a/sig/polyfills/active_support.rbi
+++ b/sig/polyfills/active_support.rbi
@@ -8,4 +8,5 @@ end
 
 extension Object (ActiveSupport)
   def presence: -> self?
+  def present?: -> bool
 end

--- a/sig/runners/ruby.rbi
+++ b/sig/runners/ruby.rbi
@@ -38,15 +38,19 @@ class Runners::Ruby::GemInstaller
                    constraints: Hash<String, Array<String>>,
                    trace_writer: TraceWriter) -> void
   def install!: <'x> { (Hash<String, String>) -> 'x } -> 'x
-
   def gemfile_path: -> Pathname
-  def gemfile_content: () -> Array<String>
+  def gemfile_content: -> String
+  def group_specs: -> Array<[any, Array<Spec>]>
+  def gem: (Spec, Array<String>) -> String
+  def gem_constraints: (Spec, source_type) -> Array<String>
 end
 
 class Runners::Ruby::GemInstaller::Spec
   attr_reader name: String
   attr_reader version: Array<String>
   attr_reader source: source_type
+
+  alias versions version
 
   def initialize: (name: String, version: Array<String>, ?source: source_type) -> any
   def override_by_lockfile: (LockfileLoader::Lockfile) -> self
@@ -65,6 +69,7 @@ end
 class Runners::Ruby::GemInstaller::Source::Base
   def rubygems?: -> bool
   def git?: -> bool
+  def default?: -> bool
 end
 
 class Runners::Ruby::GemInstaller::Source::Rubygems < Runners::Ruby::GemInstaller::Source::Base


### PR DESCRIPTION
Reduce duplicates. For example:

## Before

```ruby
source "https://rubygems.org"
source "https://rubygems.org" do
  gem("strong_json", "0.4.0", "<= 0.8")
end
source "https://rubygems.org" do
  gem("meowcop", "1.2.0")
end
```

## After

```ruby
source "https://rubygems.org"

gem "strong_json", "0.4.0", "<= 0.8"
gem "meowcop", "1.2.0"
```

## Why?

- Duplicate sources give a bad effect on downloading gems.
- Harder to debug.

## Note

`specs.group_by(&:source)` has not been working until now. Because the source classes do not have `#eql?` and `#hash` methods, which are needed to use these classes as a Hash key.
See <https://ruby-doc.org/core-2.6.5/Hash.html#class-Hash-label-Hash+Keys> for more details.

https://github.com/sider/runners/blob/72ca9767d87a69f92c6a4093e7fc84369c19e823/lib/runners/ruby/gem_installer.rb#L61