### PR TITLE
Add missing `tmpdir` to fix NoMethodError

### DIFF
--- a/lib/tasks/docker/timeout_test.rb
+++ b/lib/tasks/docker/timeout_test.rb
@@ -1,4 +1,5 @@
 require "open3"
+require "tmpdir"
 
 namespace :docker do
   desc 'Run timeout_test to ensure timeout(1) stops Runners'


### PR DESCRIPTION
> NoMethodError: undefined method `mktmpdir' for Dir:Class

--- https://circleci.com/gh/sider/runners/56990

See https://stackoverflow.com/a/58036781