### PR TITLE
Handle the empty externalInfoUrl in phpmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.17.0...HEAD)
 
+- Handle the empty externalInfoUrl in phpmd [#657](https://github.com/sider/runners/pull/657)
+
 ## 0.17.0
 
 [Full diff](https://github.com/sider/runners/compare/0.16.0...0.17.0)

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -156,7 +156,7 @@ module Runners
               location: loc,
               id: violation[:rule],
               message: violation.text.strip,
-              links: [violation[:externalInfoUrl]]
+              links: [violation[:externalInfoUrl]].compact,
             )
           end
         end

--- a/test/smokes/phpmd/custom_rule/custom_ruleset.xml
+++ b/test/smokes/phpmd/custom_rule/custom_ruleset.xml
@@ -15,7 +15,7 @@
   <rule name="NoMethods"
         message="Please do not use methods."
         class="custom\rules\NoMethods"
-        externalInfoUrl="https://example.com/phpmd/rules/no-methods">
+        externalInfoUrl="">
     <priority>1</priority>
   </rule>
 </ruleset>

--- a/test/smokes/phpmd/expectations.rb
+++ b/test/smokes/phpmd/expectations.rb
@@ -153,7 +153,7 @@ Smoke.add_test(
         location: { start_line: 6, end_line: 9 },
         id: "NoMethods",
         message: "Please do not use methods.",
-        links: %w[https://example.com/phpmd/rules/no-methods],
+        links: [],
         object: nil,
         git_blame_info: nil
       },
@@ -162,7 +162,7 @@ Smoke.add_test(
         location: { start_line: 8, end_line: 11 },
         id: "NoMethods",
         message: "Please do not use methods.",
-        links: %w[https://example.com/phpmd/rules/no-methods],
+        links: [],
         object: nil,
         git_blame_info: nil
       }


### PR DESCRIPTION
The externalInfoUrl of a violation sometimes does not appear.
This patch handles the situation.