### PR TITLE
[RuboCop] Fix `Ruby#installed_gem_versions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.9.0...HEAD)
 
+- [RuboCop] Fix `Ruby#installed_gem_versions` [#489](https://github.com/sider/runners/pull/489)
+
 ## 0.9.0
 
 [Full diff](https://github.com/sider/runners/compare/0.8.2...0.9.0)

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -268,7 +268,7 @@ module Runners
     end
 
     def rubocop_plugin_version(gem_name)
-      @rubocop_plugin_versions ||= installed_gem_versions("rubocop-rails", "rubocop-performance")
+      @rubocop_plugin_versions ||= installed_gem_versions("rubocop-rails", "rubocop-performance", exception: false)
       @rubocop_plugin_versions[gem_name]&.first
     end
 

--- a/lib/runners/ruby.rb
+++ b/lib/runners/ruby.rb
@@ -77,20 +77,20 @@ module Runners
       @analyzer_version ||= extract_version! ruby_analyzer_bin
     end
 
-    def installed_gem_versions(gem_name, *gem_names)
+    def installed_gem_versions(gem_name, *gem_names, exception: true)
       gem_names = [gem_name] + gem_names
 
       # @see https://guides.rubygems.org/command-reference/#gem-list
       stdout, = capture3! "gem", "list", "--quiet", "--exact", *gem_names
-      gem_names.map do |name|
+      gem_names.each_with_object({}) do |name, hash|
         # NOTE: A format example: `rubocop (0.75.1, 0.75.0)`
         version, = /#{Regexp.escape(name)} \((.+)\)/.match(stdout)&.captures
         if version
-          [name, version.split(/,\s*/)]
-        else
+          hash[name] = version.split(/,\s*/)
+        elsif exception
           raise "Not found installed gem #{name.inspect}"
         end
-      end.to_h
+      end
     end
 
     def default_gem_specs(gem_name = analyzer_bin, *gem_names)

--- a/sig/runners/ruby.rbi
+++ b/sig/runners/ruby.rbi
@@ -6,7 +6,7 @@ module Runners::Ruby : Processor
   def user_specs: (Array<GemInstaller::Spec>, LockfileLoader::Lockfile) -> Array<GemInstaller::Spec>
   def show_ruby_runtime_versions: -> void
   def ruby_analyzer_bin: -> Array<String>
-  def installed_gem_versions: (String, *String) -> Hash<String, Array<String>>
+  def installed_gem_versions: (String, *String, ?exception: bool) -> Hash<String, Array<String>>
   def default_gems: (?String, *String) -> Array<GemInstaller::Spec>
 end
 

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -763,6 +763,14 @@ EOF
       assert_raises(RuntimeError) { processor.installed_gem_versions("foo") }.tap do |error|
         assert_equal 'Not found installed gem "foo"', error.message
       end
+
+      mock(processor).capture3!("gem", "list", "--quiet", "--exact", "foo", "meowcop") do
+        <<~OUTPUT
+          meowcop (2.4.0)
+        OUTPUT
+      end
+      assert_equal({ "meowcop" => ["2.4.0"] },
+                   processor.installed_gem_versions("foo", "meowcop", exception: false))
     end
   end
 


### PR DESCRIPTION
This aims to avoid the following error:

> Not found installed gem "rubocop-performance"