### PR TITLE
[RuboCop] Bump Ruby from 2.5.6 to 2.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - [HAML-Lint] Bump rubocop-rspec from 1.36.0 to 1.37.0 [#531](https://github.com/sider/runners/pull/531)
 - [HAML-Lint] Bump rubocop-rails from 2.3.2 to 2.4.0 [#532](https://github.com/sider/runners/pull/532)
 - Configure instance_profile_credentials_* for Aws::S3::Client [#526](https://github.com/sider/runners/pull/526)
+- [RuboCop] Bump Ruby from 2.5.6 to 2.5.7 [#534](https://github.com/sider/runners/pull/534)
 
 ## 0.10.0
 

--- a/images/rubocop/Dockerfile
+++ b/images/rubocop/Dockerfile
@@ -6,7 +6,7 @@ FROM sider/devon_rex_ruby:2.10.0
 
 # NOTE: RuboCop 0.60.0 does not work on Ruby 2.6, so install and use Ruby 2.5 instead.
 #       See https://github.com/sider/runners/issues/57#issuecomment-530858769
-ENV GLOBAL_RUBY_VERSION 2.5.6
+ENV GLOBAL_RUBY_VERSION 2.5.7
 RUN rbenv install $GLOBAL_RUBY_VERSION && \
     rbenv global $GLOBAL_RUBY_VERSION && \
     rbenv versions && \

--- a/images/rubocop/Dockerfile.erb
+++ b/images/rubocop/Dockerfile.erb
@@ -2,7 +2,7 @@ FROM sider/devon_rex_ruby:2.10.0
 
 # NOTE: RuboCop 0.60.0 does not work on Ruby 2.6, so install and use Ruby 2.5 instead.
 #       See https://github.com/sider/runners/issues/57#issuecomment-530858769
-ENV GLOBAL_RUBY_VERSION 2.5.6
+ENV GLOBAL_RUBY_VERSION 2.5.7
 RUN rbenv install $GLOBAL_RUBY_VERSION && \
     rbenv global $GLOBAL_RUBY_VERSION && \
     rbenv versions && \


### PR DESCRIPTION
This release includes security fixes.
See the [announce](https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-5-7-released) for details.