### PR TITLE
[TSLint] Loosen the version constraint allowing v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.18.0...HEAD)
 
+- [TSLint] Loosen the version constraint allowing v6 [#681](https://github.com/sider/runners/pull/681)
+
 ## 0.18.0
 
 [Full diff](https://github.com/sider/runners/compare/0.17.1...0.18.0)

--- a/lib/runners/processor/tslint.rb
+++ b/lib/runners/processor/tslint.rb
@@ -31,7 +31,7 @@ module Runners
     )
 
     CONSTRAINTS = {
-      "tslint" => Constraint.new(">= 5.0.0", "< 6.0.0"),
+      "tslint" => Constraint.new(">= 5.0.0", "< 7.0.0"),
     }.freeze
 
     def self.ci_config_section_name

--- a/test/smokes/tslint/expectations.rb
+++ b/test/smokes/tslint/expectations.rb
@@ -381,3 +381,24 @@ Smoke.add_test(
     analyzer: nil
   }
 )
+
+Smoke.add_test(
+  "tslint-v6",
+  {
+    guid: "test-guid",
+    timestamp: :_,
+    type: "success",
+    issues: [
+      {
+        id: "no-console",
+        path: "foo.ts",
+        location: { start_line: 1, end_line: 1 },
+        message: "Calls to 'console.log' are not allowed.",
+        links: [],
+        object: nil,
+        git_blame_info: nil
+      }
+    ],
+    analyzer: { name: "TSLint", version: "6.0.0" }
+  }
+)

--- a/test/smokes/tslint/tslint-v6/foo.ts
+++ b/test/smokes/tslint/tslint-v6/foo.ts
@@ -1,0 +1,1 @@
+console.log(1);

--- a/test/smokes/tslint/tslint-v6/package.json
+++ b/test/smokes/tslint/tslint-v6/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "tslint": "6.0.0"
+  }
+}


### PR DESCRIPTION
TSLint v6 has some breaking changes, but it does not break the runners behavior.

See also:
- https://github.com/palantir/tslint/releases/tag/6.0.0
- https://github.com/palantir/tslint/blob/6.0.0/CHANGELOG.md