### PR TITLE
Include :git_blame_info in `Issue` instances

### DIFF
--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -6,7 +6,6 @@ module Runners
 
     delegate :push_dir, :current_dir, :capture3, :capture3!, :capture3_trace, :capture3_with_retry!, to: :shell
     delegate :env_hash, :push_env_hash, to: :shell
-    delegate :git_blame_info, to: :workspace
 
     def initialize(guid:, workspace:, git_ssh_path:, trace_writer:)
       @guid = guid
@@ -238,6 +237,10 @@ module Runners
 
     def show_runtime_versions
       # noop by default
+    end
+
+    def git_blame_info(path_string, start_line)
+      workspace.range_git_blame_info(path_string, start_line, start_line).last
     end
   end
 end

--- a/lib/runners/processor/brakeman.rb
+++ b/lib/runners/processor/brakeman.rb
@@ -61,7 +61,8 @@ module Runners
             location: loc,
             id: "#{warning[:warning_type]}-#{warning[:warning_code]}",
             message: warning[:message],
-            links: [warning[:link]]
+            links: [warning[:link]],
+            git_blame_info: git_blame_info(warning[:file], line),
           )
         end
 

--- a/lib/runners/processor/checkstyle.rb
+++ b/lib/runners/processor/checkstyle.rb
@@ -120,6 +120,7 @@ module Runners
               message: message,
               links: build_links(error[:source]),
               object: { severity: severity },
+              git_blame_info: git_blame_info(file[:name], line),
               schema: Schema.issue,
             )
           when "exception"

--- a/lib/runners/processor/code_sniffer.rb
+++ b/lib/runners/processor/code_sniffer.rb
@@ -182,6 +182,7 @@ module Runners
                 severity: suggest[:severity],
                 fixable: suggest[:fixable],
               },
+              git_blame_info: git_blame_info(path, suggest[:line]),
               schema: Schema.issue,
             )
           end

--- a/lib/runners/processor/coffeelint.rb
+++ b/lib/runners/processor/coffeelint.rb
@@ -97,6 +97,7 @@ module Runners
               location: loc,
               id: issue[:rule] || issue[:name],
               message: message,
+              git_blame_info: git_blame_info(file, line),
             )
           end
         end

--- a/lib/runners/processor/cppcheck.rb
+++ b/lib/runners/processor/cppcheck.rb
@@ -132,6 +132,7 @@ module Runners
               cwe: err[:cwe],
               location_info: loc[:info] != err[:msg] ? loc[:info] : nil,
             },
+            git_blame_info: git_blame_info(loc[:file], loc[:line]),
             schema: Schema.rule,
           )
         end

--- a/lib/runners/processor/cpplint.rb
+++ b/lib/runners/processor/cpplint.rb
@@ -105,6 +105,7 @@ module Runners
                 object: {
                   confidence: confidence,
                 },
+                git_blame_info: git_blame_info(path.to_s, line),
                 schema: Schema.issue,
               )
             else

--- a/lib/runners/processor/eslint.rb
+++ b/lib/runners/processor/eslint.rb
@@ -192,6 +192,7 @@ module Runners
               category: details.dig(:docs, :category),
               recommended: details.dig(:docs, :recommended),
             },
+            git_blame_info: git_blame_info(issue[:filePath], details[:line]),
             schema: Schema.issue,
           )
         end

--- a/lib/runners/processor/flake8.rb
+++ b/lib/runners/processor/flake8.rb
@@ -118,6 +118,7 @@ module Runners
           location: loc,
           id: id,
           message: message,
+          git_blame_info: git_blame_info(path, loc.start_line),
         )
       end.compact
     end

--- a/lib/runners/processor/go_vet.rb
+++ b/lib/runners/processor/go_vet.rb
@@ -40,6 +40,7 @@ module Runners
             location: loc,
             id: Digest::SHA1.hexdigest(issue['message']),
             message: issue['message'],
