### PR TITLE
Remove #ensure_runner_config_schema

### DIFF
--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -132,12 +132,6 @@ module Runners
       end
     end
 
-    # @deprecated This method will be removed in favor of `Runners::Config`.
-    # @param schema [StrongJSON]
-    def ensure_runner_config_schema(_schema)
-      yield ci_section
-    end
-
     # Returns e.g. "$.linter.rubocop.gems"
     def build_field_reference_from_path(path)
       path.to_s.sub('$', "$.linter.#{self.class.ci_config_section_name}")

--- a/lib/runners/processor/brakeman.rb
+++ b/lib/runners/processor/brakeman.rb
@@ -21,11 +21,9 @@ module Runners
     end
 
     def setup
-      ensure_runner_config_schema(Schema.runner_config) do
-        install_gems default_gem_specs, constraints: CONSTRAINTS do |versions|
-          analyzer
-          yield
-        end
+      install_gems default_gem_specs, constraints: CONSTRAINTS do
+        analyzer
+        yield
       end
     rescue InstallGemsFailure => exn
       trace_writer.error exn.message

--- a/lib/runners/processor/cppcheck.rb
+++ b/lib/runners/processor/cppcheck.rb
@@ -40,43 +40,36 @@ module Runners
     end
 
     def analyze(_changes)
-      ensure_runner_config_schema(Schema.runner_config) do |config|
-        @config = config
-        run_analyzer
-      end
+      run_analyzer
     end
 
     private
 
-    def config
-      @config or raise "Must be initialized!"
-    end
-
     def target
-      Array(config[:target] || DEFAULT_TARGET)
+      Array(ci_section[:target] || DEFAULT_TARGET)
     end
 
     def ignore
-      Array(config[:ignore] || DEFAULT_IGNORE).map { |i| ["-i", i] }.flatten
+      Array(ci_section[:ignore] || DEFAULT_IGNORE).map { |i| ["-i", i] }.flatten
     end
 
     def enable
-      id = config[:enable]
+      id = ci_section[:enable]
       Array(id ? "--enable=#{id}" : nil)
     end
 
     def std
-      id = config[:std]
+      id = ci_section[:std]
       Array(id ? "--std=#{id}" : nil)
     end
 
     def project
-      file = config[:project]
+      file = ci_section[:project]
       Array(file ? "--project=#{file}" : nil)
     end
 
     def language
-      lang = config[:language]
+      lang = ci_section[:language]
       Array(lang ? "--language=#{lang}" : nil)
     end
 

--- a/lib/runners/processor/cpplint.rb
+++ b/lib/runners/processor/cpplint.rb
@@ -30,30 +30,23 @@ module Runners
     end
 
     def analyze(changes)
-      ensure_runner_config_schema(Schema.runner_config) do |config|
-        @config = config
-        run_analyzer
-      end
+      run_analyzer
     end
 
     private
-
-    def config
-      @config or raise "Must be initialized!"
-    end
 
     def analyzer_options
       [].tap do |opts|
         opts << "--output=junit"
         opts << "--recursive"
-        opts << "--extensions=#{config[:extensions]}" if config[:extensions]
-        opts << "--headers=#{config[:headers]}" if config[:headers]
-        opts << "--filter=#{config[:filter]}" if config[:filter]
-        opts << "--linelength=#{config[:linelength]}" if config[:linelength]
-        Array(config[:exclude]).each do |exclude|
+        opts << "--extensions=#{ci_section[:extensions]}" if ci_section[:extensions]
+        opts << "--headers=#{ci_section[:headers]}" if ci_section[:headers]
+        opts << "--filter=#{ci_section[:filter]}" if ci_section[:filter]
+        opts << "--linelength=#{ci_section[:linelength]}" if ci_section[:linelength]
+        Array(ci_section[:exclude]).each do |exclude|
           opts << "--exclude=#{exclude}"
         end
-        Array(config[:target] || DEFAULT_TARGET).each do |target|
+        Array(ci_section[:target] || DEFAULT_TARGET).each do |target|
           opts << target
         end
       end

--- a/lib/runners/processor/flake8.rb
+++ b/lib/runners/processor/flake8.rb
@@ -29,13 +29,11 @@ module Runners
     end
 
     def analyze(changes)
