### PR TITLE
[RuboCop] Use `--out=FILE` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - [SwiftLint] Bump SwiftLint from 0.38.2 to 0.39.1 [#738](https://github.com/sider/runners/pull/738)
 - [FxCop] New support [#731](https://github.com/sider/runners/pull/731)
 - Aggregate log entries by `delete_unchanged_files` method [#765](https://github.com/sider/runners/pull/765)
+- [RuboCop] Use `--out=FILE` option [#769](https://github.com/sider/runners/pull/769)
 
 ## 0.20.0
 

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -200,7 +200,7 @@ module Runners
 
       # NOTE: `--out` option must be after `--format` option.
       #
-      # @see https://github.com/rubocop-hq/rubocop/blob/v0.80.0/manual/formatters.md
+      # @see https://docs.rubocop.org/en/stable/formatters
       options << "--format=json"
       options << "--out=#{output_file.path}"
 

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -197,8 +197,12 @@ module Runners
     end
 
     def run_analyzer(options)
-      stdout, stderr, status = capture3(*ruby_analyzer_bin, *options)
+      output_file = Tempfile.new("rubocop-")
+      options << "--out=#{output_file.path}"
+
+      _, stderr, status = capture3(*ruby_analyzer_bin, *options)
       check_rubocop_yml_warning(stderr)
+
       # 0: no offences
       # 1: offences exist
       # 2: RuboCop crashes by unhandled errors.
@@ -210,10 +214,15 @@ module Runners
         return Results::Failure.new(guid: guid, message: error_message, analyzer: analyzer)
       end
 
-      Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
-        break result if stdout == '' # No offenses
+      output_json = output_file.read
+      unless output_json.empty?
+        trace_writer.message "Output JSON: #{output_json}"
+      end
 
-        JSON.parse(stdout, symbolize_names: true)[:files].reject { |v| v[:offenses].empty? }.each do |hash|
+      Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
+        break result if output_json == '' # No offenses
+
+        JSON.parse(output_json, symbolize_names: true)[:files].reject { |v| v[:offenses].empty? }.each do |hash|
           hash[:offenses].each do |offense|
             loc = Location.new(
               start_line: offense[:location][:line],

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -117,7 +117,6 @@ module Runners
       opts = %w[
         --display-style-guide
         --cache=false
-        --format=json
         --no-display-cop-names
       ]
 
@@ -198,6 +197,11 @@ module Runners
 
     def run_analyzer(options)
       output_file = Tempfile.new("rubocop-")
+
+      # NOTE: `--out` option must be after `--format` option.
+      #
+      # @see https://github.com/rubocop-hq/rubocop/blob/v0.80.0/manual/formatters.md
+      options << "--format=json"
       options << "--out=#{output_file.path}"
 
       _, stderr, status = capture3(*ruby_analyzer_bin, *options)


### PR DESCRIPTION
Handling STDOUT is unsafe due to bugs of RuboCop itself or its plugins.

The [RuboCop document](https://docs.rubocop.org/en/latest/basic_usage/#command-line-flags) says:

> `-o/--out`    Write output to a file instead of STDOUT.