### PR TITLE
Set default `TAG`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -101,14 +101,7 @@ namespace :docker do
   end
 
   def tag
-    key = 'TAG'
-    ENV[key].tap do |value|
-      abort <<~MSG if value.nil? || value.empty?
-        Error: `#{key}` environment variable must be required. For example, run as follow:
-
-            $ #{key}=dev bundle exec rake docker:build
-      MSG
-    end
+    ENV.fetch('TAG', 'dev')
   end
 
   def docker_user

--- a/lib/tasks/docker/timeout_test.rb
+++ b/lib/tasks/docker/timeout_test.rb
@@ -6,7 +6,6 @@ namespace :docker do
   task :timeout_test do
     # NOTE: Either analyzer is fine, I chose it because of its lightness.
     ENV['ANALYZER'] = 'code_sniffer'
-    ENV['TAG'] = 'dev'
     ENV['RUNNERS_TIMEOUT'] = '5s'
 
     # Build docker images with dummy code


### PR DESCRIPTION
Why?

- Reduce a project-setup work.
- Even if the `dev` tag is pushed to Docker Hub, it does not affect our service (just removing it).