### PR TITLE
[HAML-Lint] Fix incompatibility with RuboCop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.10.0...HEAD)
 
 - Bump devon_rex images from 2.9.0 to 2.10.0 [#527](https://github.com/sider/runners/pull/527)
+- [HAML-Lint] Fix incompatibility with RuboCop [#533](https://github.com/sider/runners/pull/533)
 
 ## 0.10.0
 

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -51,6 +51,8 @@ module Runners
       GemInstaller::Spec.new(name: "rubocop-thread_safety", version: []),
     ].freeze
 
+    DEFAULT_GEMS = ["haml_lint", "rubocop"].freeze
+
     CONSTRAINTS = {
       "haml_lint" => [">= 0.26.0"]
     }.freeze
@@ -68,7 +70,7 @@ module Runners
     end
 
     def default_gem_specs
-      super("haml_lint").tap do |gems|
+      super(*DEFAULT_GEMS).tap do |gems|
         if setup_default_config
           # NOTE: See rubocop.rb about no versions.
           gems << GemInstaller::Spec.new(name: "meowcop", version: [])

--- a/test/smokes/haml_lint/expectations.rb
+++ b/test/smokes/haml_lint/expectations.rb
@@ -135,16 +135,9 @@ Smoke.add_test(
   'incompatible_rubocop',
   guid: 'test-guid',
   timestamp: :_,
-  type: 'success',
-  issues: [{
-             message: 'Avoid defining `class` in attributes hash for static class names',
-             links: [],
-             id: 'ClassAttributeWithStaticValue',
-             path: 'test.haml',
-             location: { start_line: 4 },
-             object: nil,
-           }],
-  analyzer: {name: 'haml_lint', version: '0.34.0'})
+  type: 'failure',
+  message: /Failed to install gems/,
+  analyzer: nil)
 
 # This test case, `incompatible_haml`, will be failed if updating HAML-Lint version,
 # because HAML-Lint 4.1 beta support was dropped.


### PR DESCRIPTION
This fixes a but that the HAML-Lint runner always installs the latest RuboCop.

See the [CI failure log](https://circleci.com/gh/sider/runners/49264) for details.