### PR TITLE
Add a feature to mask secure strings on TraceWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.11.0...HEAD)
 
+- Add a feature to mask secure strings on TraceWriter [#537](https://github.com/sider/runners/pull/537)
+
 ## 0.11.0
 
 [Full diff](https://github.com/sider/runners/compare/0.10.0...0.11.0)

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -29,5 +29,13 @@ rules:
     pass: |
       class FooError < UserError; end
 
+  - id: sider.runners.trace_writer.masked_string
+    glob: lib/runners/trace_writer.rb
+    message: |
+      Use `#masked_string` if the passed string has possibly sensitive values
+    justification:
+      - When the passed value is not sensitive
+      - When your change is irrelevant to `:writer`
+
 import:
   - https://raw.githubusercontent.com/sider/goodcheck-rules/master/rules/typo.yml

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -19,10 +19,11 @@ end
 
 class Runners::TraceWriter
   attr_reader writer: _Writer
-  def initialize: (writer: _Writer) -> any
+  attr_reader sensitive_strings: Array<String>
+  def initialize: (writer: _Writer, ?sensitive_strings: Array<String>) -> any
 
   def command_line: (Array<String>, ?recorded_at: Time) -> void
-  def status: (any, ?recorded_at: Time) -> void
+  def status: (Process::Status, ?recorded_at: Time) -> void
   def stdout: (String, ?recorded_at: Time, ?max_length: Integer) -> void
   def stderr: (String, ?recorded_at: Time, ?max_length: Integer) -> void
   def message: (String, ?recorded_at: Time, ?max_length: Integer) -> void
@@ -33,6 +34,7 @@ class Runners::TraceWriter
   def error: (String, ?recorded_at: Time, ?max_length: Integer) -> void
   def <<: (any) -> void
   def each_slice: (String, size: Integer) { (String) -> void } -> void
+  def masked_string: (String) -> String
 end
 
 class Runners::Analyzer


### PR DESCRIPTION
We are planning to fetch source code via Git. To get source code
from a private repository, we must set a token and perform command like
this:

```shell-session
$ git config http.extraheader "Authorization: Basic token"
```

I'm going to run the command with `Shell#capture3!`. However, this
command writes its passed command line via `TraceWriter`. So, we have to
mask the secure string and prevent it from being output in traces.

Secure strings also should be masked on stdout or stderr, so I
implemented the feature on `TraceWriter` instead of `Shell`.