### PR TITLE
Report message and metadata on `Shell::ExecError` to Bugsnag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.7.3...HEAD)
 
+- Report message and metadata on `Shell::ExecError` to Bugsnag [#414](https://github.com/sider/runners/pull/414)
+
 ## 0.7.3
 
 [Full diff](https://github.com/sider/runners/compare/0.7.2...0.7.3)

--- a/lib/runners/shell.rb
+++ b/lib/runners/shell.rb
@@ -9,6 +9,7 @@ module Runners
       attr_reader :dir
 
       def initialize(type:, args:, stdout_str:, stderr_str:, status:, dir:)
+        super("Command [#{args.join(' ')}] exited with #{status.exitstatus.inspect}")
         @type = type
         @args = args
         @stdout_str = stdout_str
@@ -19,6 +20,18 @@ module Runners
 
       def inspect
         "#<#{self.class.name}: type=#{type}, args=#{args.inspect}, status=#{status.inspect}, dir=#{dir.inspect}, stdout_str=..., stderr_str=...>"
+      end
+
+      # @see https://docs.bugsnag.com/platforms/ruby/customizing-error-reports/#custom-error-diagnostic-data
+      def bugsnag_meta_data
+        {
+          details: {
+            args: args,
+            stdout: stdout_str,
+            stderr: stderr_str,
+            status: status.exitstatus,
+          }
+        }
       end
     end
 

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -179,7 +179,7 @@ class Runners::Shell
   def env_hash: -> Hash<String, String?>
 end
 
-class Runners::Shell::ExecError
+class Runners::Shell::ExecError < StandardError
   attr_reader type: Symbol
   attr_reader args: Array<String>
   attr_reader stdout_str: String

--- a/test/shell_test.rb
+++ b/test/shell_test.rb
@@ -74,6 +74,7 @@ class ShellTest < Minitest::Test
         shell.capture3_trace("echo Error | tee /dev/stderr && exit 1", raise_on_failure: true)
       end
 
+      assert_equal "Command [echo Error | tee /dev/stderr && exit 1] exited with 1", error.message
       assert_equal :capture3, error.type
       assert_equal ["echo Error | tee /dev/stderr && exit 1"], error.args
       assert_equal "Error\n", error.stdout_str
@@ -85,6 +86,15 @@ class ShellTest < Minitest::Test
         { trace: "stdout", string: "Error\n" },
         { trace: "stderr", string: "Error\n" },
       ]
+
+      assert_equal({
+        details: {
+          args: ["echo Error | tee /dev/stderr && exit 1"],
+          stdout: "Error\n",
+          stderr: "Error\n",
+          status: 1,
+        }
+      }, error.bugsnag_meta_data)
     end
   end
 


### PR DESCRIPTION
In order to distinguish errors by their details on Bugsnag.

See https://docs.bugsnag.com/platforms/ruby/customizing-error-reports/#custom-error-diagnostic-data