### PR TITLE
Show stderr of git-blame(1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.20.0...HEAD)
 
+- Show stderr of git-blame(1) [#756](https://github.com/sider/runners/pull/756)
+
 ## 0.20.0
 
 [Full diff](https://github.com/sider/runners/compare/0.19.4...0.20.0)

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -5,7 +5,7 @@ module Runners
       head = git_source.head
       if base && head
         shell = Shell.new(current_dir: git_directory, trace_writer: trace_writer, env_hash: {})
-        stdout, _ = shell.capture3!("git", "blame", "-p", "-L", "#{start_line},#{end_line}", "#{base}...#{head}", "--", path_string, trace_stdout: false, trace_stderr: false)
+        stdout, _ = shell.capture3!("git", "blame", "-p", "-L", "#{start_line},#{end_line}", "#{base}...#{head}", "--", path_string, trace_stdout: false, trace_stderr: true)
         GitBlameInfo.parse(stdout)
       else
         []


### PR DESCRIPTION
We disabled `:trace_stdout` and `:trace_stderr` in case the bunch of traces would output. However, the lack of stderr makes it difficult to look into what is happening if git-blame(1) exits unsuccessfully.

This patch enables `:trace_stderr`, and I believe this does not cause performance issues.
