### PR TITLE
Add warnings if the analysis tries to use Python 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.18.1...HEAD)
 
 - [RuboCop] Add more plugins to OPTIONAL_GEMS [#683](https://github.com/sider/runners/pull/683)
+- [Flake8] Add warnings if the analysis tries to use Python 2 [#702](https://github.com/sider/runners/pull/702)
 
 ## 0.18.1
 

--- a/lib/runners/processor/flake8.rb
+++ b/lib/runners/processor/flake8.rb
@@ -91,7 +91,11 @@ module Runners
     end
 
     def python2_version
-      @python2_version ||= capture3!('pyenv', 'versions', '--bare').first.match(/^2[0-9\.]+$/m).to_s
+      @python2_version ||= capture3!('pyenv', 'versions', '--bare').first.match(/^2[0-9\.]+$/m).to_s.tap do
+        add_warning(<<~MESSAGE.chomp)
+          Python 2 is deprecated. Consider migrating to Python 3.
+        MESSAGE
+      end
     end
 
     def python3_version

--- a/test/smokes/flake8/expectations.rb
+++ b/test/smokes/flake8/expectations.rb
@@ -201,7 +201,8 @@ Smoke.add_test(
 
 Smoke.add_test(
   "python2",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Flake8", version: "3.7.9" } }
+  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Flake8", version: "3.7.9" } },
+  { warnings: [{ message: "Python 2 is deprecated. Consider migrating to Python 3.", file: nil }] }
 )
 
 Smoke.add_test(
@@ -211,5 +212,6 @@ Smoke.add_test(
 
 Smoke.add_test(
   "dot_python_version_2",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Flake8", version: "3.7.9" } }
+  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Flake8", version: "3.7.9" } },
+  { warnings: [{ message: "Python 2 is deprecated. Consider migrating to Python 3.", file: nil }] }
 )


### PR DESCRIPTION
I updated the documentation [here](https://help.sider.review/tools/python/flake8) to notify users about the deprecation of Python 2.
Runners also should warn about the deprecation.