-      ensure_runner_config_schema(Schema.runner_config) do |config|
-        capture3! 'pyenv', 'global', detected_python_version(config)
-        capture3! "python", "--version" # NOTE: `show_runtime_versions` does not work...
-        capture3! "pip", "--version"
-        prepare_plugins(config)
-        run_analyzer
-      end
+      capture3! 'pyenv', 'global', detected_python_version
+      capture3! "python", "--version" # NOTE: `show_runtime_versions` does not work...
+      capture3! "pip", "--version"
+      prepare_plugins
+      run_analyzer
     end
 
     private
@@ -50,23 +48,23 @@ module Runners
       return default_config.delete unless configs.empty?
     end
 
-    def prepare_plugins(config)
-      if config[:plugins]
-        plugins = Array(config[:plugins]).flatten
+    def prepare_plugins
+      if ci_section[:plugins]
+        plugins = Array(ci_section[:plugins]).flatten
         capture3!('pip', 'install', *plugins)
       end
     end
 
-    def detected_python_version(config)
+    def detected_python_version
       [
-        specified_python_version(config),
+        specified_python_version,
         specified_python_version_via_pyenv,
         python3_version
       ].compact.first
     end
 
-    def specified_python_version(config)
-      case config[:version]&.to_i
+    def specified_python_version
+      case ci_section[:version]&.to_i
       when 2
         python2_version
       when 3

--- a/lib/runners/processor/hadolint.rb
+++ b/lib/runners/processor/hadolint.rb
@@ -28,35 +28,28 @@ module Runners
       "hadolint"
     end
 
-    def analyze(changes)
-      ensure_runner_config_schema(Schema.runner_config) do |config|
-        @config = config
-        run_analyzer
-      end
+    def analyze(_changes)
+      run_analyzer
     end
 
     private
 
-    def config
-      @config or raise "Must be initialized!"
-    end
-
     def analyzer_options
       [].tap do |opts|
         opts << "--format=json"
-        Array(config[:'trusted-registry']).each do |trusted|
+        Array(ci_section[:'trusted-registry']).each do |trusted|
           opts << "--trusted-registry=#{trusted}"
         end
-        Array(config[:ignore]).each do |ignore|
+        Array(ci_section[:ignore]).each do |ignore|
           opts << "--ignore=#{ignore}"
         end
-        opts << "--config=#{config[:config]}" if config[:config]
+        opts << "--config=#{ci_section[:config]}" if ci_section[:config]
       end
     end
 
     def analysis_target
-      if config[:target]
-        Array(config[:target])
+      if ci_section[:target]
+        Array(ci_section[:target])
       else
         current_dir.glob(DEFAULT_TARGET, File::FNM_EXTGLOB)
           .reject { |path| path.fnmatch?(DEFAULT_TARGET_EXCLUDED, File::FNM_EXTGLOB) }

--- a/lib/runners/processor/ktlint.rb
+++ b/lib/runners/processor/ktlint.rb
@@ -166,25 +166,23 @@ module Runners
     end
 
     def analyze(changes)
-      ensure_runner_config_schema(Schema.runner_config) do |config|
-        delete_unchanged_files changes, only: [".kt", ".kts"]
+      delete_unchanged_files changes, only: [".kt", ".kts"]
 
-        check_runner_config(config) do |checked_config|
-          @ktlint_config = checked_config
+      check_runner_config do |checked_config|
+        @ktlint_config = checked_config
 
-          issues = case
-                   when gradle_config
-                     run_gradle
-                   when maven_config
-                     run_maven
-                   else
-                     run_cli
-                   end
+        issues = case
+                 when gradle_config
+                   run_gradle
+                 when maven_config
+                   run_maven
+                 else
+                   run_cli
+                 end
 
-          Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
-            issues.each do |issue|
-              result.add_issue issue
-            end
+        Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
+          issues.each do |issue|
+            result.add_issue issue
           end
         end
       end
@@ -271,36 +269,36 @@ module Runners
       end
     end
 
-    def check_runner_config(config)
+    def check_runner_config
       case
-      when config[:gradle]
+      when ci_section[:gradle]
         yield(
           {
             gradle: {
-              task: config[:gradle][:task],
-              reporter: config[:gradle][:reporter],
-              output: config[:gradle][:output]
+              task: ci_section[:gradle][:task],
+              reporter: ci_section[:gradle][:reporter],
+              output: ci_section[:gradle][:output]
             }
           }
         )
-      when config[:maven]
+      when ci_section[:maven]
         yield(
           {
             maven: {
-              goal: config[:maven][:goal],
-              reporter: config[:maven][:reporter],
-              output: config[:maven][:output]
+              goal: ci_section[:maven][:goal],
+              reporter: ci_section[:maven][:reporter],
+              output: ci_section[:maven][:output]
             }
           }
         )
