### PR TITLE
Bugsnag notify on `rescue` block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.7.5...HEAD)
 
+- Bugsnag notify on `rescue` block [#445](https://github.com/sider/runners/pull/445)
+
 ## 0.7.5
 
 [Full diff](https://github.com/sider/runners/compare/0.7.4...0.7.5)

--- a/bin/runners
+++ b/bin/runners
@@ -4,7 +4,6 @@ require "pathname"
 
 $LOAD_PATH << Pathname(__dir__).parent + "lib"
 
-require "bugsnag"
 require "runners"
 require "runners/cli"
 
@@ -33,7 +32,4 @@ trap('SIGUSR2') do
   Bugsnag.notify(RunnersTimeoutError.new)
 end
 
-result = Runners::CLI.new(argv: ARGV.dup, stdout: STDOUT, stderr: STDERR).validate_options!.run
-if result.instance_of?(Runners::Results::Error)
-  Bugsnag.notify(result.exception)
-end
+Runners::CLI.new(argv: ARGV.dup, stdout: STDOUT, stderr: STDERR).validate_options!.run

--- a/lib/runners.rb
+++ b/lib/runners.rb
@@ -30,6 +30,7 @@ require "active_support/core_ext/module/attribute_accessors"
 require "active_support/core_ext/string/filters"
 require "active_support/core_ext/module/delegation"
 require "aws-sdk-s3"
+require "bugsnag"
 
 require "runners/location"
 require "runners/results"

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -75,6 +75,7 @@ module Runners
           end
         end
       rescue => exn
+        Bugsnag.notify(exn)
         Results::Error.new(guid: guid, exception: exn)
       end
     end


### PR DESCRIPTION
The notification in `bin/runners` is unstable because the `result` return value may not be `Runners::Results::Error`.

To ensure reporting errors to Bugsnag, this calls `Bugsnag.notify` directly on the `rescue` block in `Harness#ensure_result`.