### PR TITLE
[HAML-Lint] Add warnings if RuboCop fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Filter issues with the "diff lines" [#584](https://github.com/sider/runners/pull/584)
 - [PHPMD] Reduce trace size [#588](https://github.com/sider/runners/pull/588)
 - [PHPMD] Handle invalid output XML [#589](https://github.com/sider/runners/pull/589)
+- [HAML-Lint] Add warnings if RuboCop fails [#587](https://github.com/sider/runners/pull/587)
 
 ## 0.12.0
 

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -218,11 +218,8 @@ module Runners
     #
     # @see https://github.com/sds/haml-lint/issues/317
     def add_rubocop_warnings_if_exists(stderr)
-      stderr.each_line(chomp: true) do |line|
-        line.match(/\b(cannot load such file -- [\w-]+)\b/) do |match|
-          error_message, = match.captures
-          add_warning error_message
-        end
+      stderr.scan(/\bcannot load such file -- [\w-]+\b/) do |message|
+        add_warning message
       end
     end
   end

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -195,6 +195,8 @@ module Runners
         'json',
         *options,
       )
+
+      # @see https://github.com/sds/haml-lint/blob/v0.34.1/lib/haml_lint/cli.rb#L110
       unless [65, 0].include?(status.exitstatus)
         return Results::Failure.new(guid: guid, message: <<~MESSAGE, analyzer: analyzer)
           stdout:
@@ -205,8 +207,22 @@ module Runners
         MESSAGE
       end
 
+      add_rubocop_warnings_if_exists(stderr)
+
       Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
         parse_result(stdout).each { |v| result.add_issue(v) }
+      end
+    end
+
+    # NOTE: HAML-Lint exits successfully even if RuboCop fails.
+    #
+    # @see https://github.com/sds/haml-lint/issues/317
+    def add_rubocop_warnings_if_exists(stderr)
+      stderr.each_line(chomp: true) do |line|
+        line.match(/\b(cannot load such file -- [\w-]+)\b/) do |match|
+          error_message, = match.captures
+          add_warning error_message
+        end
       end
     end
   end

--- a/test/smokes/haml_lint/expectations.rb
+++ b/test/smokes/haml_lint/expectations.rb
@@ -66,8 +66,6 @@ Smoke.add_test(
   }],
   analyzer: {name: 'haml_lint', version: '0.34.0'})
 
-# rubocop-rspec will not be installed because `Gemfile.lock` does not exists.
-# However, haml-lint does not stop to perform the analysis, and reports other offenses.
 Smoke.add_test(
   'rubocop-rspec',
   guid: 'test-guid',
@@ -173,4 +171,21 @@ Smoke.add_test('pinned_haml_version', {
     object: { severity: "warning" },
   }],
   analyzer: { name: 'haml_lint', version: '0.32.0' }
+})
+
+Smoke.add_test('missing_rubocop_required_gems', {
+  guid: 'test-guid',
+  timestamp: :_,
+  type: 'success',
+  issues: [{
+    message: 'Avoid defining `class` in attributes hash for static class names',
+    links: ["https://github.com/sds/haml-lint/blob/v0.34.1/lib/haml_lint/linter#classattributewithstaticvalue"],
+    id: 'ClassAttributeWithStaticValue',
+    path: 'test.haml',
+    location: { start_line: 1 },
+    object: { severity: "warning" },
+  }],
+  analyzer: { name: 'haml_lint', version: '0.34.1' },
+}, {
+  warnings: [{ message: 'cannot load such file -- rubocop-performance', file: nil }],
 })

--- a/test/smokes/haml_lint/missing_rubocop_required_gems/.rubocop.yml
+++ b/test/smokes/haml_lint/missing_rubocop_required_gems/.rubocop.yml
@@ -1,2 +1,3 @@
 require:
+  - rubocop-performance
   - rubocop-rspec

--- a/test/smokes/haml_lint/missing_rubocop_required_gems/test.haml
+++ b/test/smokes/haml_lint/missing_rubocop_required_gems/test.haml
@@ -1,0 +1,1 @@
+%p{ class: 'my-class' } Hello, world

--- a/test/smokes/haml_lint/rubocop-rspec/Gemfile
+++ b/test/smokes/haml_lint/rubocop-rspec/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'rubocop-rspec'


### PR DESCRIPTION
## Why?

HAML-Lint exists successfully even if RuboCop fails, so users may notice such errors. By adding warnings, this aims to make users noticing the errors.

See https://github.com/sds/haml-lint/issues/317