### PR TITLE
Remove a warning for Node.js analyzers without dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.7.2...HEAD)
 
+- Remove a warning for Node.js analyzers without dependencies [#410](https://github.com/sider/runners/pull/410)
+
 ## 0.7.2
 
 [Full diff](https://github.com/sider/runners/compare/0.7.1...0.7.2)

--- a/lib/runners/nodejs.rb
+++ b/lib/runners/nodejs.rb
@@ -212,16 +212,13 @@ module Runners
       stdout, _, _ = capture3 "npm", "ls", "--depth=0", "--json"
       installed_deps = JSON.parse(stdout)["dependencies"]
 
+      return unless installed_deps
+
       warn_about_fallback_to_default = -> {
         add_warning <<~MSG.strip, file: "package.json"
           No required dependencies for analysis were installed. Instead, the pre-installed `#{default_dependency}` will be used.
         MSG
       }
-
-      unless installed_deps
-        warn_about_fallback_to_default.call
-        return
-      end
 
       all_constraints_satisfied = true
 

--- a/test/nodejs_test.rb
+++ b/test/nodejs_test.rb
@@ -540,7 +540,6 @@ class NodejsTest < Minitest::Test
 
       expected_warnings = [
         "No required dependencies for analysis were installed. Instead, the pre-installed `eslint@5.1.0` will be used.",
-        "No required dependencies for analysis were installed. Instead, the pre-installed `eslint@5.1.0` will be used.",
         "The required dependency `eslint` may not have been correctly installed. It may be a missing peer dependency."
       ]
       actual_warnings = trace_writer.writer.select { |e| e[:trace] == "warning" }.map { |e| e[:message] }
@@ -548,7 +547,6 @@ class NodejsTest < Minitest::Test
       assert_equal [
         { message: expected_warnings[0], file: "package.json" },
         { message: expected_warnings[1], file: "package.json" },
-        { message: expected_warnings[2], file: "package.json" },
       ], processor.warnings
 
       expected_errors = [


### PR DESCRIPTION
Currently, when the `dependencies` field does not exist in user's `package.json`,
Runners shows a warning like `No required dependencies for analysis were installed`.

However, this warning is too strict for users who have just a `package.json` without dependencies.
So, this removes the warning in that case.