### PR TITLE
Fix Ruby warning

### DIFF
--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -37,7 +37,9 @@ module Runners
         #       This logic assumes that each subclass has its `#analyze` method.
         source_file, _ = cls.instance_method(:analyze).source_location
         analyzer_id_from_filename = File.basename(source_file, ".rb")
-        cls.define_method(:analyzer_id) { analyzer_id_from_filename }
+        unless cls.method_defined?(:analyzer_id)
+          cls.define_method(:analyzer_id) { analyzer_id_from_filename }
+        end
 
         analyzer == analyzer_id_from_filename
       end or raise "Not found processor class with '#{analyzer}'")

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -52,9 +52,8 @@ module Runners
       @analyzers ||= Analyzers.new
     end
 
-    def analyzer_id
-      raise NotImplementedError, "`#{self.class}##{__method__}` should be defined dynamically"
-    end
+    # NOTE: This method should be defined dynamically.
+    # def analyzer_id; end
 
     def analyzer_name
       analyzers.name(analyzer_id)

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -40,6 +40,7 @@ extension Module (Polyfill)
   def name: -> String
   def instance_method: (Symbol) -> UnboundMethod
   def define_method: (Symbol) { () -> any } -> Symbol
+  def method_defined?: (Symbol, ?bool) -> bool
 end
 
 extension String (Polyfill)

--- a/test/processor/phpmd_test.rb
+++ b/test/processor/phpmd_test.rb
@@ -10,7 +10,9 @@ class Runners::Processor::PhpmdTest < Minitest::Test
   end
 
   def subject(workspace, yaml: nil)
-    Phpmd.new(guid: SecureRandom.uuid, workspace: workspace, config: config(yaml), git_ssh_path: nil, trace_writer: trace_writer)
+    Phpmd.new(guid: SecureRandom.uuid, workspace: workspace, config: config(yaml), git_ssh_path: nil, trace_writer: trace_writer).tap do |s|
+      stub(s).analyzer_id { "phpmd" }
+    end
   end
 
   def test_target_files


### PR DESCRIPTION
These warnings are raised only on unit tests.

> lib/runners/cli.rb:40: warning: method redefined; discarding old analyzer_id
> lib/runners/cli.rb:40: warning: previous definition of analyzer_id was here