### PR TITLE
Set Bugsnag `release_stage` explicitly

### DIFF
--- a/bin/runners
+++ b/bin/runners
@@ -14,6 +14,7 @@ EXIT_STATUS_FOR_SIGTERM = 126
 
 Bugsnag.configure do |config|
   config.app_version = ENV["RUNNERS_VERSION"]
+  config.release_stage = ENV["BUGSNAG_RELEASE_STAGE"]
 end
 
 def notify_with_bugsnag(exception)


### PR DESCRIPTION
Runners is NOT a Rails app, so we need to set [`config.release_stage`](https://docs.bugsnag.com/platforms/ruby/other/configuration-options/#release_stage) explicitly.