### PR TITLE
Fix Bundler warning

### DIFF
--- a/lib/runners/ruby/gem_installer.rb
+++ b/lib/runners/ruby/gem_installer.rb
@@ -29,7 +29,7 @@ module Runners
 
         trace_writer.header "Installing gems..."
 
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           shell.push_dir gem_home do
             shell.capture3!("bundle", "install")
             shell.capture3!("bundle", "list")

--- a/lib/runners/ruby/lockfile_loader.rb
+++ b/lib/runners/ruby/lockfile_loader.rb
@@ -45,7 +45,7 @@ module Runners
       def generate_lockfile(lockfile_path)
         shell.trace_writer.message "By using detected Gemfile, generating Gemfile.lock..."
 
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           shell.push_env_hash({ "BUNDLE_GEMFILE" => gemfile_path.to_s }) do
             shell.capture3! "bundle", "lock", "--lockfile", lockfile_path.to_s
             return lockfile_path.read.tap do |content|

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -207,7 +207,7 @@ gem 'jack_and_the_elastic_beanstalk', git: 'https://github.com/sider/jack_and_th
 EOF
 
       shell.push_dir(path) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           shell.capture3!("bundle", "lock")
         end
       end
@@ -425,7 +425,7 @@ gem 'meowcop'
 EOF
 
       shell.push_dir(path) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           shell.capture3!("bundle", "lock")
         end
       end
@@ -509,7 +509,7 @@ gem 'meowcop'
 EOF
 
       shell.push_dir(path) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           shell.capture3!("bundle", "lock")
         end
       end
@@ -555,7 +555,7 @@ gem 'activerecord'
 EOF
 
       shell.push_dir(path) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           shell.capture3!("bundle", "lock")
         end
       end
@@ -592,7 +592,7 @@ gem 'rubocop', '0.62.0'
 EOF
 
       shell.push_dir(path) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           shell.capture3!("bundle", "lock")
         end
       end


### PR DESCRIPTION
> [DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env`

See also:
- https://github.com/bundler/bundler/blob/v2.1.2/lib/bundler.rb#L376
- https://github.com/bundler/bundler/blob/v2.1.2/lib/bundler.rb#L381