### PR TITLE
Update CI configurations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,9 @@ commands:
       - run:
           name: Bundle install
           command: |
-            gem install bundler
-            bundle install --jobs=4 --retry=3 --path=vendor/bundle
+            gem install bundler --no-document
+            bundle config set path vendor/bundle
+            bundle install --jobs=4 --retry=3
       - save_cache:
           paths:
             - vendor/bundle

--- a/.github/workflows/bump_analyzers.yml
+++ b/.github/workflows/bump_analyzers.yml
@@ -8,13 +8,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-ruby@v1
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: .ruby-version
       - run: |
           gem install bundler --no-document
-          bundle install --jobs=4 --retry=3 --path=vendor/bundle
+          bundle config set path vendor/bundle
+          bundle install --jobs=4 --retry=3
       - run: |
           bundle exec rake bump:analyzers
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:


### PR DESCRIPTION
- GitHub Actions
  - Update [actions/checkout](https://github.com/actions/checkout)
  - Use [ruby/setup-ruby](https://github.com/ruby/setup-ruby) instead of [actions/setup-ruby](https://github.com/actions/setup-ruby)
- Bundler
  - Use `bundle config set` instead of `bundle install --path` option.
    See <https://github.com/rubygems/bundler/blob/master/UPGRADING.md#cli-deprecations>