### PR TITLE
[Refactor] Rename Changes#changed_files to Changes#changed_paths

### DIFF
--- a/lib/runners/changes.rb
+++ b/lib/runners/changes.rb
@@ -1,42 +1,13 @@
 module Runners
   class Changes
-    class ChangedFile
-      # @dynamic path
-      attr_reader :path
-
-      def initialize(path:)
-        @path = path
-      end
-
-      def ==(other)
-        other.is_a?(ChangedFile) && other.path == path
-      end
-
-      def eql?(other)
-        self == other
-      end
-
-      def hash
-        path.hash
-      end
-    end
-
-    # @dynamic changed_files, unchanged_paths, untracked_paths
-    attr_reader :changed_files
+    attr_reader :changed_paths
     attr_reader :unchanged_paths
     attr_reader :untracked_paths
 
-    def initialize(changed_files:, unchanged_paths:, untracked_paths:)
-      @changed_files = changed_files
+    def initialize(changed_paths:, unchanged_paths:, untracked_paths:)
+      @changed_paths = changed_paths
       @unchanged_paths = unchanged_paths
       @untracked_paths = untracked_paths
-    end
-
-    def ==(other)
-      other.is_a?(Changes) &&
-        other.changed_files == changed_files &&
-        other.unchanged_paths == unchanged_paths &&
-        other.untracked_paths == untracked_paths
     end
 
     def delete_unchanged(dir:, except: [], only: [])
@@ -59,11 +30,8 @@ module Runners
     end
 
     def self.calculate(base_dir:, head_dir:, working_dir:)
-      # @type var changed_paths: Array<Pathname>
       changed_paths = []
-      # @type var unchanged_paths: Array<Pathname>
       unchanged_paths = []
-      # @type var untracked_paths: Array<Pathname>
       untracked_paths = []
 
       Pathname.glob(working_dir + "**/*", File::FNM_DOTMATCH).each do |working_path|
@@ -97,7 +65,7 @@ module Runners
         end
       end
 
