### PR TITLE
[ESLint] Use `--output-file` option to fix JSON parse error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - [cpplint] New support [#417](https://github.com/sider/runners/pull/417)
 - Add Options module and delete insecure options [#415](https://github.com/sider/runners/pull/415)
 - Output an unexpected error message to the trace log [#446](https://github.com/sider/runners/pull/446)
+- [ESLint] Use `--output-file` option to fix JSON parse error [#447](https://github.com/sider/runners/pull/447)
 
 ## 0.7.5
 

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -651,7 +651,7 @@ Smoke.add_test("typescript", {
     {
       id: "@typescript-eslint/no-unused-vars",
       message: "'x' is assigned a value but never used.",
-      links: ["https://github.com/typescript-eslint/typescript-eslint/blob/v2.6.0/packages/eslint-plugin/docs/rules/no-unused-vars.md"],
+      links: ["https://github.com/typescript-eslint/typescript-eslint/blob/v1.13.0/packages/eslint-plugin/docs/rules/no-unused-vars.md"],
       path: "index.ts",
       location: { start_line: 1, start_column: 7, end_line: 1, end_column: 8 },
       object: {
@@ -665,4 +665,6 @@ Smoke.add_test("typescript", {
     name: "ESLint",
     version: "6.5.1",
   },
+}, {
+  warnings: [{ message: /The required dependency `eslint` may not have been correctly installed/, file: "package.json" }],
 })

--- a/test/smokes/eslint/typescript/package.json
+++ b/test/smokes/eslint/typescript/package.json
@@ -1,9 +1,9 @@
 {
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "2.6.0",
-    "@typescript-eslint/parser": "2.6.0",
+    "@typescript-eslint/eslint-plugin": "1.13.0",
+    "@typescript-eslint/parser": "1.13.0",
     "eslint": "6.5.1",
-    "typescript": "3.6.4"
+    "typescript": "2.9.2"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
[`typescript-eslint`](https://github.com/typescript-eslint/typescript-eslint) can output a warning to STDOUT.
In that case, JSON parsing for STDOUT fails.

To avoid the error, we must use the `--output-file` option of ESLint.

See also #401