### PR TITLE
Tool deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - [Goodcheck] Update goodcheck requirement from 2.4.5 to 2.5.0 [#775](https://github.com/sider/runners/pull/775)
 - Add Runners::Config, which is responsible for sider.yml [#763](https://github.com/sider/runners/pull/763)
 - [hadolint] Exclude template files by default [#780](https://github.com/sider/runners/pull/780)
+- [TSLint] Add a deprecation warning [#783](https://github.com/sider/runners/pull/783)
 
 ## 0.20.0
 

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -173,12 +173,12 @@ module Runners
       end
     end
 
-    def add_warning_for_deprecated_linter(alternative:, deadline: nil)
+    def add_warning_for_deprecated_linter(alternative:, ref:, deadline: nil)
       deadline_str = deadline ? deadline.strftime("on %B %-d, %Y") : "in the near future"
       add_warning <<~MSG.strip, file: config.path_name
         DEPRECATION WARNING!!!
         The support for #{analyzer_name} is deprecated. Sider will drop these versions #{deadline_str}.
-        Please consider using an alternative tool #{alternative}.
+        Please consider using an alternative tool #{alternative}. See #{ref}
       MSG
     end
 

--- a/lib/runners/processor/go_vet.rb
+++ b/lib/runners/processor/go_vet.rb
@@ -22,7 +22,9 @@ module Runners
     end
 
     def setup
-      add_warning_for_deprecated_linter(alternative: "GolangCi-Lint", deadline: Time.new(2_020, 3, 31))
+      add_warning_for_deprecated_linter(alternative: "GolangCi-Lint",
+                                        ref: "https://help.sider.review/tools/go/govet",
+                                        deadline: Time.new(2020, 3, 31))
       yield
     end
 

--- a/lib/runners/processor/golint.rb
+++ b/lib/runners/processor/golint.rb
@@ -22,7 +22,9 @@ module Runners
     end
 
     def setup
-      add_warning_for_deprecated_linter(alternative: "GolangCi-Lint", deadline: Time.new(2_020, 3, 31))
+      add_warning_for_deprecated_linter(alternative: "GolangCi-Lint",
+                                        ref: "https://help.sider.review/tools/go/golint",
+                                        deadline: Time.new(2020, 3, 31))
       yield
     end
 

--- a/lib/runners/processor/gometalinter.rb
+++ b/lib/runners/processor/gometalinter.rb
@@ -44,6 +44,10 @@ module Runners
     end
 
     def setup
+      add_warning_for_deprecated_linter(alternative: "GolangCi-Lint",
+                                        ref: "https://github.com/alecthomas/gometalinter/issues/590",
+                                        deadline: Time.new(2020, 3, 31))
+
       with_import_path do |path|
         if path
           trace_writer.message "Copying source files to #{path}" do
@@ -58,7 +62,6 @@ module Runners
         end
       end
 
-      add_warning_for_deprecated_linter(alternative: "GolangCi-Lint", deadline: Time.new(2_020, 3, 31))
       yield
     end
 

--- a/lib/runners/processor/tslint.rb
+++ b/lib/runners/processor/tslint.rb
@@ -41,7 +41,9 @@ module Runners
     end
 
     def setup
-      add_warning_if_deprecated_options([:options], doc: "https://help.sider.review/tools/javascript/tslint")
+      add_warning_for_deprecated_linter(alternative: "ESLint",
+                                        ref: "https://github.com/palantir/tslint/issues/4534",
+                                        deadline: Time.new(2020, 12, 1))
 
       begin
         install_nodejs_deps(DEFAULT_DEPS, constraints: CONSTRAINTS, install_option: ci_section[:npm_install])

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -138,7 +138,7 @@ class Runners::Processor
   def add_warning: (String, ?file: String?) -> void
   def add_warning_if_deprecated_version: (minimum: String, ?file: String?, ?deadline: Time?) -> void
   def add_warning_if_deprecated_options: (Array<Symbol>, doc: String) -> void
-  def add_warning_for_deprecated_linter: (alternative: String, ?deadline: Time?) -> void
+  def add_warning_for_deprecated_linter: (alternative: String, ref: String, ?deadline: Time?) -> void
   def analyzer: -> Analyzer
   def analyzer_name: -> String
   def analyzer_bin: -> String

--- a/test/smokes/go_vet/expectations.rb
+++ b/test/smokes/go_vet/expectations.rb
@@ -21,11 +21,12 @@ Smoke.add_test(
   },
   warnings: [
     {
-      message: <<~MSG.strip,
+      message: <<~MSG
         DEPRECATION WARNING!!!
         The support for go_vet is deprecated. Sider will drop these versions on March 31, 2020.
-        Please consider using an alternative tool GolangCi-Lint.
+        Please consider using an alternative tool GolangCi-Lint. See https://help.sider.review/tools/go/govet
       MSG
+        .strip,
       file: "sider.yml"
     }
   ]

--- a/test/smokes/golint/expectations.rb
+++ b/test/smokes/golint/expectations.rb
@@ -21,11 +21,12 @@ Smoke.add_test(
   },
   warnings: [
     {
-      message: <<~MSG.strip,
+      message: <<~MSG
         DEPRECATION WARNING!!!
         The support for golint is deprecated. Sider will drop these versions on March 31, 2020.
-        Please consider using an alternative tool GolangCi-Lint.
+        Please consider using an alternative tool GolangCi-Lint. See https://help.sider.review/tools/go/golint
       MSG
+        .strip,
       file: "sider.yml"
     }
   ]

--- a/test/smokes/gometalinter/expectations.rb
+++ b/test/smokes/gometalinter/expectations.rb
@@ -7,11 +7,12 @@ Smoke.add_test(
   },
   warnings: [
     {
-      message: <<~MSG.strip,
-          DEPRECATION WARNING!!!
-          The support for gometalinter is deprecated. Sider will drop these versions on March 31, 2020.
-          Please consider using an alternative tool GolangCi-Lint.
+      message: <<~MSG
+        DEPRECATION WARNING!!!
+        The support for gometalinter is deprecated. Sider will drop these versions on March 31, 2020.
+        Please consider using an alternative tool GolangCi-Lint. See https://github.com/alecthomas/gometalinter/issues/590
       MSG
+        .strip,
       file: "sider.yml"
     }
   ]
@@ -36,16 +37,7 @@ Smoke.add_test(
     ],
     analyzer: { name: "gometalinter", version: "2.0.11" }
   },
-  warnings: [
-    {
-      message: <<~MSG.strip,
-          DEPRECATION WARNING!!!
-          The support for gometalinter is deprecated. Sider will drop these versions on March 31, 2020.
-          Please consider using an alternative tool GolangCi-Lint.
-      MSG
-      file: "sideci.yml"
-    }
-  ]
+  warnings: [{ message: /The support for gometalinter is deprecated/, file: "sideci.yml" }]
 )
 
 Smoke.add_test(
@@ -67,16 +59,7 @@ Smoke.add_test(
     ],
     analyzer: { name: "gometalinter", version: "2.0.11" }
   },
-  warnings: [
-    {
-      message: <<~MSG.strip,
-          DEPRECATION WARNING!!!
-          The support for gometalinter is deprecated. Sider will drop these versions on March 31, 2020.
-          Please consider using an alternative tool GolangCi-Lint.
-      MSG
-      file: "sideci.yml"
-    }
-  ]
+  warnings: [{ message: /The support for gometalinter is deprecated/, file: "sideci.yml" }]
 ) { |config| config.ssh_key = "ssh_key" }
 
 Smoke.add_test(
@@ -135,16 +118,7 @@ Smoke.add_test(
     ],
     analyzer: { name: "gometalinter", version: "2.0.11" }
   },
-  warnings: [
-    {
-      message: <<~MSG.strip,
-        DEPRECATION WARNING!!!
-        The support for gometalinter is deprecated. Sider will drop these versions on March 31, 2020.
-        Please consider using an alternative tool GolangCi-Lint.
-      MSG
-      file: "sideci.yml"
-    }
-  ]
+  warnings: [{ message: /The support for gometalinter is deprecated/, file: "sideci.yml" }]
 )
 
 Smoke.add_test(
@@ -153,15 +127,8 @@ Smoke.add_test(
     guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "gometalinter", version: "2.0.11" }
   },
   warnings: [
-    { message: "`install_path` option is deprecated. Use `import_path` instead.", file: "sideci.yml" },
-    {
-      message: <<~MSG.strip,
-        DEPRECATION WARNING!!!
-        The support for gometalinter is deprecated. Sider will drop these versions on March 31, 2020.
-        Please consider using an alternative tool GolangCi-Lint.
-      MSG
-      file: "sideci.yml"
-    }
+    { message: /The support for gometalinter is deprecated/, file: "sideci.yml" },
+    { message: "`install_path` option is deprecated. Use `import_path` instead.", file: "sideci.yml" }
   ]
 )
 
