### PR TITLE
Change deadline for Go tools

### DIFF
--- a/lib/runners/processor/go_vet.rb
+++ b/lib/runners/processor/go_vet.rb
@@ -24,7 +24,7 @@ module Runners
     def setup
       add_warning_for_deprecated_linter(alternative: "GolangCi-Lint",
                                         ref: "https://help.sider.review/tools/go/govet",
-                                        deadline: Time.new(2020, 3, 31))
+                                        deadline: Time.new(2020, 4, 30))
       yield
     end
 

--- a/lib/runners/processor/golint.rb
+++ b/lib/runners/processor/golint.rb
@@ -24,7 +24,7 @@ module Runners
     def setup
       add_warning_for_deprecated_linter(alternative: "GolangCi-Lint",
                                         ref: "https://help.sider.review/tools/go/golint",
-                                        deadline: Time.new(2020, 3, 31))
+                                        deadline: Time.new(2020, 4, 30))
       yield
     end
 

--- a/lib/runners/processor/gometalinter.rb
+++ b/lib/runners/processor/gometalinter.rb
@@ -46,7 +46,7 @@ module Runners
     def setup
       add_warning_for_deprecated_linter(alternative: "GolangCi-Lint",
                                         ref: "https://github.com/alecthomas/gometalinter/issues/590",
-                                        deadline: Time.new(2020, 3, 31))
+                                        deadline: Time.new(2020, 4, 30))
 
       with_import_path do |path|
         if path

--- a/test/smokes/go_vet/expectations.rb
+++ b/test/smokes/go_vet/expectations.rb
@@ -23,7 +23,7 @@ Smoke.add_test(
     {
       message: <<~MSG
         DEPRECATION WARNING!!!
-        The support for go_vet is deprecated. Sider will drop these versions on March 31, 2020.
+        The support for go_vet is deprecated. Sider will drop these versions on April 30, 2020.
         Please consider using an alternative tool GolangCi-Lint. See https://help.sider.review/tools/go/govet
       MSG
         .strip,

--- a/test/smokes/golint/expectations.rb
+++ b/test/smokes/golint/expectations.rb
@@ -23,7 +23,7 @@ Smoke.add_test(
     {
       message: <<~MSG
         DEPRECATION WARNING!!!
-        The support for golint is deprecated. Sider will drop these versions on March 31, 2020.
+        The support for golint is deprecated. Sider will drop these versions on April 30, 2020.
         Please consider using an alternative tool GolangCi-Lint. See https://help.sider.review/tools/go/golint
       MSG
         .strip,

--- a/test/smokes/gometalinter/expectations.rb
+++ b/test/smokes/gometalinter/expectations.rb
@@ -9,7 +9,7 @@ Smoke.add_test(
     {
       message: <<~MSG
         DEPRECATION WARNING!!!
-        The support for gometalinter is deprecated. Sider will drop these versions on March 31, 2020.
+        The support for gometalinter is deprecated. Sider will drop these versions on April 30, 2020.
         Please consider using an alternative tool GolangCi-Lint. See https://github.com/alecthomas/gometalinter/issues/590
       MSG
         .strip,


### PR DESCRIPTION
This changes the deadline from `2020-03-31` to `2020-04-30`.

See also #767