### PR TITLE
Configure instance_profile_credentials_* for Aws::S3::Client

### DIFF
--- a/lib/runners/io/aws_s3.rb
+++ b/lib/runners/io/aws_s3.rb
@@ -29,6 +29,8 @@ module Runners
       args = {
         retry_limit: 5,
         retry_base_delay: 1.2,
+        instance_profile_credentials_retries: 5,
+        instance_profile_credentials_timeout: 3,
       }.tap do |hash|
         if ENV["S3_ENDPOINT"]
           hash[:endpoint] = ENV["S3_ENDPOINT"]

--- a/test/io/aws_s3_test.rb
+++ b/test/io/aws_s3_test.rb
@@ -5,12 +5,16 @@ class AwsS3Test < Minitest::Test
 
   def test_initialize
     with_stubbed_env('S3_ENDPOINT', nil) do
-      mock(Aws::S3::Client).new(retry_limit: is_a(Numeric), retry_base_delay: is_a(Numeric))
+      mock(Aws::S3::Client).new(retry_limit: is_a(Numeric), retry_base_delay: is_a(Numeric),
+                                instance_profile_credentials_retries: is_a(Numeric),
+                                instance_profile_credentials_timeout: is_a(Numeric))
       Runners::IO::AwsS3.new('s3://bucket_name/object_name')
     end
 
     with_stubbed_env('S3_ENDPOINT', 'https://s3.example.com') do
       mock(Aws::S3::Client).new(retry_limit: is_a(Numeric), retry_base_delay: is_a(Numeric),
+                                instance_profile_credentials_retries: is_a(Numeric),
+                                instance_profile_credentials_timeout: is_a(Numeric),
                                 endpoint: 'https://s3.example.com', force_path_style: true)
       Runners::IO::AwsS3.new('s3://bucket_name/object_name')
     end
@@ -24,7 +28,9 @@ class AwsS3Test < Minitest::Test
   end
 
   def test_write_flush
-    mock(Aws::S3::Client).new(retry_limit: is_a(Numeric), retry_base_delay: is_a(Numeric))
+    mock(Aws::S3::Client).new(retry_limit: is_a(Numeric), retry_base_delay: is_a(Numeric),
+                              instance_profile_credentials_retries: is_a(Numeric),
+                              instance_profile_credentials_timeout: is_a(Numeric))
     io = Runners::IO::AwsS3.new('s3://bucket_name/object_name')
     io.write('abc')
     io.write('!!!')
@@ -33,7 +39,9 @@ class AwsS3Test < Minitest::Test
   end
 
   def test_should_flush?
-    mock(Aws::S3::Client).new(retry_limit: is_a(Numeric), retry_base_delay: is_a(Numeric))
+    mock(Aws::S3::Client).new(retry_limit: is_a(Numeric), retry_base_delay: is_a(Numeric),
+                              instance_profile_credentials_retries: is_a(Numeric),
+                              instance_profile_credentials_timeout: is_a(Numeric))
     io = Runners::IO::AwsS3.new('s3://bucket_name/object_name')
 
     2.times { io.write }
@@ -47,7 +55,9 @@ class AwsS3Test < Minitest::Test
 
   def test_flush!
     mock_object = Object.new
-    mock(Aws::S3::Client).new(retry_limit: is_a(Numeric), retry_base_delay: is_a(Numeric)) { mock_object }
+    mock(Aws::S3::Client).new(retry_limit: is_a(Numeric), retry_base_delay: is_a(Numeric),
+                              instance_profile_credentials_retries: is_a(Numeric),
+                              instance_profile_credentials_timeout: is_a(Numeric)) { mock_object }
     mock(mock_object).put_object(bucket: 'bucket_name', key: 'object_name', body: instance_of(Tempfile))
     io = Runners::IO::AwsS3.new('s3://bucket_name/object_name')
     io.write


### PR DESCRIPTION
We sometimes get hit with `Aws::Sigv4::Errors::MissingCredentialsError`. I wonder we can avoid this with `instance_profile_credentials_retries` and `instance_profile_credentials_timeout`.