### PR TITLE
Flush content whenever its size reaches the buffer max limit

### DIFF
--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -38,6 +38,7 @@ module Runners
     end
 
     def run
+      io.flush! # Write or upload empty content to let the caller of Runners notice the beginning of the analysis.
       with_working_dir do |working_dir|
         writer = JSONSEQ::Writer.new(io: io)
         trace_writer = TraceWriter.new(writer: writer)
@@ -64,7 +65,7 @@ module Runners
           end
         end
       ensure
-        io.finalize! if defined?(:@io)
+        io.flush! if defined?(:@io)
       end
     end
 

--- a/lib/runners/io.rb
+++ b/lib/runners/io.rb
@@ -18,9 +18,9 @@ module Runners
       ios.each { |io| io.flush(*args) }
     end
 
-    def finalize!
+    def flush!
       ios.each do |io|
-        io.finalize! if io.respond_to?(:finalize!)
+        io.flush! if io.respond_to?(:flush!)
       end
     end
   end

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -36,6 +36,7 @@ extension String (Polyfill)
   def strip!: -> String
   def casecmp?: (String) -> bool?
   def delete: (*String) -> String
+  def delete_prefix: (String) -> String
 end
 
 class Time
@@ -86,6 +87,7 @@ class URI
   def self.parse: (String) -> URI
   def path: -> String
   def scheme: -> String
+  def host: -> String
 end
 
 class Net::HTTP

--- a/sig/runners/io.rbi
+++ b/sig/runners/io.rbi
@@ -4,7 +4,7 @@ class Runners::IO
   def initialize: (*any) -> any
   def write: (*any) -> void
   def flush: (*any) -> void
-  def finalize!: () -> void
+  def flush!: () -> void
 end
 
 Runners::IO::REQUIRED_METHODS_FOR_IOS: Array<Symbol>

--- a/test/io_test.rb
+++ b/test/io_test.rb
@@ -7,8 +7,8 @@ class IOTest < Minitest::Test
     out1 = StringIO.new
     out2 = StringIO.new
 
-    def out2.finalize!
-      self.write('@finalized!')
+    def out2.flush!
+      self.write('@flush!')
     end
 
     io = Runners::IO.new(out1, out2)
@@ -16,10 +16,10 @@ class IOTest < Minitest::Test
     io.flush
     assert_equal 'abc', out1.tap(&:rewind).read
     assert_equal 'abc', out2.tap(&:rewind).read
-    io.finalize!
-    # NOTE: `dont_allow(out1).finalize!` doesn't work because of RR,
-    #        so check only whether `out2#finalize!` was called or not.
-    assert_equal 'abc@finalized!', out2.tap(&:rewind).read
+    io.flush!
+    # NOTE: `dont_allow(out1).flush!` doesn't work because of RR,
+    #        so check only whether `out2#flush!` was called or not.
+    assert_equal 'abc@flush!', out2.tap(&:rewind).read
   end
 
   private

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -101,7 +101,7 @@ class OptionsTest < Minitest::Test
       s3_mock = Object.new
       stub(s3_mock).write
       stub(s3_mock).flush
-      stub(s3_mock).finalize!
+      stub(s3_mock).flush!
       mock(Runners::IO::AwsS3).new("s3://bucket/abc") { s3_mock }
       mock.proxy(Runners::IO).new(stdout, s3_mock)
 


### PR DESCRIPTION
Currently, the trace of the analysis is flushed at the end of the
analysis. However, I want to see the on-going trace log even though the
analysis has not yet finished. Also, I want to know whether the analysis
has started or not, so at the beginning of the analysis, I inserted the
`io.flush!` procedure.