### PR TITLE
Fix HAML-Lint smoke test

### DIFF
--- a/test/smokes/haml_lint/expectations.rb
+++ b/test/smokes/haml_lint/expectations.rb
@@ -63,7 +63,7 @@ Smoke.add_test(
     location: {start_line: 3 },
     object: nil,
   }],
-  analyzer: {name: 'haml_lint', version: '0.30.0'})
+  analyzer: {name: 'haml_lint', version: '0.34.0'})
 
 # rubocop-rspec will not be installed because `Gemfile.lock` does not exists.
 # However, haml-lint does not stop to perform the analysis, and reports other offenses.

--- a/test/smokes/haml_lint/with-inherit-gem/Gemfile.lock
+++ b/test/smokes/haml_lint/with-inherit-gem/Gemfile.lock
@@ -2,34 +2,32 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    haml (5.0.4)
+    haml (5.1.2)
       temple (>= 0.8.0)
       tilt
-    haml_lint (0.30.0)
-      haml (>= 4.0, < 5.1)
+    haml_lint (0.34.0)
+      haml (>= 4.0, < 5.2)
       rainbow
-      rake (>= 10, < 13)
       rubocop (>= 0.50.0)
       sysexits (~> 1.1)
-    jaro_winkler (1.5.2)
-    meowcop (1.20.0)
-      rubocop (>= 0.69.0)
-    parallel (1.17.0)
-    parser (2.6.3.0)
+    jaro_winkler (1.5.3)
+    meowcop (2.5.0)
+      rubocop (>= 0.76.0, < 1.0.0)
+    parallel (1.18.0)
+    parser (2.6.5.0)
       ast (~> 2.4.0)
     rainbow (3.0.0)
-    rake (12.3.2)
-    rubocop (0.69.0)
+    rubocop (0.76.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    ruby-progressbar (1.10.0)
+    ruby-progressbar (1.10.1)
     sysexits (1.2.0)
-    temple (0.8.1)
-    tilt (2.0.9)
+    temple (0.8.2)
+    tilt (2.0.10)
     unicode-display_width (1.6.0)
 
 PLATFORMS
@@ -41,4 +39,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
Reason:

[RuboCop 0.76](https://github.com/rubocop-hq/rubocop/releases/tag/v0.76.0) has renamed `Unneeded*` cops to `Redundant*` (**breaking changes**).
The mismatch between RuboCop 0.76 and MeowCop 1.20.

Reproduction:

```sh
$ bundle exec rake docker:build docker:smoke ANALYZER=haml_lint SHOW_TRACE=true ONLY=with-inherit-gem
```

```
{:trace=>"stderr",
 :string=>
  "/home/analyzer_runner/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/meowcop-1.20.0/config/rubocop.yml: Rails/SafeNavigation has the wrong namespace - should be Style\n" +
  "Error: The `Lint/UnneededCopDisableDirective` cop has been renamed to `Lint/RedundantCopDisableDirective`.\n" +
  "(obsolete configuration found in /home/analyzer_runner/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/meowcop-1.20.0/config/rubocop.yml, please update it)\n" +
  "The `Style/UnneededInterpolation` cop has been renamed to `Style/RedundantInterpolation`.\n" +
  "(obsolete configuration found in /home/analyzer_runner/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/meowcop-1.20.0/config/rubocop.yml, please update it)\n" +
  "The `Style/UnneededPercentQ` cop has been renamed to `Style/RedundantPercentQ`.\n" +
  "(obsolete configuration found in /home/analyzer_runner/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/meowcop-1.20.0/config/rubocop.yml, please update it)\n",
 :recorded_at=>"2019-10-29T00:49:39Z"}
```

Fix:

Updated the invalid `Gemfile.lock` via `bundle update`.