+            git_blame_info: git_blame_info(issue['path'], issue['line']),
           )
         end
       end

--- a/lib/runners/processor/golint.rb
+++ b/lib/runners/processor/golint.rb
@@ -40,6 +40,7 @@ module Runners
             location: loc,
             id: Digest::SHA1.hexdigest(issue['message']),
             message: issue['message'],
+            git_blame_info: git_blame_info(issue['path'], issue['line']),
           )
         end
       end

--- a/lib/runners/processor/gometalinter.rb
+++ b/lib/runners/processor/gometalinter.rb
@@ -59,6 +59,7 @@ module Runners
               location: loc,
               id: Digest::SHA1.hexdigest(issue['message']),
               message: "[#{issue['linter']}] #{issue['message']}",
+              git_blame_info: git_blame_info(issue['path'], issue['line']),
             )
           end
         end

--- a/lib/runners/processor/goodcheck.rb
+++ b/lib/runners/processor/goodcheck.rb
@@ -92,8 +92,10 @@ module Runners
               end_line: hash[:location][:end_line],
               end_column: hash[:location][:end_column],
             )
+            blame_info = git_blame_info(hash[:path], location.start_line)
           else
             location = nil
+            blame_info = nil
           end
 
           object = {
@@ -108,6 +110,7 @@ module Runners
             id: id,
             message: hash[:message],
             object: object,
+            git_blame_info: blame_info,
             schema: Schema.rule
           )
 

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -174,6 +174,7 @@ module Runners
             object: {
               severity: offense[:severity],
             },
+            git_blame_info: git_blame_info(path, line),
             schema: Schema.issue,
           )
         end

--- a/lib/runners/processor/javasee.rb
+++ b/lib/runners/processor/javasee.rb
@@ -78,16 +78,16 @@ module Runners
       json[:issues].each do |hash|
         path = relative_path(hash[:script])
         loc = Location.new(start_line: hash[:location][:start][0],
-                                        start_column: hash[:location][:start][1],
-                                        end_line: hash[:location][:end][0],
-                                        end_column: hash[:location][:end][1])
-
+                           start_column: hash[:location][:start][1],
+                           end_line: hash[:location][:end][0],
+                           end_column: hash[:location][:end][1])
         result.add_issue Issue.new(
           path: path,
           location: loc,
           id: hash[:rule][:id],
           message: hash[:rule][:message],
           object: hash[:rule],
+          git_blame_info: git_blame_info(path.to_s, loc.start_line),
           schema: Schema.rule
         )
       end

--- a/lib/runners/processor/jshint.rb
+++ b/lib/runners/processor/jshint.rb
@@ -71,6 +71,7 @@ module Runners
             location: Location.new(start_line: error[:line]),
             id: error[:source] || Digest::SHA1.hexdigest(message),
             message: message.strip,
+            git_blame_info: git_blame_info(file[:name], error[:line]),
           )
         end
       end

--- a/lib/runners/processor/ktlint.rb
+++ b/lib/runners/processor/ktlint.rb
@@ -229,6 +229,7 @@ module Runners
         location: Location.new(start_line: line),
         id: rule.empty? ? Digest::SHA1.hexdigest(message)[0, 8] : rule,
         message: message,
+        git_blame_info: git_blame_info(file, line),
       )
     end
 

--- a/lib/runners/processor/misspell.rb
+++ b/lib/runners/processor/misspell.rb
@@ -79,6 +79,7 @@ module Runners
             location: loc,
             id: message,
             message: message,
+            git_blame_info: git_blame_info(file, loc.start_line),
           )
         end
       end

--- a/lib/runners/processor/phinder.rb
+++ b/lib/runners/processor/phinder.rb
@@ -75,21 +75,23 @@ module Runners
 
         Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
           json[:result].each do |issue|
