### PR TITLE
[Brakeman] Quiet output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.16.0...HEAD)
 
+- [Brakeman] Quiet output [#647](https://github.com/sider/runners/pull/647)
+
 ## 0.16.0
 
 [Full diff](https://github.com/sider/runners/compare/0.15.0...0.16.0)

--- a/lib/runners/processor/brakeman.rb
+++ b/lib/runners/processor/brakeman.rb
@@ -32,7 +32,14 @@ module Runners
 
     def analyze(changes)
       # run analysis and return result
-      stdout, stderr, status = capture3(*ruby_analyzer_bin, '--format=json', '--no-exit-on-warn', '--no-exit-on-error')
+      stdout, stderr, status = capture3(
+        *ruby_analyzer_bin,
+        '--format=json',
+        '--no-exit-on-warn',
+        '--no-exit-on-error',
+        '--no-progress',
+        '--quiet',
+      )
       return Results::Failure.new(guid: guid, message: stderr, analyzer: analyzer) unless status.success?
       construct_result(stdout)
     end


### PR DESCRIPTION
This adds `--no-progress` and `--quiet` options to suppress verbose output to logs.