### PR TITLE
Truncate long message on trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.13.1...HEAD)
 
+- Truncate long message on trace [#605](https://github.com/sider/runners/pull/605)
+
 ## 0.13.1
 
 [Full diff](https://github.com/sider/runners/compare/0.13.0...0.13.1)

--- a/lib/runners/processor/code_sniffer.rb
+++ b/lib/runners/processor/code_sniffer.rb
@@ -165,7 +165,7 @@ module Runners
       end
 
       output = output_file.read
-      trace_writer.message output
+      trace_writer.message output, limit: 24_000 # Avoid timeout
 
       Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
         issues = []

--- a/lib/runners/trace_writer.rb
+++ b/lib/runners/trace_writer.rb
@@ -31,9 +31,12 @@ module Runners
       end
     end
 
-    # @type method message: (String, ?recorded_at: Time, ?max_length: Integer) ?{ -> any } -> any
-    def message(message, recorded_at: Time.now, max_length: 4_000)
-      each_slice(masked_string(message), size: max_length) do |text|
+    def message(message, recorded_at: Time.now, max_length: 4_000, limit: 40_000, omission: "...(truncated)")
+      string = masked_string(message)
+      if string.size > limit
+        string = string[0, limit] + omission
+      end
+      each_slice(string, size: max_length) do |text|
         self << { trace: 'message', message: text, recorded_at: recorded_at.utc.iso8601 }
       end
       if block_given?

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -26,8 +26,7 @@ class Runners::TraceWriter
   def status: (Process::Status, ?recorded_at: Time) -> void
   def stdout: (String, ?recorded_at: Time, ?max_length: Integer) -> void
   def stderr: (String, ?recorded_at: Time, ?max_length: Integer) -> void
-  def message: (String, ?recorded_at: Time, ?max_length: Integer) -> void
-             | <'x> (String, ?recorded_at: Time, ?max_length: Integer) { -> 'x } -> 'x
+  def message: (String, ?recorded_at: Time, ?max_length: Integer, ?limit: Integer, ?omission: String) ?{ -> any } -> any
   def header: (String, ?recorded_at: Time) -> void
   def warning: (String, ?file: any, ?recorded_at: Time) -> void
   def ci_config: (Hash<any, any>, ?recorded_at: Time) -> void

--- a/test/trace_writer_test.rb
+++ b/test/trace_writer_test.rb
@@ -49,6 +49,18 @@ class TraceWriterTest < Minitest::Test
     assert writer.writer.all? {|trace| trace[:trace] == 'message' && (trace[:message] == 'a'*4000 || trace[:message] == 'a'*4000 + '\\')}
   end
 
+  def test_message_with_limit
+    writer.message("abcdef", limit: 3)
+    assert_equal 1, writer.writer.size
+    assert writer.writer.all? {|trace| trace[:trace] == 'message' && trace[:message] == "abc...(truncated)" }
+  end
+
+  def test_message_with_omission
+    writer.message("abcdef", limit: 3, omission: "...")
+    assert_equal 1, writer.writer.size
+    assert writer.writer.all? {|trace| trace[:trace] == 'message' && trace[:message] == "abc..." }
+  end
+
   def test_warning
     writer.warning('hogehoge warn', recorded_at: now)
     writer.warning('hogehoge warn2', file: 'path/to/file.rb', recorded_at: now)


### PR DESCRIPTION
Timeout errors occur with PHP_CodeSniffer analysis in a project.
This bug was introduced by the PR #592.

https://github.com/sider/runners/pull/592/files#diff-d85c8bb1b65d7c22f99cdb38ad7f6df6L143-L153