### PR TITLE
Fix error for issue sorting when location is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.7.3...HEAD)
 
 - Report message and metadata on `Shell::ExecError` to Bugsnag [#414](https://github.com/sider/runners/pull/414)
+- Fix error for issue sorting when location is nil [#416](https://github.com/sider/runners/pull/416)
 
 ## 0.7.3
 

--- a/lib/runners/results.rb
+++ b/lib/runners/results.rb
@@ -38,7 +38,17 @@ module Runners
       def as_json
         super.tap do |json|
           json[:type] = 'success'
-          json[:issues] = issues.map(&:as_json).sort_by! {|issue| [issue[:id], issue[:path], issue.dig(:location, :start_line)]}
+          json[:issues] = issues.map(&:as_json).sort_by! do |issue|
+            [
+              issue[:id] || "",
+              issue[:path] || "",
+              issue.dig(:location, :start_line) || 0,
+              issue.dig(:location, :start_column) || 0,
+              issue.dig(:location, :end_line) || 0,
+              issue.dig(:location, :end_column) || 0,
+              issue[:message] || "",
+            ]
+          end
           json[:analyzer] = analyzer.as_json
         end
       end

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -20,6 +20,12 @@ class ResultTest < Minitest::Test
       },
       schema: nil
     )
+    result.add_issue Issue.new(
+      path: Pathname("foo/bar/baz.rb"),
+      location: nil,
+      id: "some_error_id",
+      message: "abc def",
+    )
 
     assert result.valid?
 
@@ -32,12 +38,20 @@ class ResultTest < Minitest::Test
                        issues: [
                          {
                            path: "foo/bar/baz.rb",
+                           location: nil,
+                           id: "some_error_id",
+                           message: "abc def",
+                           links: [],
+                           object: nil,
+                         },
+                         {
+                           path: "foo/bar/baz.rb",
                            location: { start_line: 1 },
                            id: "some_error_id",
                            message: "abc def",
                            links: [],
                            object: { args: [1,2,3] }
-                         }
+                         },
                        ],
                        analyzer: { name: "RuboCop", version: "1.3.2pre" }
                      })


### PR DESCRIPTION
[`Array#sort_by!`](http://ruby-doc.org/core-2.6.5/Array.html#method-i-sort_by-21) raises the following error when `nil` is included as a member of an array.

> ArgumentError: comparison of Array with Array failed