-      new(changed_files: changed_paths.sort!.map {|path| ChangedFile.new(path: path) },
+      new(changed_paths: changed_paths.sort,
           unchanged_paths: unchanged_paths.sort!,
           untracked_paths: untracked_paths.sort!)
     end

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -49,7 +49,7 @@ module Runners
               case result
               when Results::Success
                 trace_writer.message "Removing issues from unchanged or untracked files..." do
-                  changed_paths = Set.new(changes.changed_files.map(&:path))
+                  changed_paths = Set.new(changes.changed_paths)
                   result.filter_issue { |issue| changed_paths.member?(issue.path) }
                 end
               else

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -57,8 +57,8 @@ module Runners
       delete_unchanged_files(changes, only: target_files(config), except: config[:custom_rule_path] || [])
 
       trace_writer.message "Changed files:" do
-        changes.changed_files.each do |file|
-          trace_writer.message "  * #{file.path}"
+        changes.changed_paths.each do |path|
+          trace_writer.message "  * #{path}"
         end
       end
 
@@ -144,7 +144,7 @@ module Runners
       trace_writer.message output_xml
       xml_doc = REXML::Document.new(output_xml)
 
-      change_paths = changes.changed_files.map(&:path)
+      change_paths = changes.changed_paths
       errors = []
       xml_doc.root.each_element('error') do |error|
         errors << error[:msg] if change_paths.include?(relative_path(error[:filename]))

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -85,20 +85,15 @@ class Runners::Results::Error < Runners::Results::Base
 end
 
 class Runners::Changes
-  attr_reader changed_files: Array<ChangedFile>
+  attr_reader changed_paths: Array<Pathname>
   attr_reader unchanged_paths: Array<Pathname>
   attr_reader untracked_paths: Array<Pathname>
 
-  def initialize: (changed_files: Array<ChangedFile>,
+  def initialize: (changed_paths: Array<Pathname>,
                    unchanged_paths: Array<Pathname>,
                    untracked_paths: Array<Pathname>) -> any
   def delete_unchanged: (dir: Pathname, ?except: Array<String>, ?only: Array<String>) { (Pathname) -> void }-> void
   def self.calculate: (base_dir: Pathname, head_dir: Pathname, working_dir: Pathname) -> instance
-end
-
-class Runners::Changes::ChangedFile
-  attr_reader path: Pathname
-  def initialize: (path: Pathname) -> any
 end
 
 class Runners::Processor

--- a/test/changes_test.rb
+++ b/test/changes_test.rb
@@ -5,7 +5,7 @@ class ChangesTest < Minitest::Test
 
   Changes = Runners::Changes
 
-  def test_changed_files
+  def test_changed_paths
     mktmpdir do |base_path|
       mktmpdir do |head_path|
         mktmpdir do |working_path|
@@ -30,7 +30,7 @@ class ChangesTest < Minitest::Test
 
           changes = Changes.calculate(base_dir: base_path, head_dir: head_path, working_dir: working_path)
 
-          assert_equal [Pathname("changed1.rb"), Pathname("changed2.rb")], changes.changed_files.map(&:path)
+          assert_equal [Pathname("changed1.rb"), Pathname("changed2.rb")], changes.changed_paths
           assert_equal [Pathname("unchanged.rb")], changes.unchanged_paths
           assert_equal [Pathname("built1.rb"), Pathname("built2.rb")], changes.untracked_paths
         end
@@ -38,8 +38,8 @@ class ChangesTest < Minitest::Test
     end
   end
 
-  def test_changed_files_with_empty_base
-    # This is simulation for diff disabled mode, put everything to changed_files
+  def test_changed_paths_with_empty_base
+    # This is simulation for diff disabled mode, put everything to changed_paths
     mktmpdir do |base_path|
       mktmpdir do |head_path|
         mktmpdir do |working_path|
@@ -61,7 +61,7 @@ class ChangesTest < Minitest::Test
 
           changes = Changes.calculate(base_dir: base_path, head_dir: head_path, working_dir: working_path)
 
-          assert_equal [Pathname("changed1.rb"), Pathname("changed2.rb"), Pathname("unchanged.rb")], changes.changed_files.map(&:path)
+          assert_equal [Pathname("changed1.rb"), Pathname("changed2.rb"), Pathname("unchanged.rb")], changes.changed_paths
           assert_equal [], changes.unchanged_paths
           assert_equal [Pathname("built1.rb"), Pathname("built2.rb")], changes.untracked_paths
         end
@@ -75,7 +75,7 @@ class ChangesTest < Minitest::Test
       dir.join("file2").write("foo")
       dir.join("file3").write("foo")
 
-      changes = Changes.new(changed_files: [], unchanged_paths: [Pathname("file1"), Pathname("file2"), Pathname("file3")], untracked_paths: [])
+      changes = Changes.new(changed_paths: [], unchanged_paths: [Pathname("file1"), Pathname("file2"), Pathname("file3")], untracked_paths: [])
 
       changes.delete_unchanged(dir: dir)
 
@@ -91,7 +91,7 @@ class ChangesTest < Minitest::Test
       dir.join("file2").write("foo")
       dir.join("file3").write("foo")
 
-      changes = Changes.new(changed_files: [], unchanged_paths: [Pathname("file1"), Pathname("file2"), Pathname("file3")], untracked_paths: [])
+      changes = Changes.new(changed_paths: [], unchanged_paths: [Pathname("file1"), Pathname("file2"), Pathname("file3")], untracked_paths: [])
 
       changes.delete_unchanged(dir: dir, only: ["file[2-3]"], except: ["file3"])
 

--- a/test/workspace_test.rb
+++ b/test/workspace_test.rb
@@ -42,7 +42,7 @@ class WorkspaceTest < Minitest::Test
         assert (workspace.working_dir + "querly.gemspec").file?
         refute (workspace.working_dir + "foo.tgz").file?
 
-        refute changes.changed_files.empty?
+        refute changes.changed_paths.empty?
         refute changes.unchanged_paths.empty?
         assert changes.untracked_paths.empty?
       end
@@ -56,7 +56,7 @@ class WorkspaceTest < Minitest::Test
         assert (workspace.working_dir / "README.md").file?
         refute (workspace.working_dir / ".git").exist?
 
-        refute changes.changed_files.empty?
+        refute changes.changed_paths.empty?
         refute changes.unchanged_paths.empty?
         assert changes.untracked_paths.empty?
 
@@ -72,7 +72,7 @@ class WorkspaceTest < Minitest::Test
         assert (workspace.working_dir + "querly.gemspec").file?
         refute (workspace.working_dir + "foo.tgz").file?
 
-        refute changes.changed_files.empty?
+        refute changes.changed_paths.empty?
         assert changes.unchanged_paths.empty?
         assert changes.untracked_paths.empty?
       end


### PR DESCRIPTION
`ChangedFile` is used as `Pathname` everywhere, so I removed it and renamed `#changed_files` to `#changed_paths`.