-      when config[:cli]
+      when ci_section[:cli]
         yield(
           {
             cli: {
-              patterns: Array(config[:cli][:patterns]),
-              ruleset: Array(config[:cli][:ruleset]),
-              disabled_rules: Array(config[:cli][:disabled_rules]),
-              experimental: config[:cli][:experimental] || false
+              patterns: Array(ci_section[:cli][:patterns]),
+              ruleset: Array(ci_section[:cli][:ruleset]),
+              disabled_rules: Array(ci_section[:cli][:disabled_rules]),
+              experimental: ci_section[:cli][:experimental] || false
             }
           }
         )

--- a/lib/runners/processor/pmd_java.rb
+++ b/lib/runners/processor/pmd_java.rb
@@ -48,13 +48,9 @@ module Runners
     end
 
     def analyze(changes)
-      ensure_runner_config_schema(Schema.runner_config) do |config|
-        delete_unchanged_files changes, only: [".java"]
+      delete_unchanged_files changes, only: [".java"]
 
-        check_runner_config(config) do |dir, rulesets, encoding, min_priority|
-          run_analyzer(dir, rulesets, encoding, min_priority)
-        end
-      end
+      run_analyzer(dir, rulesets, encoding, min_priority)
     end
 
     def run_analyzer(dir, rulesets, encoding, min_priority)
@@ -122,33 +118,24 @@ module Runners
       end
     end
 
-    def check_runner_config(config)
-      dir = check_directory(config)
-      rulesets = rulesets(config)
-      encoding = encoding(config)
-      min_priority = min_priority(config)
-
-      yield dir, rulesets, encoding, min_priority
-    end
-
-    def rulesets(config)
-      array(config[:rulesets] || default_ruleset)
+    def rulesets
+      array(ci_section[:rulesets] || default_ruleset)
     end
 
     def default_ruleset
       (Pathname(Dir.home) / "default-ruleset.xml").realpath
     end
 
-    def check_directory(config)
-      config[:dir] || "."
+    def dir
+      ci_section[:dir] || "."
     end
 
-    def encoding(config)
-      config[:encoding]
+    def encoding
+      ci_section[:encoding]
     end
 
-    def min_priority(config)
-      config[:min_priority]
+    def min_priority
+      ci_section[:min_priority]
     end
 
     def array(value)

--- a/lib/runners/processor/querly.rb
+++ b/lib/runners/processor/querly.rb
@@ -37,11 +37,9 @@ module Runners
     end
 
     def setup
-      ret = ensure_runner_config_schema(Schema.runner_config) do
-        install_gems default_gem_specs, optionals: OPTIONAL_GEMS, constraints: CONSTRAINTS do |versions|
-          analyzer
-          yield
-        end
+      ret = install_gems default_gem_specs, optionals: OPTIONAL_GEMS, constraints: CONSTRAINTS do
+        analyzer
+        yield
       end
 
       # NOTE: Exceptionally MissingFileFailure is treated as successful

--- a/lib/runners/processor/reek.rb
+++ b/lib/runners/processor/reek.rb
@@ -21,11 +21,9 @@ module Runners
     end
 
     def setup
-      ensure_runner_config_schema(Schema.runner_config) do
-        install_gems default_gem_specs, constraints: CONSTRAINTS do |versions|
-          analyzer
-          yield
-        end
+      install_gems default_gem_specs, constraints: CONSTRAINTS do
+        analyzer
+        yield
       end
     rescue InstallGemsFailure => exn
       trace_writer.error exn.message

--- a/lib/runners/processor/scss_lint.rb
+++ b/lib/runners/processor/scss_lint.rb
@@ -40,21 +40,13 @@ module Runners
       yield
     end
 
-    def analyze(changes)
-      ensure_runner_config_schema(Schema.runner_config) do |config|
-        check_runner_config(config) do |options|
-          run_analyzer(options)
-        end
-      end
+    def analyze(_changes)
+      options = [scss_lint_config].compact
+      run_analyzer(options)
     end
 
-    def check_runner_config(config)
-      scss_lint_config = scss_lint_config(config)
-      yield [scss_lint_config].compact
-    end
-
-    def scss_lint_config(config)
-      config = config[:config] || config.dig(:options, :config)
+    def scss_lint_config
+      config = ci_section[:config] || ci_section.dig(:options, :config)
       "--config=#{config}" if config
     end
 

