### PR TITLE
Bump devon_rex images from 2.7.0 to 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Bump eslint from 6.5.1 to 6.6.0 [#431](https://github.com/sider/runners/pull/431)
 - Bump goodcheck from 2.4.0 to 2.4.3 [#468](https://github.com/sider/runners/pull/468)
 - Bump rubocop from 0.75.0 to 0.76.0 [#434](https://github.com/sider/runners/pull/434)
+- Bump devon_rex images from 2.7.0 to 2.8.0 [#474](https://github.com/sider/runners/pull/474)
 
 ## 0.8.2
 

--- a/images/Dockerfile.java.erb
+++ b/images/Dockerfile.java.erb
@@ -1,5 +1,5 @@
 <% analyzer = ENV.fetch('ANALYZER') %>
-FROM sider/devon_rex_java:2.7.0 AS builder
+FROM sider/devon_rex_java:2.8.0 AS builder
 
 # NOTE: Download required dependency JAR files via maven-dependency-plugin.
 #       Also, this image uses a build layer because Maven downloads too many files to `~/.m2` directory.
@@ -9,7 +9,7 @@ COPY --chown=<%= ENV.fetch("RUNNER_CHOWN") %> images/<%= analyzer %>/pom.xml ${R
 RUN cd "${RUNNER_USER_HOME}/<%= analyzer %>" && \
     mvn -ntp -B -T 4 dependency:copy-dependencies -DoutputDirectory=.
 
-FROM sider/devon_rex_java:2.7.0
+FROM sider/devon_rex_java:2.8.0
 
 COPY --chown=<%= ENV.fetch("RUNNER_CHOWN") %> --from=builder ${RUNNER_USER_HOME}/<%= analyzer %>/*.jar ${RUNNER_USER_HOME}/<%= analyzer %>/
 ENV CLASSPATH ${RUNNER_USER_HOME}/<%= analyzer %>/*:${CLASSPATH}

--- a/images/brakeman/Dockerfile
+++ b/images/brakeman/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/brakeman/Dockerfile.erb
+++ b/images/brakeman/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>

--- a/images/checkstyle/Dockerfile
+++ b/images/checkstyle/Dockerfile
@@ -3,7 +3,7 @@
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-FROM sider/devon_rex_java:2.7.0 AS builder
+FROM sider/devon_rex_java:2.8.0 AS builder
 
 # NOTE: Download required dependency JAR files via maven-dependency-plugin.
 #       Also, this image uses a build layer because Maven downloads too many files to `~/.m2` directory.
@@ -13,7 +13,7 @@ COPY --chown=analyzer_runner:nogroup images/checkstyle/pom.xml ${RUNNER_USER_HOM
 RUN cd "${RUNNER_USER_HOME}/checkstyle" && \
     mvn -ntp -B -T 4 dependency:copy-dependencies -DoutputDirectory=.
 
-FROM sider/devon_rex_java:2.7.0
+FROM sider/devon_rex_java:2.8.0
 
 COPY --chown=analyzer_runner:nogroup --from=builder ${RUNNER_USER_HOME}/checkstyle/*.jar ${RUNNER_USER_HOME}/checkstyle/
 ENV CLASSPATH ${RUNNER_USER_HOME}/checkstyle/*:${CLASSPATH}

--- a/images/code_sniffer/Dockerfile
+++ b/images/code_sniffer/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_php:2.7.0
+FROM sider/devon_rex_php:2.8.0
 
 
 # Install PHP packages via Composer

--- a/images/code_sniffer/Dockerfile.erb
+++ b/images/code_sniffer/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_php:2.7.0
+FROM sider/devon_rex_php:2.8.0
 
 <%= render_erb 'images/Dockerfile.php.erb' %>
 

--- a/images/coffeelint/Dockerfile
+++ b/images/coffeelint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.7.0
+FROM sider/devon_rex_npm:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/coffeelint/Dockerfile.erb
+++ b/images/coffeelint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:2.7.0
+FROM sider/devon_rex_npm:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.npm.erb' %>

--- a/images/cppcheck/Dockerfile
+++ b/images/cppcheck/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_python:2.7.0 AS builder
+FROM sider/devon_rex_python:2.8.0 AS builder
 
 # NOTE: The reason using Python image: when setting `MATCHCOMPILER=yes`, Python is used to optimise cppcheck.
 #
@@ -20,7 +20,7 @@ RUN cd /tmp && \
       CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function" && \
     rm -rf cppcheck-${CPPCHECK_VERSION}
 
-FROM sider/devon_rex_base:2.7.0
+FROM sider/devon_rex_base:2.8.0
 
 COPY --from=builder /usr/share/cppcheck /usr/share/cppcheck
 COPY --from=builder /usr/bin/cppcheck /usr/bin/cppcheck

--- a/images/cppcheck/Dockerfile.erb
+++ b/images/cppcheck/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_python:2.7.0 AS builder
+FROM sider/devon_rex_python:2.8.0 AS builder
 
 # NOTE: The reason using Python image: when setting `MATCHCOMPILER=yes`, Python is used to optimise cppcheck.
 #
@@ -16,7 +16,7 @@ RUN cd /tmp && \
       CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function" && \
     rm -rf cppcheck-${CPPCHECK_VERSION}
 
-FROM sider/devon_rex_base:2.7.0
+FROM sider/devon_rex_base:2.8.0
 
 COPY --from=builder /usr/share/cppcheck /usr/share/cppcheck
 COPY --from=builder /usr/bin/cppcheck /usr/bin/cppcheck

--- a/images/cpplint/Dockerfile
+++ b/images/cpplint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_python:2.7.0
+FROM sider/devon_rex_python:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/cpplint/Dockerfile.erb
+++ b/images/cpplint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_python:2.7.0
+FROM sider/devon_rex_python:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.python.erb' %>

--- a/images/eslint/Dockerfile
+++ b/images/eslint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.7.0
+FROM sider/devon_rex_npm:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/eslint/Dockerfile.erb
+++ b/images/eslint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:2.7.0
+FROM sider/devon_rex_npm:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.npm.erb' %>

--- a/images/flake8/Dockerfile
+++ b/images/flake8/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_python:2.7.0
+FROM sider/devon_rex_python:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/flake8/Dockerfile.erb
+++ b/images/flake8/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_python:2.7.0
+FROM sider/devon_rex_python:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.python.erb' %>

--- a/images/go_vet/Dockerfile
+++ b/images/go_vet/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_go:2.7.0
+FROM sider/devon_rex_go:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/go_vet/Dockerfile.erb
+++ b/images/go_vet/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_go:2.7.0
+FROM sider/devon_rex_go:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 

--- a/images/golint/Dockerfile
+++ b/images/golint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_go:2.7.0
+FROM sider/devon_rex_go:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/golint/Dockerfile.erb
+++ b/images/golint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_go:2.7.0
+FROM sider/devon_rex_go:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 

--- a/images/gometalinter/Dockerfile
+++ b/images/gometalinter/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_go:2.7.0
+FROM sider/devon_rex_go:2.8.0
 
 ARG LINT_TOOL_VERSION="2.0.11"
 

--- a/images/gometalinter/Dockerfile.erb
+++ b/images/gometalinter/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_go:2.7.0
+FROM sider/devon_rex_go:2.8.0
 
 ARG LINT_TOOL_VERSION="2.0.11"
 

--- a/images/goodcheck/Dockerfile
+++ b/images/goodcheck/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/goodcheck/Dockerfile.erb
+++ b/images/goodcheck/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>

--- a/images/haml_lint/Dockerfile
+++ b/images/haml_lint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/haml_lint/Dockerfile.erb
+++ b/images/haml_lint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>

--- a/images/javasee/Dockerfile
+++ b/images/javasee/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:2.7.0
+FROM sider/devon_rex_java:2.8.0
 
 ARG JAVASEE_VERSION=0.1.2
 USER root

--- a/images/javasee/Dockerfile.erb
+++ b/images/javasee/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_java:2.7.0
+FROM sider/devon_rex_java:2.8.0
 
 ARG JAVASEE_VERSION=0.1.2
 USER root

--- a/images/jshint/Dockerfile
+++ b/images/jshint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.7.0
+FROM sider/devon_rex_npm:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/jshint/Dockerfile.erb
+++ b/images/jshint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:2.7.0
+FROM sider/devon_rex_npm:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.npm.erb' %>

--- a/images/ktlint/Dockerfile
+++ b/images/ktlint/Dockerfile
@@ -3,7 +3,7 @@
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-FROM sider/devon_rex_java:2.7.0 AS builder
+FROM sider/devon_rex_java:2.8.0 AS builder
 
 # NOTE: Download required dependency JAR files via maven-dependency-plugin.
 #       Also, this image uses a build layer because Maven downloads too many files to `~/.m2` directory.
@@ -13,7 +13,7 @@ COPY --chown=analyzer_runner:nogroup images/ktlint/pom.xml ${RUNNER_USER_HOME}/k
 RUN cd "${RUNNER_USER_HOME}/ktlint" && \
     mvn -ntp -B -T 4 dependency:copy-dependencies -DoutputDirectory=.
 
-FROM sider/devon_rex_java:2.7.0
+FROM sider/devon_rex_java:2.8.0
 
 COPY --chown=analyzer_runner:nogroup --from=builder ${RUNNER_USER_HOME}/ktlint/*.jar ${RUNNER_USER_HOME}/ktlint/
 ENV CLASSPATH ${RUNNER_USER_HOME}/ktlint/*:${CLASSPATH}

--- a/images/misspell/Dockerfile
+++ b/images/misspell/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_base:2.7.0
+FROM sider/devon_rex_base:2.8.0
 
 USER root
 ARG MISSPELL_VERSION=0.3.4

--- a/images/misspell/Dockerfile.erb
+++ b/images/misspell/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_base:2.7.0
+FROM sider/devon_rex_base:2.8.0
 
 USER root
 ARG MISSPELL_VERSION=0.3.4

--- a/images/phinder/Dockerfile
+++ b/images/phinder/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_php:2.7.0
+FROM sider/devon_rex_php:2.8.0
 
 
 # Install PHP packages via Composer

--- a/images/phinder/Dockerfile.erb
+++ b/images/phinder/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_php:2.7.0
+FROM sider/devon_rex_php:2.8.0
 
 <%= render_erb 'images/Dockerfile.php.erb' %>
 <%= render_erb 'images/Dockerfile.base.erb' %>

--- a/images/phpmd/Dockerfile
+++ b/images/phpmd/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_php:2.7.0
+FROM sider/devon_rex_php:2.8.0
 
 
 # Install PHP packages via Composer

--- a/images/phpmd/Dockerfile.erb
+++ b/images/phpmd/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_php:2.7.0
+FROM sider/devon_rex_php:2.8.0
 
 <%= render_erb 'images/Dockerfile.php.erb' %>
 <%= render_erb 'images/Dockerfile.base.erb' %>

--- a/images/pmd_java/Dockerfile
+++ b/images/pmd_java/Dockerfile
@@ -3,7 +3,7 @@
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-FROM sider/devon_rex_java:2.7.0 AS builder
+FROM sider/devon_rex_java:2.8.0 AS builder
 
 # NOTE: Download required dependency JAR files via maven-dependency-plugin.
 #       Also, this image uses a build layer because Maven downloads too many files to `~/.m2` directory.
@@ -13,7 +13,7 @@ COPY --chown=analyzer_runner:nogroup images/pmd_java/pom.xml ${RUNNER_USER_HOME}
 RUN cd "${RUNNER_USER_HOME}/pmd_java" && \
     mvn -ntp -B -T 4 dependency:copy-dependencies -DoutputDirectory=.
 
-FROM sider/devon_rex_java:2.7.0
+FROM sider/devon_rex_java:2.8.0
 
 COPY --chown=analyzer_runner:nogroup --from=builder ${RUNNER_USER_HOME}/pmd_java/*.jar ${RUNNER_USER_HOME}/pmd_java/
 ENV CLASSPATH ${RUNNER_USER_HOME}/pmd_java/*:${CLASSPATH}

--- a/images/querly/Dockerfile
+++ b/images/querly/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/querly/Dockerfile.erb
+++ b/images/querly/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>

--- a/images/rails_best_practices/Dockerfile
+++ b/images/rails_best_practices/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/rails_best_practices/Dockerfile.erb
+++ b/images/rails_best_practices/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>

--- a/images/reek/Dockerfile
+++ b/images/reek/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/reek/Dockerfile.erb
+++ b/images/reek/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>

--- a/images/rubocop/Dockerfile
+++ b/images/rubocop/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 # NOTE: RuboCop 0.60.0 does not work on Ruby 2.6, so install and use Ruby 2.5 instead.
 #       See https://github.com/sider/runners/issues/57#issuecomment-530858769

--- a/images/rubocop/Dockerfile.erb
+++ b/images/rubocop/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 # NOTE: RuboCop 0.60.0 does not work on Ruby 2.6, so install and use Ruby 2.5 instead.
 #       See https://github.com/sider/runners/issues/57#issuecomment-530858769

--- a/images/scss_lint/Dockerfile
+++ b/images/scss_lint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/scss_lint/Dockerfile.erb
+++ b/images/scss_lint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.7.0
+FROM sider/devon_rex_ruby:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>

--- a/images/shellcheck/Dockerfile
+++ b/images/shellcheck/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_base:2.6.0
+FROM sider/devon_rex_base:2.8.0
 
 USER root
 RUN apt-get update && \

--- a/images/shellcheck/Dockerfile.erb
+++ b/images/shellcheck/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_base:2.6.0
+FROM sider/devon_rex_base:2.8.0
 
 USER root
 RUN apt-get update && \

--- a/images/stylelint/Dockerfile
+++ b/images/stylelint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.7.0
+FROM sider/devon_rex_npm:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/stylelint/Dockerfile.erb
+++ b/images/stylelint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:2.7.0
+FROM sider/devon_rex_npm:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.npm.erb' %>

--- a/images/swiftlint/Dockerfile
+++ b/images/swiftlint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_swift:2.7.0
+FROM sider/devon_rex_swift:2.8.0
 
 ARG SWIFTLINT_VERSION=0.36.0
 

--- a/images/swiftlint/Dockerfile.erb
+++ b/images/swiftlint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_swift:2.7.0
+FROM sider/devon_rex_swift:2.8.0
 
 ARG SWIFTLINT_VERSION=0.36.0
 

--- a/images/tslint/Dockerfile
+++ b/images/tslint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.7.0
+FROM sider/devon_rex_npm:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/tslint/Dockerfile.erb
+++ b/images/tslint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:2.7.0
+FROM sider/devon_rex_npm:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.npm.erb' %>

--- a/images/tyscan/Dockerfile
+++ b/images/tyscan/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.7.0
+FROM sider/devon_rex_npm:2.8.0
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 

--- a/images/tyscan/Dockerfile.erb
+++ b/images/tyscan/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:2.7.0
+FROM sider/devon_rex_npm:2.8.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.npm.erb' %>


### PR DESCRIPTION
Via:
```
$ bundle exec rake dockerfile:bump_devon_rex'[2.8.0]'
```

See also:
- https://github.com/sider/devon_rex/releases/tag/2.8.0
- https://github.com/sider/devon_rex/blob/2.8.0/CHANGELOG.md