### PR TITLE
[RuboCop][HAML-Lint] Set an upper limit for constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - [RuboCop] Update rubocop requirement from 0.79.0 to 0.80.0 [#752](https://github.com/sider/runners/pull/752)
 - [HAML-Lint] Update rubocop requirement from 0.79.0 to 0.80.0 [#753](https://github.com/sider/runners/pull/753)
+- [RuboCop] [HAML-Lint] Set an upper limit for constraints [#755](https://github.com/sider/runners/pull/755)
 
 ## 0.19.4
 

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -36,7 +36,7 @@ module Runners
     DEFAULT_GEMS = ["haml_lint", "rubocop"].freeze
 
     CONSTRAINTS = {
-      "haml_lint" => [">= 0.26.0"]
+      "haml_lint" => [">= 0.26.0", "< 1.0.0"]
     }.freeze
 
     def self.ci_config_section_name

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -65,7 +65,7 @@ module Runners
     ].freeze
 
     CONSTRAINTS = {
-      "rubocop" => [">= 0.61.0"]
+      "rubocop" => [">= 0.61.0", "< 1.0.0"]
     }.freeze
 
     def self.ci_config_section_name

--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -462,7 +462,7 @@ Smoke.add_test(
     {
       message: <<~MSG,
         Sider tried to install `rubocop 0.60.0` according to your `Gemfile.lock`, but it installs `0.80.0` instead.
-        Because `0.60.0` does not satisfy the Sider constraints [\">= 0.61.0\"].
+        Because `0.60.0` does not satisfy the Sider constraints [\">= 0.61.0\", \"< 1.0.0\"].
 
         If you want to use a different version of `rubocop`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
         See https://help.sider.review/getting-started/custom-configuration#gems-option


### PR DESCRIPTION
`< 1.0.0`: This aims to prevent breaking due to unsupported versions of the linters. For example, we usually predict that the version 1.0.0 may include some breaking changes.
