### PR TITLE
[cpplint] Fix error when the output line number is `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - [HAML-Lint] Bump rubocop-rails from 2.3.2 to 2.4.0 [#532](https://github.com/sider/runners/pull/532)
 - Configure instance_profile_credentials_* for Aws::S3::Client [#526](https://github.com/sider/runners/pull/526)
 - [RuboCop] Bump Ruby from 2.5.6 to 2.5.7 [#534](https://github.com/sider/runners/pull/534)
+- [cpplint] Fix error when the output line number is `None` [#536](https://github.com/sider/runners/pull/536)
 
 ## 0.10.0
 

--- a/lib/runners/processor/cpplint.rb
+++ b/lib/runners/processor/cpplint.rb
@@ -87,7 +87,7 @@ module Runners
     # @see https://github.com/cpplint/cpplint/blob/1.4.4/cpplint.py#L1151
     # @see https://github.com/cpplint/cpplint/blob/1.4.4/cpplint.py#L1441-L1448
     def parse_result(xml_doc)
-      message_pattern = /(\d+): (.+) \[(.+)\] \[(.+)\]/
+      message_pattern = /([^:]+): (.+) \[(.+)\] \[(.+)\]/
 
       xml_doc.each_element("testcase") do |testcase|
         path = relative_path(testcase[:name])
@@ -96,10 +96,11 @@ module Runners
             matched = issue_line.match(message_pattern)
             if matched
               line, message, category, confidence = matched.captures
+              no_line_number = (line == "0" || !line.match?(/\A\d+\z/))
               yield Issue.new(
                 id: category,
                 path: path,
-                location: line == "0" ? nil : Location.new(start_line: line),
+                location: no_line_number ? nil : Location.new(start_line: line),
                 message: message.strip,
                 object: {
                   confidence: confidence,

--- a/test/smokes/cpplint/expectations.rb
+++ b/test/smokes/cpplint/expectations.rb
@@ -174,3 +174,32 @@ Smoke.add_test("option_target_multi", {
   ],
   analyzer: { name: "cpplint", version: "1.4.4" },
 })
+
+Smoke.add_test("no_line_number", {
+  guid: "test-guid",
+  timestamp: :_,
+  type: "success",
+  issues: [
+    {
+      id: "build/header_guard",
+      path: "foo.h",
+      location: nil,
+      message: /No #ifndef header guard found, suggested CPP variable is:/,
+      links: [],
+      object: {
+        confidence: "5",
+      },
+    },
+    {
+      id: "build/include",
+      path: "foo.cc",
+      location: nil,
+      message: /(.+)foo\.cc should include its header file (.+)foo\.h/,
+      links: [],
+      object: {
+        confidence: "5",
+      },
+    },
+  ],
+  analyzer: { name: "cpplint", version: "1.4.4" },
+})

--- a/test/smokes/cpplint/no_line_number/foo.cc
+++ b/test/smokes/cpplint/no_line_number/foo.cc
@@ -1,0 +1,1 @@
+// Copyright (C) 2017 Foo

--- a/test/smokes/cpplint/no_line_number/foo.h
+++ b/test/smokes/cpplint/no_line_number/foo.h
@@ -1,0 +1,1 @@
+// Copyright (C) 2017 Foo


### PR DESCRIPTION
cpplint can output `None` at the line number position, for example:

```
None: foo.cc should include its header file foo.h [build/include] [5]
```

In that case, this runner raises the error below:

```
RuntimeError: Unexpected message format: "None: foo.cc should include its header file foo.h [build/include] [5]"
```