+            loc = Location.new(
+              start_line: issue[:location][:start][0],
+              start_column: issue[:location][:start][1],
+              end_line: issue[:location][:end][0],
+              end_column: issue[:location][:end][1],
+            )
             result.add_issue Issue.new(
               id: issue[:rule][:id],
               path: relative_path(issue[:path]),
-              location: Location.new(
-                start_line: issue[:location][:start][0],
-                start_column: issue[:location][:start][1],
-                end_line: issue[:location][:end][0],
-                end_column: issue[:location][:end][1],
-              ),
+              location: loc,
               message: issue[:rule][:message],
               object: {
                 id: issue[:rule][:id],
                 message: issue[:rule][:message],
                 justifications: Array(issue[:justifications]),
               },
+              git_blame_info: git_blame_info(issue[:path], loc.start_line),
               schema: Schema.issue_object,
             )
           end

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -156,7 +156,8 @@ module Runners
               location: loc,
               id: violation[:rule],
               message: violation.text.strip,
-              links: [violation[:externalInfoUrl]]
+              links: [violation[:externalInfoUrl]],
+              git_blame_info: git_blame_info(file[:name], loc.start_line),
             )
           end
         end

--- a/lib/runners/processor/pmd_java.rb
+++ b/lib/runners/processor/pmd_java.rb
@@ -80,15 +80,16 @@ module Runners
 
             message = violation.text.strip
             id = violation[:ruleset] + "-" + violation[:rule] + "-" + Digest::SHA1.hexdigest(message)
+            loc = Location.new(
+              start_line: violation[:beginline],
+              start_column: violation[:begincolumn],
+              end_line: violation[:endline],
+              end_column: violation[:endcolumn],
+            )
 
             result.add_issue Issue.new(
               path: path,
-              location: Location.new(
-                start_line: violation[:beginline],
-                start_column: violation[:begincolumn],
-                end_line: violation[:endline],
-                end_column: violation[:endcolumn],
-              ),
+              location: loc,
               id: id,
               message: message,
               links: links,
@@ -97,6 +98,7 @@ module Runners
                 ruleset: violation[:ruleset],
                 priority: violation[:priority],
               },
+              git_blame_info: git_blame_info(path.to_s, loc.start_line),
               schema: Schema.issue,
             )
           end

--- a/lib/runners/processor/querly.rb
+++ b/lib/runners/processor/querly.rb
@@ -73,9 +73,9 @@ module Runners
           Array(json[:issues]).each do |hash|
             path = relative_path(hash[:script])
             loc = Location.new(start_line: hash[:location][:start][0],
-                                            start_column: hash[:location][:start][1],
-                                            end_line: hash[:location][:end][0],
-                                            end_column: hash[:location][:end][1])
+                               start_column: hash[:location][:start][1],
+                               end_line: hash[:location][:end][0],
+                               end_column: hash[:location][:end][1])
             msgs = hash[:rule][:messages]
             result.add_issue Issue.new(
               path: path,
@@ -83,6 +83,7 @@ module Runners
               id: hash[:rule][:id],
               message: (msgs && msgs[0]) || "No message",
               object: hash[:rule],
+              git_blame_info: git_blame_info(path.to_s, loc.start_line),
               schema: Schema.rule
             )
           end

--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -150,6 +150,7 @@ module Runners
         # NOTE: rails_best_practices returns top-level YAML array with tags.
         #       We want to just parse a YAML, so we remove YAML tags before passing to `YAML.load`.
         YAML.load(stdout.gsub('- !ruby/object:RailsBestPractices::Core::Error', '-'), symbolize_names: true).each do |yaml|
+          path = relative_path(yaml.fetch(:filename))
           loc = Location.new(
             start_line: yaml.fetch(:line_number).to_i,
             start_column: 0,
@@ -157,11 +158,12 @@ module Runners
             end_column: 0
           )
           result.add_issue Issue.new(
-            path: relative_path(yaml.fetch(:filename)),
+            path: path,
             location: loc,
             id: yaml.fetch(:type),
             message: yaml.fetch(:message),
-            links: [yaml[:url]].compact
+            links: [yaml[:url]].compact,
+            git_blame_info: git_blame_info(path.to_s, loc.start_line),
           )
         end
       end

