### PR TITLE
[hadolint] Exclude template files by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - [go-vet][Golint][Go Meta Linter] Add deprecated warning [#767](https://github.com/sider/runners/pull/767)
 - [Goodcheck] Update goodcheck requirement from 2.4.5 to 2.5.0 [#775](https://github.com/sider/runners/pull/775)
 - Add Runners::Config, which is responsible for sider.yml [#763](https://github.com/sider/runners/pull/763)
+- [hadolint] Exclude template files by default [#780](https://github.com/sider/runners/pull/780)
 
 ## 0.20.0
 

--- a/lib/runners/processor/hadolint.rb
+++ b/lib/runners/processor/hadolint.rb
@@ -18,6 +18,7 @@ module Runners
     register_config_schema(name: :hadolint, schema: Schema.runner_config)
 
     DEFAULT_TARGET = "**/Dockerfile{,.*}".freeze
+    DEFAULT_TARGET_EXCLUDED = "*.{erb,txt}".freeze # Exclude templates
 
     def self.ci_config_section_name
       "hadolint"
@@ -57,7 +58,9 @@ module Runners
       if config[:target]
         Array(config[:target])
       else
-        Dir.glob(DEFAULT_TARGET, File::FNM_EXTGLOB, base: current_dir)
+        current_dir.glob(DEFAULT_TARGET, File::FNM_EXTGLOB)
+          .reject { |path| path.fnmatch?(DEFAULT_TARGET_EXCLUDED, File::FNM_EXTGLOB) }
+          .map { |path| relative_path(path).to_path }
       end
     end
 

--- a/test/smokes/hadolint/expectations.rb
+++ b/test/smokes/hadolint/expectations.rb
@@ -88,6 +88,15 @@ Smoke.add_test(
       message: "Last USER should not be root",
       object: { severity: "warning" },
       git_blame_info: nil
+    },
+    {
+      id: "DL3002",
+      links: %w[https://github.com/hadolint/hadolint/wiki/DL3002],
+      path: "Dockerfile.production",
+      location: { start_line: 3 },
+      message: "Last USER should not be root",
+      object: { severity: "warning" },
+      git_blame_info: nil
     }
   ],
   analyzer: { name: "hadolint", version: "1.17.4" }

--- a/test/smokes/hadolint/multi_dockerfile/Dockerfile.erb
+++ b/test/smokes/hadolint/multi_dockerfile/Dockerfile.erb
@@ -1,0 +1,3 @@
+FROM sider/devon_rex_haskell:2.4.0
+
+USER root

--- a/test/smokes/hadolint/multi_dockerfile/Dockerfile.production
+++ b/test/smokes/hadolint/multi_dockerfile/Dockerfile.production
@@ -1,0 +1,3 @@
+FROM sider/devon_rex_haskell:2.4.0
+
+USER root

--- a/test/smokes/hadolint/multi_dockerfile/Dockerfile.production.erb
+++ b/test/smokes/hadolint/multi_dockerfile/Dockerfile.production.erb
@@ -1,0 +1,3 @@
+FROM sider/devon_rex_haskell:2.4.0
+
+USER root

--- a/test/smokes/hadolint/multi_dockerfile/Dockerfile.production.txt
+++ b/test/smokes/hadolint/multi_dockerfile/Dockerfile.production.txt
@@ -1,0 +1,3 @@
+FROM sider/devon_rex_haskell:2.4.0
+
+USER root

--- a/test/smokes/hadolint/multi_dockerfile/Dockerfile.txt
+++ b/test/smokes/hadolint/multi_dockerfile/Dockerfile.txt
@@ -1,0 +1,3 @@
+FROM sider/devon_rex_haskell:2.4.0
+
+USER root


### PR DESCRIPTION
By default, the hadolint runner tries to analyze files to match the `**/Dockerfile{,.*}` glob pattern.
For example, the pattern matches `Dockerfile.erb` which is used as a template file such as in this *sider/runners* repository.

This change excludes `*.erb` and `*.txt` files by default.
Because such files are a template file and are not a real Dockerfile.

*NOTE: We may add some file extensions to be excluded in the future.*