### PR TITLE
Configure :endpoint if S3_ENDPOINT is set

### DIFF
--- a/lib/runners/io/aws_s3.rb
+++ b/lib/runners/io/aws_s3.rb
@@ -22,7 +22,17 @@ module Runners
       @uri = uri
       @bucket_name, @object_name = self.class.parse_s3_uri!(uri)
       @tempfile = Tempfile.new
-      @client = Aws::S3::Client.new(retry_limit: 5, retry_base_delay: 1.2)
+
+      args = {
+        retry_limit: 5,
+        retry_base_delay: 1.2,
+      }.tap do |hash|
+        if ENV["S3_ENDPOINT"]
+          hash[:endpoint] = ENV["S3_ENDPOINT"]
+          hash[:force_path_style] = true
+        end
+      end
+      @client = Aws::S3::Client.new(**args)
     end
 
     def finalize!

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -151,6 +151,7 @@ extension Hash (Polyfill)
   def merge!: (*Hash<any, any>) -> Hash<any, any>
   def compact: -> self
   def dig: (*'key) -> 'value?
+  def []=: (any, any) -> any
 end
 
 class Psych::SyntaxError

--- a/test/io/aws_s3_test.rb
+++ b/test/io/aws_s3_test.rb
@@ -3,6 +3,19 @@ require_relative "../test_helper"
 class AwsS3Test < Minitest::Test
   include TestHelper
 
+  def test_initialize
+    with_stubbed_env('S3_ENDPOINT', nil) do
+      mock(Aws::S3::Client).new(retry_limit: is_a(Numeric), retry_base_delay: is_a(Numeric))
+      Runners::IO::AwsS3.new('s3://bucket_name/object_name')
+    end
+
+    with_stubbed_env('S3_ENDPOINT', 'https://s3.example.com') do
+      mock(Aws::S3::Client).new(retry_limit: is_a(Numeric), retry_base_delay: is_a(Numeric),
+                                endpoint: 'https://s3.example.com', force_path_style: true)
+      Runners::IO::AwsS3.new('s3://bucket_name/object_name')
+    end
+  end
+
   def test_parse_s3_uri
     assert_raises(RuntimeError) { Runners::IO::AwsS3.parse_s3_uri!('http://example.com') }
     assert_raises(RuntimeError) { Runners::IO::AwsS3.parse_s3_uri!('s3://bucket') }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,11 +23,17 @@ module TestHelper
     Pathname(__dir__).join("incorrect_yarn_data", file)
   end
 
-  def with_runners_options_env(hash)
-    backup = ENV['RUNNERS_OPTIONS']
-    ENV['RUNNERS_OPTIONS'] = JSON.dump(hash)
+  def with_stubbed_env(name, value)
+    backup = ENV[name]
+    ENV[name] = value
     yield
   ensure
-    ENV['RUNNERS_OPTIONS'] = backup
+    ENV[name] = backup
+  end
+
+  def with_runners_options_env(hash)
+    with_stubbed_env('RUNNERS_OPTIONS', JSON.dump(hash)) do
+      yield
+    end
   end
 end


### PR DESCRIPTION
In some environments, we want Runners to upload traces to another S3
compatible endpoint like [Minio](https://min.io/). This PR let us
configure the S3 endpoint.

Note: This feature assumes that S3 compatible endpoint is served by
Minio, so `:force_path_style` is set to `true` if the `S3_ENDPOINT`
environment variable exists.