### PR TITLE
Add #add_git_blame_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.17.0...HEAD)
 
 - Handle the empty externalInfoUrl in phpmd [#657](https://github.com/sider/runners/pull/657)
+- Add #add_git_blame_info [#655](https://github.com/sider/runners/pull/655)
 
 ## 0.17.0
 

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -49,7 +49,9 @@ module Runners
               case result
               when Results::Success
                 trace_writer.message "Removing issues from unchanged or untracked files..." do
-                  result.filter_issues(changes)
+                  result.filter_issues(changes).tap do |new_result|
+                    new_result.add_git_blame_info(workspace)
+                  end
                 end
               else
                 result

--- a/lib/runners/issue.rb
+++ b/lib/runners/issue.rb
@@ -8,7 +8,7 @@ module Runners
     attr_reader :object
     attr_reader :git_blame_info
 
-    def initialize(path:, location:, id:, message:, links: [], object: nil, schema: nil, git_blame_info: nil)
+    def initialize(path:, location:, id:, message:, links: [], object: nil, schema: nil)
       path.instance_of?(Pathname) or
         raise ArgumentError, "#{path.inspect} must be a #{Pathname}"
 
@@ -26,7 +26,6 @@ module Runners
       @message = message
       @links = links
       @object = object
-      @git_blame_info = git_blame_info
     end
 
     def eql?(other)
@@ -57,6 +56,15 @@ module Runners
         object: object,
         git_blame_info: git_blame_info&.to_h,
       )
+    end
+
+    def add_git_blame_info(workspace)
+      loc = location # NOTE: It's required to pass typecheck
+      @git_blame_info = if loc
+                          workspace.range_git_blame_info(path.to_s, loc.start_line, loc.start_line).first
+                        else
+                          nil
+                        end
     end
   end
 end

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -6,7 +6,6 @@ module Runners
 
     delegate :push_dir, :current_dir, :capture3, :capture3!, :capture3_trace, :capture3_with_retry!, to: :shell
     delegate :env_hash, :push_env_hash, to: :shell
-    delegate :git_blame_info, to: :workspace
 
     def initialize(guid:, workspace:, git_ssh_path:, trace_writer:)
       @guid = guid

--- a/lib/runners/results.rb
+++ b/lib/runners/results.rb
@@ -68,6 +68,12 @@ module Runners
         end
         result
       end
+
+      def add_git_blame_info(workspace)
+        issues.each do |issue|
+          issue.add_git_blame_info(workspace)
+        end
+      end
     end
 
     # Result to indicate that processing failed by some error.

--- a/lib/runners/workspace.rb
+++ b/lib/runners/workspace.rb
@@ -67,6 +67,10 @@ module Runners
       @root_tmp_dir ||= Pathname(Dir.mktmpdir)
     end
 
+    def range_git_blame_info(path_string, start_line, end_line)
+      []
+    end
+
     private
 
     def archive_source
@@ -175,10 +179,6 @@ module Runners
 
     def patches
       nil
-    end
-
-    def git_blame_info(path_string, start_line, end_line)
-      []
     end
   end
 end

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -1,5 +1,17 @@
 module Runners
   class Workspace::Git < Workspace
+    def range_git_blame_info(path_string, start_line, end_line)
+      base = git_source.base
+      head = git_source.head
+      if base && head
+        shell = Shell.new(current_dir: git_directory, trace_writer: trace_writer, env_hash: {})
+        stdout, _ = shell.capture3!("git", "blame", "-p", "-L", "#{start_line},#{end_line}", "#{base}...#{head}", "--", path_string, trace_stdout: false, trace_stderr: false)
+        GitBlameInfo.parse(stdout)
+      else
+        []
+      end
+    end
+
     private
 
     def prepare_base_source(dest)
@@ -57,18 +69,6 @@ module Runners
         end
       else
         nil
-      end
-    end
-
-    def git_blame_info(path_string, start_line, end_line)
-      base = git_source.base
-      head = git_source.head
-      if base && head
-        shell = Shell.new(current_dir: git_directory, trace_writer: trace_writer, env_hash: {})
-        stdout, _ = shell.capture3!("git", "blame", "-p", "-L", "#{start_line},#{end_line}", "#{base}...#{head}", "--", path_string)
-        GitBlameInfo.parse(stdout)
-      else
-        []
       end
     end
   end

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -66,6 +66,7 @@ class Runners::Results::Success < Runners::Results::Base
   def initialize: (guid: String, analyzer: Analyzer) -> any
   def add_issue: (Runners::Issue) -> void
   def (constructor) filter_issues: (Changes) -> instance
+  def add_git_blame_info: (Workspace) -> void
 end
 
 class Runners::Results::Failure < Runners::Results::Base

--- a/sig/runners/issue.rbi
+++ b/sig/runners/issue.rbi
@@ -8,6 +8,7 @@ class Runners::Issue
   attr_reader git_blame_info: GitBlameInfo?
 
   def initialize: (path: Pathname, location: Location?, id: String, message: String,
-                   ?links: Array<String>, ?object: any, ?schema: any, ?git_blame_info: GitBlameInfo?) -> any
+                   ?links: Array<String>, ?object: any, ?schema: any) -> any
   def as_json: () -> any
+  def add_git_blame_info: (Workspace) -> void
 end

--- a/sig/runners/workspace.rbi
+++ b/sig/runners/workspace.rbi
@@ -16,7 +16,7 @@ class Runners::Workspace
   def git_source: () -> Options::GitSource
   def root_tmp_dir: () -> Pathname
   def patches: () -> GitDiffParser::Patches?
-  def git_blame_info: (String, Integer, Integer) -> Array<GitBlameInfo>
+  def range_git_blame_info: (String, Integer, Integer) -> Array<GitBlameInfo>
 end
 
 class Runners::Workspace::HTTP < Workspace

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -82,7 +82,7 @@ class WorkspaceGitTest < Minitest::Test
   def test_git_blame_info
     with_workspace(base: "abe1cfc294c8d39de7484954bf8c3d7792fd8ad1", head: "998bc02a913e3899f3a1cd327e162dd54d489a4b",
                    git_http_url: "https://github.com", owner: "sider", repo: "runners", pull_number: 533) do |workspace|
-      info = workspace.send(:git_blame_info, 'test/smokes/haml_lint/expectations.rb', 137, 140)
+      info = workspace.range_git_blame_info('test/smokes/haml_lint/expectations.rb', 137, 140)
       assert_equal(
         [
           GitBlameInfo.new(commit: "abe1cfc294c8d39de7484954bf8c3d7792fd8ad1", original_line: 137, final_line: 137, line_hash: "c57a7c8a63aa22b9aa40625f019fe097c3a23ab8"),


### PR DESCRIPTION
Make Runners add `:git_blame_info` for every issue via
`Results::Success#add_git_blame_info`.

Also, I renamed the API `Workspace#git_blame_info` to
`Workspace#range_git_blame_info`, and declare `Processor#git_blame_info`
because I want to relate the method name with the `GitBlameInfo` class.

See also #654