--- a/lib/runners/processor/reek.rb
+++ b/lib/runners/processor/reek.rb
@@ -47,12 +47,14 @@ module Runners
         # NOTE: reek returns top-level JSON array
         JSON.parse(stdout, symbolize_names: true).each do |hash|
           hash[:lines].each do |line|
+            path = relative_path(hash[:source])
             result.add_issue Issue.new(
-              path: relative_path(hash[:source]),
+              path: path,
               location: Location.new(start_line: line),
               id: hash[:smell_type],
               message: "`#{hash[:context]}` #{hash[:message]}",
-              links: v4? ? [hash[:wiki_link]] : [hash[:documentation_link]]
+              links: v4? ? [hash[:wiki_link]] : [hash[:documentation_link]],
+              git_blame_info: git_blame_info(path.to_s, line),
             )
           end
         end

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -222,6 +222,7 @@ module Runners
                 severity: offense[:severity],
                 corrected: offense[:corrected],
               },
+              git_blame_info: git_blame_info(hash[:path], loc.start_line),
               schema: Schema.issue,
             )
           end

--- a/lib/runners/processor/scss_lint.rb
+++ b/lib/runners/processor/scss_lint.rb
@@ -74,6 +74,7 @@ module Runners
             location: loc,
             id: id,
             message: message,
+            git_blame_info: git_blame_info(file, loc.start_line),
           )
         end
       end

--- a/lib/runners/processor/shellcheck.rb
+++ b/lib/runners/processor/shellcheck.rb
@@ -158,6 +158,7 @@ module Runners
             severity: comment[:level],
             fix: comment[:fix],
           },
+          git_blame_info: git_blame_info(comment[:file], comment[:line]),
           schema: Schema.issue,
         )
       end

--- a/lib/runners/processor/stylelint.rb
+++ b/lib/runners/processor/stylelint.rb
@@ -153,6 +153,7 @@ module Runners
             object: {
               severity: warning[:severity],
             },
+            git_blame_info: git_blame_info(path.to_s, line),
             schema: Schema.issue,
           )
         end

--- a/lib/runners/processor/swiftlint.rb
+++ b/lib/runners/processor/swiftlint.rb
@@ -103,6 +103,7 @@ module Runners
           location: loc,
           id: id,
           message: message,
+          git_blame_info: git_blame_info(fname, loc.start_line),
         )
       end.compact
     end

--- a/lib/runners/processor/tslint.rb
+++ b/lib/runners/processor/tslint.rb
@@ -151,6 +151,7 @@ module Runners
             location: loc,
             id: issue[:ruleName],
             message: issue[:failure],
+            git_blame_info: git_blame_info(issue[:name], loc.start_line),
           )
         end
       end

--- a/lib/runners/processor/tyscan.rb
+++ b/lib/runners/processor/tyscan.rb
@@ -106,20 +106,22 @@ module Runners
 
       Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
         json[:matches].each do |match|
+          loc = Location.new(
+            start_line: match[:location][:start][0],
+            start_column: match[:location][:start][1],
+            end_line: match[:location][:end][0],
+            end_column: match[:location][:end][1],
+          )
           result.add_issue Issue.new(
             id: match[:rule][:id],
             path: relative_path(match[:path]),
-            location: Location.new(
-              start_line: match[:location][:start][0],
-              start_column: match[:location][:start][1],
-              end_line: match[:location][:end][0],
-              end_column: match[:location][:end][1],
-            ),
+            location: loc,
             message: match[:rule][:message],
             object: {
               id: match[:rule][:id],
               message: match[:rule][:message],
             },
+            git_blame_info: git_blame_info(match[:path], loc.start_line),
             schema: Schema.issue_object,
           )
         end

