### PR TITLE
Use `bundle config without` instead of `--without` CLI option

### DIFF
--- a/images/Dockerfile.base.erb
+++ b/images/Dockerfile.base.erb
@@ -5,5 +5,6 @@ COPY --chown=<%= ENV.fetch("RUNNER_CHOWN") %> Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install

--- a/images/brakeman/Dockerfile
+++ b/images/brakeman/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/brakeman/Gemfile ${RUNNER_USER_HOME}/brakeman_Gemfile

--- a/images/checkstyle/Dockerfile
+++ b/images/checkstyle/Dockerfile
@@ -27,8 +27,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin
 COPY --chown=analyzer_runner:nogroup lib ${RUNNERS_DIR}/lib

--- a/images/code_sniffer/Dockerfile
+++ b/images/code_sniffer/Dockerfile
@@ -22,8 +22,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin
 COPY --chown=analyzer_runner:nogroup lib ${RUNNERS_DIR}/lib

--- a/images/coffeelint/Dockerfile
+++ b/images/coffeelint/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/coffeelint/package.json ${RUNNER_USER_HOME}/coffeelint_package.json

--- a/images/cppcheck/Dockerfile
+++ b/images/cppcheck/Dockerfile
@@ -32,8 +32,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin
 COPY --chown=analyzer_runner:nogroup lib ${RUNNERS_DIR}/lib

--- a/images/cpplint/Dockerfile
+++ b/images/cpplint/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/cpplint/Pipfile ${RUNNER_USER_HOME}/cpplint_Pipfile

--- a/images/eslint/Dockerfile
+++ b/images/eslint/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/eslint/package.json ${RUNNER_USER_HOME}/eslint_package.json

--- a/images/flake8/Dockerfile
+++ b/images/flake8/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/flake8/Pipfile ${RUNNER_USER_HOME}/flake8_Pipfile

--- a/images/go_vet/Dockerfile
+++ b/images/go_vet/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 ARG LINT_TOOL_VERSION="3.0.0"
 

--- a/images/golint/Dockerfile
+++ b/images/golint/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 ARG LINT_TOOL_VERSION="3.0.0"
 

--- a/images/gometalinter/Dockerfile
+++ b/images/gometalinter/Dockerfile
@@ -23,8 +23,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 COPY --chown=analyzer_runner:nogroup images/gometalinter/gometalinter.json ${RUNNER_USER_HOME}/
 

--- a/images/goodcheck/Dockerfile
+++ b/images/goodcheck/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/goodcheck/Gemfile ${RUNNER_USER_HOME}/goodcheck_Gemfile

--- a/images/haml_lint/Dockerfile
+++ b/images/haml_lint/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/haml_lint/Gemfile ${RUNNER_USER_HOME}/haml_lint_Gemfile

--- a/images/javasee/Dockerfile
+++ b/images/javasee/Dockerfile
@@ -23,8 +23,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin
 COPY --chown=analyzer_runner:nogroup lib ${RUNNERS_DIR}/lib

--- a/images/jshint/Dockerfile
+++ b/images/jshint/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/jshint/package.json ${RUNNER_USER_HOME}/jshint_package.json

--- a/images/ktlint/Dockerfile
+++ b/images/ktlint/Dockerfile
@@ -27,8 +27,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin
 COPY --chown=analyzer_runner:nogroup lib ${RUNNERS_DIR}/lib

--- a/images/misspell/Dockerfile
+++ b/images/misspell/Dockerfile
@@ -19,8 +19,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin
 COPY --chown=analyzer_runner:nogroup lib ${RUNNERS_DIR}/lib

--- a/images/phinder/Dockerfile
+++ b/images/phinder/Dockerfile
@@ -15,8 +15,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin
 COPY --chown=analyzer_runner:nogroup lib ${RUNNERS_DIR}/lib

--- a/images/phpmd/Dockerfile
+++ b/images/phpmd/Dockerfile
@@ -15,8 +15,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 COPY --chown=analyzer_runner:nogroup images/phpmd/sider_config.xml ${RUNNER_USER_HOME}/
 

--- a/images/pmd_java/Dockerfile
+++ b/images/pmd_java/Dockerfile
@@ -24,8 +24,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 COPY images/pmd_java/pmd /usr/local/bin/
 

--- a/images/querly/Dockerfile
+++ b/images/querly/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/querly/Gemfile ${RUNNER_USER_HOME}/querly_Gemfile

--- a/images/rails_best_practices/Dockerfile
+++ b/images/rails_best_practices/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/rails_best_practices/Gemfile ${RUNNER_USER_HOME}/rails_best_practices_Gemfile

--- a/images/reek/Dockerfile
+++ b/images/reek/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/reek/Gemfile ${RUNNER_USER_HOME}/reek_Gemfile

--- a/images/rubocop/Dockerfile
+++ b/images/rubocop/Dockerfile
@@ -22,8 +22,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/rubocop/Gemfile ${RUNNER_USER_HOME}/rubocop_Gemfile

--- a/images/scss_lint/Dockerfile
+++ b/images/scss_lint/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/scss_lint/Gemfile ${RUNNER_USER_HOME}/scss_lint_Gemfile

--- a/images/shellcheck/Dockerfile
+++ b/images/shellcheck/Dockerfile
@@ -33,8 +33,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin
 COPY --chown=analyzer_runner:nogroup lib ${RUNNERS_DIR}/lib

--- a/images/stylelint/Dockerfile
+++ b/images/stylelint/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/stylelint/package.json ${RUNNER_USER_HOME}/stylelint_package.json

--- a/images/swiftlint/Dockerfile
+++ b/images/swiftlint/Dockerfile
@@ -23,8 +23,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin
 COPY --chown=analyzer_runner:nogroup lib ${RUNNERS_DIR}/lib

--- a/images/tslint/Dockerfile
+++ b/images/tslint/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/tslint/package.json ${RUNNER_USER_HOME}/tslint_package.json

--- a/images/tyscan/Dockerfile
+++ b/images/tyscan/Dockerfile
@@ -11,8 +11,9 @@ COPY --chown=analyzer_runner:nogroup Gemfile* ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
     bundle config --global jobs 4 && \
     bundle config --global retry 3 && \
+    bundle config --local without development:test && \
     bundle config && \
-    bundle install --without='development test'
+    bundle install
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/tyscan/package.json ${RUNNER_USER_HOME}/tyscan_package.json


### PR DESCRIPTION
The CLI option is deprecated. See below:

https://github.com/bundler/bundler/blob/v2.1.1/UPGRADING.md#cli-deprecations

Here is the `docker build` log:

```
Step 4/16 : RUN cd ${RUNNERS_DIR} &&     bundle config --global jobs 4 &&     bundle config --global retry 3 &&     bundle config --local without development:test &&     bundle config &&     bundle install
 ---> Running in 466cf01a4480
You are replacing the current local value of without, which is currently nil
Settings are listed in order of priority. The top value will be used.
jobs
Set for the current user (/home/analyzer_runner/.bundle/config): 4

retry
Set for the current user (/home/analyzer_runner/.bundle/config): 3

without
Set for your local app (/home/analyzer_runner/runners/.bundle/config): [:development, :test]
```