@@ -170,16 +137,7 @@ Smoke.add_test(
   {
     guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "gometalinter", version: "2.0.11" }
   },
-  warnings: [
-    {
-      message: <<~MSG.strip,
-          DEPRECATION WARNING!!!
-          The support for gometalinter is deprecated. Sider will drop these versions on March 31, 2020.
-          Please consider using an alternative tool GolangCi-Lint.
-      MSG
-      file: "sideci.yml"
-    }
-  ]
+  warnings: [{ message: /The support for gometalinter is deprecated/, file: "sideci.yml" }]
 )
 
 Smoke.add_test(
@@ -187,14 +145,5 @@ Smoke.add_test(
   {
     guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "gometalinter", version: "2.0.11" }
   },
-  warnings: [
-    {
-      message: <<~MSG.strip,
-          DEPRECATION WARNING!!!
-          The support for gometalinter is deprecated. Sider will drop these versions on March 31, 2020.
-          Please consider using an alternative tool GolangCi-Lint.
-      MSG
-      file: "sideci.yml"
-    }
-  ]
+  warnings: [{ message: /The support for gometalinter is deprecated/, file: "sideci.yml" }]
 )

--- a/test/smokes/tslint/expectations.rb
+++ b/test/smokes/tslint/expectations.rb
@@ -27,7 +27,8 @@ Smoke.add_test(
       }
     ],
     analyzer: { name: "TSLint", version: "6.0.0" }
