### PR TITLE
[PHPMD] Reduce trace size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Bump haml_lint from 0.34.0 to 0.34.1 [#576](https://github.com/sider/runners/pull/576)
 - [PHPMD] Output report to file instead of STDOUT [#577](https://github.com/sider/runners/pull/577)
 - Filter issues with the "diff lines" [#584](https://github.com/sider/runners/pull/584)
+- [PHPMD] Reduce trace size [#588](https://github.com/sider/runners/pull/588)
 
 ## 0.12.0
 

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -40,7 +40,7 @@ module Runners
     def analyze(changes)
       ensure_runner_config_schema(Schema.runner_config) do |config|
         check_runner_config(config) do |targets, rule, options|
-          prepare_analysis_files(changes, config)
+          delete_unchanged_files(changes, only: target_files(config), except: config[:custom_rule_path] || [])
           run_analyzer(changes, targets, rule, options)
         end
       end
@@ -51,26 +51,6 @@ module Runners
     def target_files(config)
       _, suffixes = suffixes(config)
       suffixes&.split(",")&.map { |suffix| "*.#{suffix}" } || ["*.php"]
-    end
-
-    def prepare_analysis_files(changes, config)
-      delete_unchanged_files(changes, only: target_files(config), except: config[:custom_rule_path] || [])
-
-      trace_writer.message "Changed files:" do
-        changes.changed_paths.each do |path|
-          trace_writer.message "  * #{path}"
-        end
-      end
-
-      trace_writer.message "Untracked files:" do
-        changes.untracked_paths.each do |path|
-          trace_writer.message "  * #{path}"
-        end
-      end
-
-      trace_writer.message "Existing files:" do
-        capture3('find', '.', '-type', 'f')
-      end
     end
 
     def check_runner_config(config)


### PR DESCRIPTION
Why?
----

- The `delete_unchanged_files` method is used by other runners. It is reliable enough.
- The number of the method result file paths can be quite large.
  But the trace size which users can see in their browser is limited.
- Perhaps the trace information may not be so useful for users.