### PR TITLE
Wrap Workspace with Harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.9.2...HEAD)
 
 - Bump devon_rex images from 2.8.0 to 2.9.0 [#500](https://github.com/sider/runners/pull/500)
+- Wrap Workspace with Harness [#501](https://github.com/sider/runners/pull/501)
 
 ## 0.9.2
 

--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -44,29 +44,27 @@ module Runners
         trace_writer = TraceWriter.new(writer: writer)
         trace_writer.header "Analysis started"
 
-        Workspace.open(base: options.base, base_key: options.base_key, head: options.head, head_key: options.head_key, ssh_key: options.ssh_key, working_dir: working_dir, trace_writer: trace_writer) do |workspace|
-          harness = Harness.new(guid: guid, processor_class: processor_class, workspace: workspace, trace_writer: trace_writer)
+        harness = Harness.new(guid: guid, processor_class: processor_class, options: options, working_dir: working_dir, trace_writer: trace_writer)
 
-          result = harness.run
-          warnings = harness.warnings
-          ci_config = harness.ci_config
-          json = {
-            result: result.as_json,
-            warnings: warnings,
-            ci_config: ci_config,
-            version: Runners::VERSION,
-          }
+        result = harness.run
+        warnings = harness.warnings
+        ci_config = harness.ci_config
+        json = {
+          result: result.as_json,
+          warnings: warnings,
+          ci_config: ci_config,
+          version: Runners::VERSION,
+        }
 
-          trace_writer.message "Writing result..." do
-            writer << Schema::Result.envelope.coerce(json)
-          end
-          result.tap do
-            trace_writer.header "Analysis finished"
-          end
+        trace_writer.message "Writing result..." do
+          writer << Schema::Result.envelope.coerce(json)
         end
-      ensure
-        io.flush! if defined?(:@io)
+        result.tap do
+          trace_writer.header "Analysis finished"
+        end
       end
+    ensure
+      io.flush! if defined?(:@io)
     end
 
     def io

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -10,56 +10,63 @@ module Runners
       end
     end
 
-    # @dynamic guid, processor_class, workspace, trace_writer, warnings, ci_config
+    # @dynamic guid, processor_class, options, working_dir, trace_writer, warnings, ci_config
     attr_reader :guid
     attr_reader :processor_class
-    attr_reader :workspace
+    attr_reader :options
+    attr_reader :working_dir
     attr_reader :trace_writer
     attr_reader :warnings
     attr_reader :ci_config
 
-    def initialize(guid:, processor_class:, workspace:, trace_writer:)
+    def initialize(guid:, processor_class:, options:, working_dir:, trace_writer:)
       @guid = guid
       @processor_class = processor_class
-      @workspace = workspace
+      @options = options
+      @working_dir = working_dir
       @trace_writer = trace_writer
       @warnings = []
     end
 
     def run
       ensure_result do
-        begin
-          instance = processor_class.new(guid: guid, working_dir: workspace.working_dir, git_ssh_path: workspace.git_ssh_path, trace_writer: trace_writer)
+        Workspace.open(base: options.base, base_key: options.base_key,
+                       head: options.head, head_key: options.head_key,
+                       ssh_key: options.ssh_key, working_dir: working_dir, trace_writer: trace_writer) do |workspace|
 
-          root_dir_not_found = instance.check_root_dir_exist
-          return root_dir_not_found if root_dir_not_found
+          begin
+            instance = processor_class.new(guid: guid, working_dir: workspace.working_dir, git_ssh_path: workspace.git_ssh_path, trace_writer: trace_writer)
 
-          instance.push_root_dir do
-            trace_writer.header "Calculating changes between head and base"
-            changes = trace_writer.message "Running..." do
-              workspace.calculate_changes
-            end
+            root_dir_not_found = instance.check_root_dir_exist
+            return root_dir_not_found if root_dir_not_found
 
-            trace_writer.header "Setting up analyzer"
-
-            result = instance.setup do
-              trace_writer.header "Running analyzer"
-              instance.analyze(changes)
-            end
-
-            case result
-            when Results::Success
-              trace_writer.message "Removing issues from unchanged or untracked files..." do
-                changed_paths = Set.new(changes.changed_files.map(&:path))
-                result.filter_issue {|issue| changed_paths.member?(issue.path) }
+            instance.push_root_dir do
+              trace_writer.header "Calculating changes between head and base"
+              changes = trace_writer.message "Running..." do
+                workspace.calculate_changes
               end
-            else
-              result
+
+              trace_writer.header "Setting up analyzer"
+
+              result = instance.setup do
+                trace_writer.header "Running analyzer"
+                instance.analyze(changes)
+              end
+
+              case result
+              when Results::Success
+                trace_writer.message "Removing issues from unchanged or untracked files..." do
+                  changed_paths = Set.new(changes.changed_files.map(&:path))
+                  result.filter_issue { |issue| changed_paths.member?(issue.path) }
+                end
+              else
+                result
+              end
             end
+          ensure
+            @warnings = instance&.warnings || []
+            @ci_config = instance&.ci_config_for_collect
           end
-        ensure
-          @warnings = instance&.warnings || []
-          @ci_config = instance&.ci_config_for_collect
         end
       end
     end

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -196,12 +196,13 @@ end
 class Runners::Harness
   attr_reader guid: String
   attr_reader processor_class: Processor.class constructor
-  attr_reader workspace: Workspace
+  attr_reader options: Options
+  attr_reader working_dir: Pathname
   attr_reader trace_writer: TraceWriter
   attr_reader warnings: Array<String>
   attr_reader ci_config: any
 
-  def initialize: (guid: String, processor_class: Processor.class constructor, workspace: Workspace, trace_writer: TraceWriter) -> any
+  def initialize: (guid: String, processor_class: Processor.class constructor, options: Options, working_dir: Pathname, trace_writer: TraceWriter) -> any
   def run: () -> result
   def ensure_result: { -> result } -> result
   def handle_error: (Exception) -> void


### PR DESCRIPTION
`Workspace.open` sometimes raises the error `DownloadError`.
When it happens, the result won't be output in the trace.

This PR changed `Harness` and wrapped `Workspace` with `Harness`.
Since `Harness#ensure_result` catches any errors, `DownloadError`
will be handled and the `trace_writer` of `Harness` surely writes
the result.

I think it's easy to read this PR with the settings "Hide whitespace changes."