### PR TITLE
Add Runners version and set it to result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.8.1...HEAD)
 
+- Add Runners version and set it to result [#449](https://github.com/sider/runners/pull/449)
+
 ## 0.8.1
 
 [Full diff](https://github.com/sider/runners/compare/0.8.0...0.8.1)

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,9 @@ require_relative "lib/tasks/bump/analyzers"
 require_relative "lib/tasks/bump/devon_rex"
 require_relative "lib/tasks/docker/timeout_test"
 
-Aufgaben::Release.new
+Aufgaben::Release.new do |t|
+  t.files = ["lib/runners/version.rb"]
+end
 
 Aufgaben::Bump::Ruby.new do |t|
   t.files = %w[

--- a/lib/runners.rb
+++ b/lib/runners.rb
@@ -32,6 +32,7 @@ require "active_support/core_ext/module/delegation"
 require "aws-sdk-s3"
 require "bugsnag"
 
+require "runners/version"
 require "runners/options"
 require "runners/location"
 require "runners/results"

--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -53,6 +53,7 @@ module Runners
             result: result.as_json,
             warnings: warnings,
             ci_config: ci_config,
+            version: Runners::VERSION,
           }
 
           trace_writer.message "Writing result..." do

--- a/lib/runners/schema/result.rb
+++ b/lib/runners/schema/result.rb
@@ -21,7 +21,12 @@ module Runners
       let :missing_file_failure, object(guid: string, timestamp: string, type: literal("missing_files"), files: array(string))
       let :error, object(guid: string, timestamp: string, type: literal("error"), class: string, backtrace: array(string), inspect: string)
 
-      let :envelope, object(result: enum(success, failure, missing_file_failure, error), warnings: array(warning), ci_config: any?)
+      let :envelope, object(
+        result: enum(success, failure, missing_file_failure, error),
+        warnings: array(warning),
+        ci_config: any?,
+        version: string,
+      )
     end
   end
 end

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -148,6 +148,7 @@ module Runners
 
         others[:warnings] ||= []
         others[:ci_config] ||= :_
+        others[:version] ||= :_
 
         @tests[name] = {
           result: result,

--- a/lib/runners/version.rb
+++ b/lib/runners/version.rb
@@ -1,0 +1,3 @@
+module Runners
+  VERSION = "0.8.1".freeze
+end

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -1,6 +1,8 @@
 module Runners
 end
 
+Runners::VERSION: String
+
 interface Runners::_Writer
   def <<: (Schema::Types::any_trace) -> void
 end

--- a/sig/runners/schema.rbi
+++ b/sig/runners/schema.rbi
@@ -65,7 +65,8 @@ class Runners::Schema::Types::Result < StrongJSON
   def envelope: -> StrongJSON::Type::Object<{
     result: success_result | failure_result | missing_files_result | error_result,
     warnings: Array<warning>,
-    ci_config: any
+    ci_config: any,
+    version: String,
   }>
 end
 


### PR DESCRIPTION
Why?
----

If Runners client can receive its version, the client can do something different according to the some versions.
Also, I think that saving Runners versions will be useful to debug.

Notes
-----

- The `rake release` task will update the version automatically.