### PR TITLE
Suppress `npm ls` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Add Options module and delete insecure options [#415](https://github.com/sider/runners/pull/415)
 - Output an unexpected error message to the trace log [#446](https://github.com/sider/runners/pull/446)
 - [ESLint] Use `--output-file` option to fix JSON parse error [#447](https://github.com/sider/runners/pull/447)
+- Suppress `npm ls` output [#448](https://github.com/sider/runners/pull/448)
 
 ## 0.7.5
 

--- a/lib/runners/nodejs.rb
+++ b/lib/runners/nodejs.rb
@@ -208,8 +208,8 @@ module Runners
     end
 
     def check_installed_nodejs_deps(constraints, default_dependency)
-      # NOTE: `npm ls` fails when any peer dependencies are missing.
-      stdout, _, _ = capture3 "npm", "ls", "--depth=0", "--json"
+      # NOTE: `npm ls` fails when any peer dependencies are missing. Also, the command output can be too long.
+      stdout, _, _ = capture3 "npm", "ls", "--depth=0", "--json", trace_stdout: false
       installed_deps = JSON.parse(stdout)["dependencies"]
 
       return unless installed_deps


### PR DESCRIPTION
The `npm ls` command can be too long, so this suppresses the output to the trace log.