-  }
+  },
+  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
 )
 
 Smoke.add_test(
@@ -48,7 +49,8 @@ Smoke.add_test(
       }
     ],
     analyzer: { name: "TSLint", version: "6.0.0" }
-  }
+  },
+  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
 )
 
 Smoke.add_test(
@@ -87,7 +89,8 @@ Smoke.add_test(
       }
     ],
     analyzer: { name: "TSLint", version: "5.2.0" }
-  }
+  },
+  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
 )
 
 Smoke.add_test(
@@ -108,7 +111,8 @@ Smoke.add_test(
       }
     ],
     analyzer: { name: "TSLint", version: "5.4.3" }
-  }
+  },
+  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
 )
 
 Smoke.add_test(
@@ -138,7 +142,8 @@ Smoke.add_test(
       }
     ],
     analyzer: { name: "TSLint", version: "6.0.0" }
-  }
+  },
+  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sideci.yml" }] }
 )
 
 Smoke.add_test(
@@ -161,10 +166,10 @@ Smoke.add_test(
     warnings: [
       {
         message: <<~MSG
-    DEPRECATION WARNING!!!
-    The `$.linter.tslint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-    Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/tslint ).
-  MSG
+          DEPRECATION WARNING!!!
+          The support for TSLint is deprecated. Sider will drop these versions on December 1, 2020.
+          Please consider using an alternative tool ESLint. See https://github.com/palantir/tslint/issues/4534
+        MSG
           .strip,
         file: "sideci.yml"
       }
@@ -208,7 +213,8 @@ Smoke.add_test(
       }
     ],
     analyzer: { name: "TSLint", version: "5.11.0" }
-  }
+  },
+  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sideci.yml" }] }
 )
 
 Smoke.add_test(
@@ -240,7 +246,8 @@ Smoke.add_test(
       }
     ],
     analyzer: { name: "TSLint", version: "5.15.0" }
-  }
+  },
+  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sideci.yml" }] }
 )
 
 Smoke.add_test(
@@ -261,7 +268,8 @@ Smoke.add_test(
       }
     ],
     analyzer: { name: "TSLint", version: "5.15.0" }
-  }
+  },
+  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sideci.yml" }] }
 )
 
 Smoke.add_test(
@@ -291,7 +299,8 @@ Smoke.add_test(
       }
     ],
     analyzer: { name: "TSLint", version: "5.15.0" }
-  }
+  },
+  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sideci.yml" }] }
 )
 
 Smoke.add_test(
@@ -302,19 +311,30 @@ Smoke.add_test(
     type: "failure",
     message: /Your `tslint` settings could not satisfy the required constraints/,
     analyzer: nil
-  }
+  },
+  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
 )
 
 Smoke.add_test(
   "without-tslint-in-package-json",
   { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "TSLint", version: "6.0.0" } },
-  { warnings: [{ message: /No required dependencies for analysis were installed/, file: "package.json" }] }
+  {
+    warnings: [
+      { message: /The support for TSLint is deprecated/, file: "sider.yml" },
+      { message: /No required dependencies for analysis were installed/, file: "package.json" }
+    ]
+  }
 )
 
 Smoke.add_test(
   "without-tslint-and-with-typescript-in-package-json",
   { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "TSLint", version: "6.0.0" } },
-  { warnings: [{ message: /No required dependencies for analysis were installed/, file: "package.json" }] }
+  {
+    warnings: [
+      { message: /The support for TSLint is deprecated/, file: "sider.yml" },
+      { message: /No required dependencies for analysis were installed/, file: "package.json" }
+    ]
+  }
 )
 
 Smoke.add_test(
@@ -325,7 +345,8 @@ Smoke.add_test(
     type: "failure",
     message: "`yarn install` failed. Please confirm `yarn.lock` is consistent with `package.json`.",
     analyzer: nil
-  }
+  },
+  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
 )
 
 Smoke.add_test(
@@ -346,5 +367,6 @@ Smoke.add_test(
       }
     ],
     analyzer: { name: "TSLint", version: "6.0.0" }
-  }
+  },
+  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
 )


### PR DESCRIPTION
- Add `:ref` option (an useful URL) to `#add_warning_for_deprecated_linter` method.
- Add a deprecation warning for TSLint.

Fix #709

