### PR TITLE
Enhance `rake docker:shell` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -137,7 +137,8 @@ namespace :docker do
   end
 
   desc 'Run interactive shell in the specified Docker container'
-  task :shell do
-    sh "docker", "run", "-it", "--rm", "--entrypoint=bash", image_name
+  task :shell, [:extra_args] do |_task, args|
+    run_args = (args[:extra_args] || "").split(/\s+/)
+    sh "docker", "run", "-it", "--rm", "--entrypoint=bash", *run_args, image_name
   end
 end


### PR DESCRIPTION
This change allows you to pass extra arguments to the `docker:shell` rake task.

For example:

```shell
rake docker:shell"[-v $PWD/test/smokes/rubocop:/test -w /test]" ANALYZER=rubocop
```
