### PR TITLE
Add schema for gometalinter

### DIFF
--- a/lib/runners/processor/gometalinter.rb
+++ b/lib/runners/processor/gometalinter.rb
@@ -3,7 +3,29 @@ module Runners
     include Go
 
     Schema = StrongJSON.new do
-      let :runner_config, Schema::BaseConfig.base
+      let :runner_config, Schema::BaseConfig.base.update_fields { |fields|
+        fields.merge!(
+          import_path: string?,
+          install_path: string?,
+          options: object?(
+            config: string?,
+            exclude: string?,
+            include: string?,
+            skip: string?,
+            'cyclo-over': numeric?,
+            'min-confidence': numeric?,
+            'dupl-threshold': numeric?,
+            severity: string?,
+            vendor: boolean?,
+            tests: boolean?,
+            errors: boolean?,
+            'disable-all': boolean?,
+            fast: boolean?,
+            disable: enum?(string, array(string)),
+            enable: enum?(string, array(string)),
+          ),
+        )
+      }
     end
 
     register_config_schema(name: :gometalinter, schema: Schema.runner_config)
@@ -141,7 +163,7 @@ module Runners
           next unless !!v
           "--#{k}"
         when 'disable', 'enable'
-          linter_tool_options(k, v)
+          linter_tool_options(k, Array(v))
         else
           nil
         end

--- a/test/smokes/gometalinter/import_path/sideci.yml
+++ b/test/smokes/gometalinter/import_path/sideci.yml
@@ -1,3 +1,7 @@
 linter:
   gometalinter:
     import_path: github.com/sideci/install_path_test
+    options:
+      disable: gofmt
+      enable:
+        - test


### PR DESCRIPTION
`Processor::Gometalinter` should declare its schema for configuration. This patch adds schema in order that we can easily implement #750.

Note that we have to use `#ensure_runner_config_schema` to validate the configuration, but this method would be removed by #750.
