### PR TITLE
Auto-generated README content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
       - run: bundle exec rake typecheck
       - run: bundle exec rake dockerfile:generate
       - run: bundle exec rake dockerfile:verify
+      - run: bundle exec rake readme:generate
   timeout_test:
     docker:
       - image: circleci/ruby:2.6.5

--- a/README.md
+++ b/README.md
@@ -8,44 +8,44 @@ See also another related project, called [devon_rex](https://github.com/sider/de
 
 ## Supported analyzers
 
-All analyzers are provided as a Docker image.
+<!-- AUTO-GENERATED-CONTENT:START (analyzers) -->
+All 34 analyzers are provided as a Docker image:
 
-*(in alphabetical order)*
-
-- [Brakeman](https://hub.docker.com/r/sider/runner_brakeman)
-- [Checkstyle](https://hub.docker.com/r/sider/runner_checkstyle)
-- [CoffeeLint](https://hub.docker.com/r/sider/runner_coffeelint)
-- [Cppcheck](https://hub.docker.com/r/sider/runner_cppcheck)
-- [cpplint](https://hub.docker.com/r/sider/runner_cpplint)
-- [detekt](https://hub.docker.com/r/sider/runner_detekt)
-- [ESLint](https://hub.docker.com/r/sider/runner_eslint)
-- [Flake8](https://hub.docker.com/r/sider/runner_flake8)
-- [FxCop](https://hub.docker.com/r/sider/runner_fxcop)
-- [go vet](https://hub.docker.com/r/sider/runner_go_vet)
-- [GolangCI-Lint](https://hub.docker.com/r/sider/runner_golangcli_lint)
-- [Golint](https://hub.docker.com/r/sider/runner_golint)
-- [Go Meta Linter](https://hub.docker.com/r/sider/runner_gometalinter)
-- [Goodcheck](https://hub.docker.com/r/sider/runner_goodcheck)
-- [hadolint](https://hub.docker.com/r/sider/runner_hadolint)
-- [HAML-Lint](https://hub.docker.com/r/sider/runner_haml_lint)
-- [JSHint](https://hub.docker.com/r/sider/runner_jshint)
-- [JavaSee](https://hub.docker.com/r/sider/runner_javasee)
-- [ktlint](https://hub.docker.com/r/sider/runner_ktlint)
-- [Misspell](https://hub.docker.com/r/sider/runner_misspell)
-- [PHPMD](https://hub.docker.com/r/sider/runner_phpmd)
-- [PHP_CodeSniffer](https://hub.docker.com/r/sider/runner_code_sniffer)
-- [PMD Java](https://hub.docker.com/r/sider/runner_pmd_java)
-- [Phinder](https://hub.docker.com/r/sider/runner_phinder)
-- [Querly](https://hub.docker.com/r/sider/runner_querly)
-- [Rails Best Practices](https://hub.docker.com/r/sider/runner_rails_best_practices)
-- [Reek](https://hub.docker.com/r/sider/runner_reek)
-- [RuboCop](https://hub.docker.com/r/sider/runner_rubocop)
-- [SCSS-Lint](https://hub.docker.com/r/sider/runner_scss_lint)
-- [ShellCheck](https://hub.docker.com/r/sider/runner_shellcheck)
-- [stylelint](https://hub.docker.com/r/sider/runner_stylelint)
-- [SwiftLint](https://hub.docker.com/r/sider/runner_swiftlint)
-- [TSLint](https://hub.docker.com/r/sider/runner_tslint)
-- [TyScan](https://hub.docker.com/r/sider/runner_tyscan)
+- Brakeman ([docker](https://hub.docker.com/r/sider/runner_brakeman), [source](https://github.com/presidentbeef/brakeman), [doc](tools/ruby/brakeman))
+- Checkstyle ([docker](https://hub.docker.com/r/sider/runner_checkstyle), [source](https://github.com/checkstyle/checkstyle), [doc](tools/java/checkstyle))
+- PHP_CodeSniffer ([docker](https://hub.docker.com/r/sider/runner_code_sniffer), [source](https://github.com/squizlabs/PHP_CodeSniffer), [doc](tools/php/codesniffer))
+- CoffeeLint ([docker](https://hub.docker.com/r/sider/runner_coffeelint), [source](https://github.com/clutchski/coffeelint), [doc](tools/javascript/coffeelint))
+- Cppcheck ([docker](https://hub.docker.com/r/sider/runner_cppcheck), [source](https://github.com/danmar/cppcheck), [doc](tools/cplusplus/cppcheck))
+- cpplint ([docker](https://hub.docker.com/r/sider/runner_cpplint), [source](https://github.com/cpplint/cpplint), [doc](tools/cplusplus/cpplint))
+- detekt ([docker](https://hub.docker.com/r/sider/runner_detekt), [source](https://github.com/arturbosch/detekt), [doc](tools/kotlin/detekt))
+- ESLint ([docker](https://hub.docker.com/r/sider/runner_eslint), [source](https://github.com/eslint/eslint), [doc](tools/javascript/eslint))
+- Flake8 ([docker](https://hub.docker.com/r/sider/runner_flake8), [source](https://github.com/PyCQA/flake8), [doc](tools/python/flake8))
+- FxCop ([docker](https://hub.docker.com/r/sider/runner_fxcop), [source](https://github.com/dotnet/roslyn-analyzers), [doc](tools/csharp/fxcop))
+- go vet ([docker](https://hub.docker.com/r/sider/runner_go_vet), [website](https://golang.org/cmd/vet), [doc](tools/go/govet)) *deprecated*
+- GolangCI-Lint ([docker](https://hub.docker.com/r/sider/runner_golangci_lint), [source](https://github.com/golangci/golangci-lint), [doc](tools/go/golangci-lint))
+- Golint ([docker](https://hub.docker.com/r/sider/runner_golint), [source](https://github.com/golang/lint), [doc](tools/go/golint)) *deprecated*
+- Go Meta Linter ([docker](https://hub.docker.com/r/sider/runner_gometalinter), [source](https://github.com/alecthomas/gometalinter), [doc](tools/go/gometalinter)) *deprecated*
+- Goodcheck ([docker](https://hub.docker.com/r/sider/runner_goodcheck), [source](https://github.com/sider/goodcheck), [doc](tools/others/goodcheck))
+- hadolint ([docker](https://hub.docker.com/r/sider/runner_hadolint), [source](https://github.com/hadolint/hadolint), [doc](tools/dockerfile/hadolint))
+- HAML-Lint ([docker](https://hub.docker.com/r/sider/runner_haml_lint), [source](https://github.com/sds/haml-lint), [doc](tools/ruby/haml-lint))
+- JavaSee ([docker](https://hub.docker.com/r/sider/runner_javasee), [source](https://github.com/sider/JavaSee), [doc](tools/java/javasee))
+- JSHint ([docker](https://hub.docker.com/r/sider/runner_jshint), [source](https://github.com/jshint/jshint), [doc](tools/javascript/jshint))
+- ktlint ([docker](https://hub.docker.com/r/sider/runner_ktlint), [source](https://github.com/pinterest/ktlint), [doc](tools/kotlin/ktlint))
+- Misspell ([docker](https://hub.docker.com/r/sider/runner_misspell), [source](https://github.com/client9/misspell), [doc](tools/others/misspell))
+- Phinder ([docker](https://hub.docker.com/r/sider/runner_phinder), [source](https://github.com/sider/phinder), [doc](tools/php/phinder))
+- PHPMD ([docker](https://hub.docker.com/r/sider/runner_phpmd), [source](https://github.com/phpmd/phpmd), [doc](tools/php/phpmd))
+- PMD Java ([docker](https://hub.docker.com/r/sider/runner_pmd_java), [source](https://github.com/pmd/pmd), [doc](tools/java/pmd))
+- Querly ([docker](https://hub.docker.com/r/sider/runner_querly), [source](https://github.com/soutaro/querly), [doc](tools/ruby/querly))
+- Rails Best Practices ([docker](https://hub.docker.com/r/sider/runner_rails_best_practices), [source](https://github.com/flyerhzm/rails_best_practices), [doc](tools/ruby/rails-bestpractices))
+- Reek ([docker](https://hub.docker.com/r/sider/runner_reek), [source](https://github.com/troessner/reek), [doc](tools/ruby/reek))
+- RuboCop ([docker](https://hub.docker.com/r/sider/runner_rubocop), [source](https://github.com/rubocop-hq/rubocop), [doc](tools/ruby/rubocop))
+- SCSS-Lint ([docker](https://hub.docker.com/r/sider/runner_scss_lint), [source](https://github.com/sds/scss-lint), [doc](tools/css/scss-lint))
+- ShellCheck ([docker](https://hub.docker.com/r/sider/runner_shellcheck), [source](https://github.com/koalaman/shellcheck), [doc](tools/shellscript/shellcheck))
+- stylelint ([docker](https://hub.docker.com/r/sider/runner_stylelint), [source](https://github.com/stylelint/stylelint), [doc](tools/css/stylelint))
+- SwiftLint ([docker](https://hub.docker.com/r/sider/runner_swiftlint), [source](https://github.com/realm/SwiftLint), [doc](tools/swift/swiftlint))
+- TSLint ([docker](https://hub.docker.com/r/sider/runner_tslint), [source](https://github.com/palantir/tslint), [doc](tools/javascript/tslint))
+- TyScan ([docker](https://hub.docker.com/r/sider/runner_tyscan), [source](https://github.com/sider/TyScan), [doc](tools/javascript/tyscan))
+<!-- AUTO-GENERATED-CONTENT:END (analyzers) -->
 
 ## Developer guide
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require "aufgaben/bump/ruby"
 require_relative "lib/tasks/bump/analyzers"
 require_relative "lib/tasks/bump/devon_rex"
 require_relative "lib/tasks/docker/timeout_test"
+require_relative "lib/tasks/readme/generate"
 
 Aufgaben::Release.new do |t|
   t.files = ["lib/runners/version.rb"]

--- a/docs/how-to-write-a-new-runner.md
+++ b/docs/how-to-write-a-new-runner.md
@@ -33,6 +33,8 @@ Please follow the naming rules below:
 
 In the following examples, assume that the defined runner ID is `foolint`.
 
+After defining a ID, you should add also metadata of the runner into [`analyzers.yml`](../analyzers.yml).
+
 ### Create a runner image
 
 Next, let's create a Docker image for the runner.

--- a/lib/tasks/readme/generate.rb
+++ b/lib/tasks/readme/generate.rb
@@ -12,7 +12,7 @@ namespace :readme do
       links << "[docker](https://hub.docker.com/r/sider/runner_#{id})"
       links << "[source](https://github.com/#{analyzer.fetch(:github)})" if analyzer.key?(:github)
       links << "[website](#{analyzer.fetch(:website)})" if analyzer.key?(:website)
-      links << "[doc](#{analyzer.fetch(:doc)})"
+      links << "[doc](#{analyzer.fetch(:doc)})" if analyzer.key?(:doc)
 
       item = "- #{analyzer.fetch(:name)}"
       item += " (#{links.join(', ')})" unless links.empty?

--- a/lib/tasks/readme/generate.rb
+++ b/lib/tasks/readme/generate.rb
@@ -1,0 +1,49 @@
+require "yaml"
+
+namespace :readme do
+  desc "Generate README file"
+  task :generate do
+    root = Pathname(__dir__).join("../../..")
+
+    analyzers = YAML.safe_load(root.join("analyzers.yml").read, symbolize_names: true).fetch(:analyzers)
+
+    list = analyzers.map do |id, analyzer|
+      links = []
+      links << "[docker](https://hub.docker.com/r/sider/runner_#{id})"
+      links << "[source](https://github.com/#{analyzer.fetch(:github)})" if analyzer.key?(:github)
+      links << "[website](#{analyzer.fetch(:website)})" if analyzer.key?(:website)
+      links << "[doc](#{analyzer.fetch(:doc)})"
+
+      item = "- #{analyzer.fetch(:name)}"
+      item += " (#{links.join(', ')})" unless links.empty?
+      item += " *deprecated*" if analyzer[:deprecated]
+      item
+    end
+
+    generated_content = <<~MARKDOWN
+      All #{analyzers.size} analyzers are provided as a Docker image:
+
+      #{list.join("\n")}
+    MARKDOWN
+
+    start_tag = "<!-- AUTO-GENERATED-CONTENT:START (analyzers) -->"
+    end_tag = "<!-- AUTO-GENERATED-CONTENT:END (analyzers) -->"
+
+    readme = root.join("README.md")
+    new_content = readme.read.sub(
+      /#{Regexp.escape start_tag}.+#{Regexp.escape end_tag}/m,
+      "#{start_tag}\n#{generated_content}#{end_tag}"
+    )
+    readme.write(new_content)
+
+    if system("git", "diff", "--exit-code", readme.to_path)
+      puts "No changes on #{readme.relative_path_from(root)}."
+    else
+      abort <<~MSG
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        ERROR: Changes found on #{readme.relative_path_from(root)}. You should commit the changes.
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      MSG
+    end
+  end
+end


### PR DESCRIPTION
This adds a new rake task `readme:generate` via the metadata in `analyzers.yml`.
The new task is executed on CI, so we will not need to maintain the analyzers list on `README.md`.

See also #805 