### PR TITLE
Improve Bugsnag settings

### DIFF
--- a/bin/runners
+++ b/bin/runners
@@ -12,31 +12,28 @@ class RunnersTimeoutError < StandardError; end
 
 EXIT_STATUS_FOR_SIGTERM = 126
 
+# @see https://docs.bugsnag.com/platforms/ruby/rails/configuration-options
 Bugsnag.configure do |config|
   config.app_version = ENV["RUNNERS_VERSION"]
   config.release_stage = ENV["BUGSNAG_RELEASE_STAGE"]
 end
 
-def notify_with_bugsnag(exception)
-  Bugsnag.notify(exception) do |report|
-    report.add_tab(:task_guid, ENV["TASK_GUID"]) if ENV["TASK_GUID"]
-  end
-end
+# @see https://docs.bugsnag.com/platforms/ruby/customizing-error-reports/#adding-callbacks
+Bugsnag.before_notify_callbacks << ->(report) {
+  report.add_tab(:task_guid, ENV["TASK_GUID"]) if ENV["TASK_GUID"]
+  report.add_tab(:arguments, ARGV)
+}
 
 trap('SIGTERM') do
-  notify_with_bugsnag(RunnersTimeoutError.new)
+  Bugsnag.notify(RunnersTimeoutError.new)
   exit(EXIT_STATUS_FOR_SIGTERM)
 end
 
 trap('SIGUSR2') do
-  notify_with_bugsnag(RunnersTimeoutError.new)
-end
-
-at_exit do
-  notify_with_bugsnag($!) if $!
+  Bugsnag.notify(RunnersTimeoutError.new)
 end
 
 result = Runners::CLI.new(argv: ARGV, stdout: STDOUT, stderr: STDERR).validate_options!.run
 if result.instance_of?(Runners::Results::Error)
-  notify_with_bugsnag(result.exception)
+  Bugsnag.notify(result.exception)
 end


### PR DESCRIPTION
- Add custom data for CLI arguments.
- Use `before_notify_callbacks`.
  - see https://docs.bugsnag.com/platforms/ruby/customizing-error-reports/#adding-callbacks
- Remove `at_exit` handler (which is enabled by default).
  - see https://github.com/bugsnag/bugsnag-ruby/blob/v6.12.2/lib/bugsnag.rb#L53
  - see https://github.com/bugsnag/bugsnag-ruby/blob/c1952d93cb5c0cc1c54b109fbf8b372d60071265/lib/bugsnag.rb#L124-L139