--- a/lib/runners/processor/shellcheck.rb
+++ b/lib/runners/processor/shellcheck.rb
@@ -59,17 +59,10 @@ module Runners
     end
 
     def analyze(_changes)
-      ensure_runner_config_schema(Schema.runner_config) do |config|
-        @config = config
-        run_analyzer
-      end
+      run_analyzer
     end
 
     private
-
-    def config
-      @config or raise "Must be initialized!"
-    end
 
     def find_files_with_shebang
       trace_writer.message "Finding files with shell script shebang..."
@@ -90,7 +83,7 @@ module Runners
 
     def analyzed_files
       # Via glob
-      targets = Array(config[:target] || DEFAULT_TARGET)
+      targets = Array(ci_section[:target] || DEFAULT_TARGET)
       globs = targets.select { |glob| glob.is_a? String }
       files_via_glob = Dir.glob(globs, File::FNM_EXTGLOB, base: current_dir)
 
@@ -103,7 +96,7 @@ module Runners
     end
 
     def option_values(name, sep)
-      Array(config[name]).join(sep).split(sep).map(&:strip).join(sep)
+      Array(ci_section[name]).join(sep).split(sep).map(&:strip).join(sep)
     end
 
     def analyzer_options
@@ -112,9 +105,9 @@ module Runners
         option_values(:include, ",").tap { |val| opts << "--include=#{val}" unless val.empty? }
         option_values(:exclude, ",").tap { |val| opts << "--exclude=#{val}" unless val.empty? }
         option_values(:enable, ",").tap { |val| opts << "--enable=#{val}" unless val.empty? }
-        config[:shell].tap { |val| opts << "--shell=#{val}" if val }
-        config[:severity].tap { |val| opts << "--severity=#{val}" if val }
-        opts << "--norc" if config[:norc]
+        ci_section[:shell].tap { |val| opts << "--shell=#{val}" if val }
+        ci_section[:severity].tap { |val| opts << "--severity=#{val}" if val }
+        opts << "--norc" if ci_section[:norc]
       end
     end
 

--- a/lib/runners/processor/swiftlint.rb
+++ b/lib/runners/processor/swiftlint.rb
@@ -40,48 +40,31 @@ module Runners
     end
 
     def analyze(_changes)
-      ensure_runner_config_schema(Schema.runner_config) do |config|
-        check_runner_config(config) do |ignore_warnings, options|
-          run_analyzer(ignore_warnings, options)
-        end
-      end
-    end
-
-    def check_runner_config(config)
-      # Sider option.
-      ignore_warnings = ignore_warnings(config)
-
-      # Command line options.
-      path = path(config)
-      swiftlint_config = swiftlint_config(config)
-      lenient = lenient(config)
-      enable_all_rules = enable_all_rules(config)
-
       options = [path, swiftlint_config, lenient, enable_all_rules].compact.flatten
-      yield ignore_warnings, options
+      run_analyzer(ignore_warnings, options)
     end
 
-    def ignore_warnings(config)
-      config[:ignore_warnings] || false
+    def ignore_warnings
+      ci_section[:ignore_warnings] || false
     end
 
-    def path(config)
-      path = config[:path] || config.dig(:options, :path)
+    def path
+      path = ci_section[:path] || ci_section.dig(:options, :path)
       ["--path", "#{path}"] if path
     end
 
-    def swiftlint_config(config)
-      config = config[:config] || config.dig(:options, :config)
+    def swiftlint_config
+      config = ci_section[:config] || ci_section.dig(:options, :config)
       ["--config", "#{config}"] if config
     end
 
-    def lenient(config)
-      lenient = config[:lenient] || config.dig(:options, :lenient)
+    def lenient
+      lenient = ci_section[:lenient] || ci_section.dig(:options, :lenient)
       "--lenient" if lenient
     end
 
-    def enable_all_rules(config)
-      enable_all_rules = config[:'enable-all-rules'] || config.dig(:options, :'enable-all-rules')
+    def enable_all_rules
+      enable_all_rules = ci_section[:'enable-all-rules'] || ci_section.dig(:options, :'enable-all-rules')
       "--enable-all-rules" if enable_all_rules
     end
 

--- a/test/processor/phpmd_test.rb
+++ b/test/processor/phpmd_test.rb
@@ -9,16 +9,28 @@ class Runners::Processor::PhpmdTest < Minitest::Test
     @trace_writer ||= Runners::TraceWriter.new(writer: [])
   end
 