--- a/lib/runners/workspace.rb
+++ b/lib/runners/workspace.rb
@@ -67,6 +67,10 @@ module Runners
       @root_tmp_dir ||= Pathname(Dir.mktmpdir)
     end
 
+    def range_git_blame_info(path_string, start_line, end_line)
+      []
+    end
+
     private
 
     def archive_source
@@ -175,10 +179,6 @@ module Runners
 
     def patches
       nil
-    end
-
-    def git_blame_info(path_string, start_line, end_line)
-      []
     end
   end
 end

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -1,5 +1,17 @@
 module Runners
   class Workspace::Git < Workspace
+    def range_git_blame_info(path_string, start_line, end_line)
+      base = git_source.base
+      head = git_source.head
+      if base && head
+        shell = Shell.new(current_dir: git_directory, trace_writer: trace_writer, env_hash: {})
+        stdout, _ = shell.capture3!("git", "blame", "-p", "-L", "#{start_line},#{end_line}", "#{base}...#{head}", "--", path_string)
+        GitBlameInfo.parse(stdout)
+      else
+        []
+      end
+    end
+
     private
 
     def prepare_base_source(dest)
@@ -57,18 +69,6 @@ module Runners
         end
       else
         nil
-      end
-    end
-
-    def git_blame_info(path_string, start_line, end_line)
-      base = git_source.base
-      head = git_source.head
-      if base && head
-        shell = Shell.new(current_dir: git_directory, trace_writer: trace_writer, env_hash: {})
-        stdout, _ = shell.capture3!("git", "blame", "-p", "-L", "#{start_line},#{end_line}", "#{base}...#{head}", "--", path_string)
-        GitBlameInfo.parse(stdout)
-      else
-        []
       end
     end
   end

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -147,7 +147,7 @@ class Runners::Processor
   def root_dir: -> Pathname
   def directory_traversal_attack?: (String) -> bool
   def show_runtime_versions: -> void
-  def git_blame_info: (String, Integer, Integer) -> Array<GitBlameInfo>
+  def git_blame_info: (String, Integer) -> GitBlameInfo?
 end
 
 type capture3_options = bool | Proc

--- a/sig/runners/workspace.rbi
+++ b/sig/runners/workspace.rbi
@@ -16,7 +16,7 @@ class Runners::Workspace
   def git_source: () -> Options::GitSource
   def root_tmp_dir: () -> Pathname
   def patches: () -> GitDiffParser::Patches?
-  def git_blame_info: (String, Integer, Integer) -> Array<GitBlameInfo>
+  def range_git_blame_info: (String, Integer, Integer) -> Array<GitBlameInfo>
 end
 
 class Runners::Workspace::HTTP < Workspace

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -79,10 +79,10 @@ class WorkspaceGitTest < Minitest::Test
     end
   end
 
-  def test_git_blame_info
+  def test_range_git_blame_info
     with_workspace(base: "abe1cfc294c8d39de7484954bf8c3d7792fd8ad1", head: "998bc02a913e3899f3a1cd327e162dd54d489a4b",
                    git_http_url: "https://github.com", owner: "sider", repo: "runners", pull_number: 533) do |workspace|
-      info = workspace.send(:git_blame_info, 'test/smokes/haml_lint/expectations.rb', 137, 140)
+      info = workspace.range_git_blame_info('test/smokes/haml_lint/expectations.rb', 137, 140)
       assert_equal(
         [
           GitBlameInfo.new(commit: "abe1cfc294c8d39de7484954bf8c3d7792fd8ad1", original_line: 137, final_line: 137, line_hash: "c57a7c8a63aa22b9aa40625f019fe097c3a23ab8"),


### PR DESCRIPTION
Make Runners add `:git_blame_info` for every issue.

Also, I renamed the API `Workspace#git_blame_info` to
`Workspace#range_git_blame_info`, and declare `Processor#git_blame_info`
because I want to relate the method name with the `GitBlameInfo` class.