-  def subject(workspace)
-    Phpmd.new(guid: SecureRandom.uuid, workspace: workspace, config: config, git_ssh_path: nil, trace_writer: trace_writer)
+  def subject(workspace, yaml: nil)
+    Phpmd.new(guid: SecureRandom.uuid, workspace: workspace, config: config(yaml), git_ssh_path: nil, trace_writer: trace_writer)
   end
 
   def test_target_files
     with_workspace do |workspace|
-      assert_equal ["*.php"], subject(workspace).send(:target_files, {})
-      assert_equal ["*.php"], subject(workspace).send(:target_files, { suffixes: "php" })
-      assert_equal ["*.php", "*.phtml"], subject(workspace).send(:target_files, { suffixes: "php,phtml" })
-      assert_equal ["*.a", "*.b"], subject(workspace).send(:target_files, { suffixes: "a,b" })
+      assert_equal ["*.php"], subject(workspace).send(:target_files)
+      assert_equal ["*.php"], subject(workspace, yaml: <<~YAML).send(:target_files)
+        linter:
+          phpmd:
+            suffixes: php
+      YAML
+      assert_equal ["*.php", "*.phtml"], subject(workspace, yaml: <<~YAML).send(:target_files)
+        linter:
+          phpmd:
+            suffixes: php,phtml
+      YAML
+      assert_equal ["*.a", "*.b"], subject(workspace, yaml: <<~YAML).send(:target_files)
+        linter:
+          phpmd:
+            suffixes: a,b
+      YAML
     end
   end
 end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -330,33 +330,6 @@ class ProcessorTest < Minitest::Test
     end
   end
 
-  def test_ensure_runner_config_schema_with_expected_fields
-    with_workspace do |workspace|
-      processor = new_processor(workspace: workspace, config_yaml: <<~YAML)
-        linter:
-          eslint:
-            root_dir: app/bar
-      YAML
-      config = processor.ensure_runner_config_schema(Processor::Eslint::Schema.runner_config) { |c| c }
-      assert_equal(
-        {
-          root_dir: "app/bar",
-          npm_install: nil,
-          dir: nil,
-          ext: nil,
-          config: nil,
-          "ignore-path": nil,
-          "ignore-pattern": nil,
-          "no-ignore": nil,
-          global: nil,
-          quiet: nil,
-          options: nil,
-        },
-        config,
-      )
-    end
-  end
-
   def test_abort_capture3
     with_workspace do |workspace|
       processor = new_processor(workspace: workspace)

--- a/test/smokes/phinder/expectations.rb
+++ b/test/smokes/phinder/expectations.rb
@@ -94,11 +94,11 @@ Smoke.add_test(
   warnings: [
     {
       message: <<~MESSAGE,
-    Phinder configuration validation failed.
-    Check the following output by `phinder test` command.
+        Phinder configuration validation failed.
+        Check the following output by `phinder test` command.
 
-    `in_array(2, $arr, false)` does not match the rule sample.in_array_without_3rd_param but should match that rule.
-    `in_array(4, $arr)` matches the rule sample.in_array_without_3rd_param but should not match that rule.
+        `in_array(2, $arr, false)` does not match the rule sample.in_array_without_3rd_param but should match that rule.
+        `in_array(4, $arr)` matches the rule sample.in_array_without_3rd_param but should not match that rule.
   MESSAGE
       file: "phinder.yml"
     }
@@ -112,9 +112,9 @@ Smoke.add_test(
     timestamp: :_,
     type: "failure",
     message: <<~MESSAGE,
-    1 error occurred:
+      1 error occurred:
 
-    InvalidRule: Invalid id value found in 1st rule in phinder.yml
+      InvalidRule: Invalid id value found in 1st rule in phinder.yml
   MESSAGE
     analyzer: { name: "Phinder", version: "0.9.2" }
   }
@@ -162,9 +162,12 @@ Smoke.add_test(
   warnings: [
     {
       message: <<~MESSAGE,
-    File not found: `phinder.yml`. This file is necessary for analysis.
-    See also: https://help.sider.review/tools/php/phinder
-  MESSAGE
+        Sider cannot find the required configuration file(s): `phinder.yml`.
+        Please set up Phinder by following the instructions, or you can disable it in the repository settings.
+
+        - https://github.com/sider/phinder
+        - https://help.sider.review/tools/php/phinder
+      MESSAGE
       file: "phinder.yml"
     }
   ]


### PR DESCRIPTION
Related issue: #750 

This PR removes `#ensure_runner_config_schema` and ensures each runner to use the instance of `Runners::Config`.

Note that I want to rename `ci_section`, but I didn't in this PR.