### PR TITLE
Fix Bundler warnings

### DIFF
--- a/images/Dockerfile.base.erb
+++ b/images/Dockerfile.base.erb
@@ -3,8 +3,8 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=<%= chown %> Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list

--- a/images/Dockerfile.ruby.erb
+++ b/images/Dockerfile.ruby.erb
@@ -4,8 +4,10 @@ RUN cd ${RUNNER_USER_HOME} && \
     mkdir <%= analyzer %> && \
     mv <%= analyzer %>_Gemfile <%= analyzer %>/Gemfile && \
     cd <%= analyzer %> && \
-    bundle install --system --gemfile=Gemfile && \
+    bundle config set --local system 'true' && \
+    bundle install --gemfile=Gemfile && \
+    bundle config unset --local system && \
     rbenv rehash && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf <%= analyzer %> && \
-    gem list <%= analyzer %>
+    gem info <%= analyzer %>

--- a/images/brakeman/Dockerfile
+++ b/images/brakeman/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/brakeman/Gemfile ${RUNNER_USER_HOME}/brakeman_Gemfile
@@ -22,11 +22,13 @@ RUN cd ${RUNNER_USER_HOME} && \
     mkdir brakeman && \
     mv brakeman_Gemfile brakeman/Gemfile && \
     cd brakeman && \
-    bundle install --system --gemfile=Gemfile && \
+    bundle config set --local system 'true' && \
+    bundle install --gemfile=Gemfile && \
+    bundle config unset --local system && \
     rbenv rehash && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf brakeman && \
-    gem list brakeman
+    gem info brakeman
 
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin

--- a/images/checkstyle/Dockerfile
+++ b/images/checkstyle/Dockerfile
@@ -25,11 +25,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin

--- a/images/code_sniffer/Dockerfile
+++ b/images/code_sniffer/Dockerfile
@@ -21,11 +21,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin

--- a/images/coffeelint/Dockerfile
+++ b/images/coffeelint/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/coffeelint/package.json ${RUNNER_USER_HOME}/coffeelint_package.json

--- a/images/cppcheck/Dockerfile
+++ b/images/cppcheck/Dockerfile
@@ -31,11 +31,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin

--- a/images/cpplint/Dockerfile
+++ b/images/cpplint/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/cpplint/Pipfile ${RUNNER_USER_HOME}/cpplint_Pipfile

--- a/images/detekt/Dockerfile
+++ b/images/detekt/Dockerfile
@@ -26,11 +26,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin

--- a/images/eslint/Dockerfile
+++ b/images/eslint/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/eslint/package.json ${RUNNER_USER_HOME}/eslint_package.json

--- a/images/flake8/Dockerfile
+++ b/images/flake8/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/flake8/Pipfile ${RUNNER_USER_HOME}/flake8_Pipfile

--- a/images/fxcop/Dockerfile
+++ b/images/fxcop/Dockerfile
@@ -11,11 +11,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # cache target analyzer
 USER $RUNNER_USER

--- a/images/go_vet/Dockerfile
+++ b/images/go_vet/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 ARG LINT_TOOL_VERSION="3.0.0"
 

--- a/images/golangci_lint/Dockerfile
+++ b/images/golangci_lint/Dockerfile
@@ -18,11 +18,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 COPY --chown=analyzer_runner:nogroup images/golangci_lint/sider_golangci.yml ${RUNNER_USER_HOME}/
 
 # Copy the main source code

--- a/images/golint/Dockerfile
+++ b/images/golint/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 ARG LINT_TOOL_VERSION="3.0.0"
 

--- a/images/gometalinter/Dockerfile
+++ b/images/gometalinter/Dockerfile
@@ -22,11 +22,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 COPY --chown=analyzer_runner:nogroup images/gometalinter/gometalinter.json ${RUNNER_USER_HOME}/
 

--- a/images/goodcheck/Dockerfile
+++ b/images/goodcheck/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/goodcheck/Gemfile ${RUNNER_USER_HOME}/goodcheck_Gemfile
@@ -22,11 +22,13 @@ RUN cd ${RUNNER_USER_HOME} && \
     mkdir goodcheck && \
     mv goodcheck_Gemfile goodcheck/Gemfile && \
     cd goodcheck && \
-    bundle install --system --gemfile=Gemfile && \
+    bundle config set --local system 'true' && \
+    bundle install --gemfile=Gemfile && \
+    bundle config unset --local system && \
     rbenv rehash && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf goodcheck && \
-    gem list goodcheck
+    gem info goodcheck
 
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin

--- a/images/hadolint/Dockerfile
+++ b/images/hadolint/Dockerfile
@@ -20,11 +20,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin

--- a/images/haml_lint/Dockerfile
+++ b/images/haml_lint/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/haml_lint/Gemfile ${RUNNER_USER_HOME}/haml_lint_Gemfile
@@ -22,11 +22,13 @@ RUN cd ${RUNNER_USER_HOME} && \
     mkdir haml_lint && \
     mv haml_lint_Gemfile haml_lint/Gemfile && \
     cd haml_lint && \
-    bundle install --system --gemfile=Gemfile && \
+    bundle config set --local system 'true' && \
+    bundle install --gemfile=Gemfile && \
+    bundle config unset --local system && \
     rbenv rehash && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf haml_lint && \
-    gem list haml_lint
+    gem info haml_lint
 
 COPY --chown=analyzer_runner:nogroup images/haml_lint/default_rubocop.yml ${RUNNER_USER_HOME}/
 

--- a/images/javasee/Dockerfile
+++ b/images/javasee/Dockerfile
@@ -22,11 +22,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin

--- a/images/jshint/Dockerfile
+++ b/images/jshint/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/jshint/package.json ${RUNNER_USER_HOME}/jshint_package.json

--- a/images/ktlint/Dockerfile
+++ b/images/ktlint/Dockerfile
@@ -25,11 +25,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin

--- a/images/misspell/Dockerfile
+++ b/images/misspell/Dockerfile
@@ -18,11 +18,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin

--- a/images/phinder/Dockerfile
+++ b/images/phinder/Dockerfile
@@ -14,11 +14,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin

--- a/images/phpmd/Dockerfile
+++ b/images/phpmd/Dockerfile
@@ -14,11 +14,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 COPY --chown=analyzer_runner:nogroup images/phpmd/sider_config.xml ${RUNNER_USER_HOME}/
 

--- a/images/pmd_java/Dockerfile
+++ b/images/pmd_java/Dockerfile
@@ -22,11 +22,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 COPY images/pmd_java/pmd /usr/local/bin/
 

--- a/images/querly/Dockerfile
+++ b/images/querly/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/querly/Gemfile ${RUNNER_USER_HOME}/querly_Gemfile
@@ -22,11 +22,13 @@ RUN cd ${RUNNER_USER_HOME} && \
     mkdir querly && \
     mv querly_Gemfile querly/Gemfile && \
     cd querly && \
-    bundle install --system --gemfile=Gemfile && \
+    bundle config set --local system 'true' && \
+    bundle install --gemfile=Gemfile && \
+    bundle config unset --local system && \
     rbenv rehash && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf querly && \
-    gem list querly
+    gem info querly
 
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin

--- a/images/rails_best_practices/Dockerfile
+++ b/images/rails_best_practices/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/rails_best_practices/Gemfile ${RUNNER_USER_HOME}/rails_best_practices_Gemfile
@@ -22,11 +22,13 @@ RUN cd ${RUNNER_USER_HOME} && \
     mkdir rails_best_practices && \
     mv rails_best_practices_Gemfile rails_best_practices/Gemfile && \
     cd rails_best_practices && \
-    bundle install --system --gemfile=Gemfile && \
+    bundle config set --local system 'true' && \
+    bundle install --gemfile=Gemfile && \
+    bundle config unset --local system && \
     rbenv rehash && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf rails_best_practices && \
-    gem list rails_best_practices
+    gem info rails_best_practices
 
 # For backward compatibility
 RUN gem install require_all:1.5.0

--- a/images/reek/Dockerfile
+++ b/images/reek/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/reek/Gemfile ${RUNNER_USER_HOME}/reek_Gemfile
@@ -22,11 +22,13 @@ RUN cd ${RUNNER_USER_HOME} && \
     mkdir reek && \
     mv reek_Gemfile reek/Gemfile && \
     cd reek && \
-    bundle install --system --gemfile=Gemfile && \
+    bundle config set --local system 'true' && \
+    bundle install --gemfile=Gemfile && \
+    bundle config unset --local system && \
     rbenv rehash && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf reek && \
-    gem list reek
+    gem info reek
 
 COPY --chown=analyzer_runner:nogroup images/reek/v5.reek.yml ${RUNNER_USER_HOME}/.reek.yml
 COPY --chown=analyzer_runner:nogroup images/reek/v4.reek.yml ${RUNNER_USER_HOME}/config.reek

--- a/images/rubocop/Dockerfile
+++ b/images/rubocop/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/rubocop/Gemfile ${RUNNER_USER_HOME}/rubocop_Gemfile
@@ -22,11 +22,13 @@ RUN cd ${RUNNER_USER_HOME} && \
     mkdir rubocop && \
     mv rubocop_Gemfile rubocop/Gemfile && \
     cd rubocop && \
-    bundle install --system --gemfile=Gemfile && \
+    bundle config set --local system 'true' && \
+    bundle install --gemfile=Gemfile && \
+    bundle config unset --local system && \
     rbenv rehash && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf rubocop && \
-    gem list rubocop
+    gem info rubocop
 
 COPY --chown=analyzer_runner:nogroup images/rubocop/default_rubocop.yml ${RUNNER_USER_HOME}/
 

--- a/images/scss_lint/Dockerfile
+++ b/images/scss_lint/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/scss_lint/Gemfile ${RUNNER_USER_HOME}/scss_lint_Gemfile
@@ -22,11 +22,13 @@ RUN cd ${RUNNER_USER_HOME} && \
     mkdir scss_lint && \
     mv scss_lint_Gemfile scss_lint/Gemfile && \
     cd scss_lint && \
-    bundle install --system --gemfile=Gemfile && \
+    bundle config set --local system 'true' && \
+    bundle install --gemfile=Gemfile && \
+    bundle config unset --local system && \
     rbenv rehash && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf scss_lint && \
-    gem list scss_lint
+    gem info scss_lint
 
 COPY --chown=analyzer_runner:nogroup images/scss_lint/scss-lint.default.yml ${RUNNER_USER_HOME}/.scss-lint.yml
 

--- a/images/shellcheck/Dockerfile
+++ b/images/shellcheck/Dockerfile
@@ -32,11 +32,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin

--- a/images/stylelint/Dockerfile
+++ b/images/stylelint/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/stylelint/package.json ${RUNNER_USER_HOME}/stylelint_package.json

--- a/images/swiftlint/Dockerfile
+++ b/images/swiftlint/Dockerfile
@@ -22,11 +22,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Copy the main source code
 COPY --chown=analyzer_runner:nogroup bin ${RUNNERS_DIR}/bin

--- a/images/tslint/Dockerfile
+++ b/images/tslint/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/tslint/package.json ${RUNNER_USER_HOME}/tslint_package.json

--- a/images/tyscan/Dockerfile
+++ b/images/tyscan/Dockerfile
@@ -10,11 +10,11 @@ ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 # Install required gems first (due to slow download)
 COPY --chown=analyzer_runner:nogroup Gemfile* analyzers.yml ${RUNNERS_DIR}/
 RUN cd ${RUNNERS_DIR} && \
-    bundle config --global jobs 4 && \
-    bundle config --global retry 3 && \
-    bundle config --local without development:test && \
+    bundle config set --global jobs 4 && \
+    bundle config set --global retry 3 && \
     bundle config && \
-    bundle install
+    BUNDLE_WITHOUT=development:test bundle install && \
+    bundle list
 
 # Install the default version
 COPY --chown=analyzer_runner:nogroup images/tyscan/package.json ${RUNNER_USER_HOME}/tyscan_package.json

--- a/lib/runners/ruby/gem_installer.rb
+++ b/lib/runners/ruby/gem_installer.rb
@@ -29,7 +29,7 @@ module Runners
 
         trace_writer.header "Installing gems..."
 
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           shell.push_dir gem_home do
             shell.capture3!("bundle", "install")
             shell.capture3!("bundle", "list")

--- a/lib/runners/ruby/lockfile_loader.rb
+++ b/lib/runners/ruby/lockfile_loader.rb
@@ -45,7 +45,7 @@ module Runners
       def generate_lockfile(lockfile_path)
         shell.trace_writer.message "By using detected Gemfile, generating Gemfile.lock..."
 
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           shell.push_env_hash({ "BUNDLE_GEMFILE" => gemfile_path.to_s }) do
             shell.capture3! "bundle", "lock", "--lockfile", lockfile_path.to_s
             return lockfile_path.read.tap do |content|

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -227,7 +227,7 @@ gem 'jack_and_the_elastic_beanstalk', git: 'https://github.com/sider/jack_and_th
 EOF
 
       shell.push_dir(path) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           shell.capture3!("bundle", "lock")
         end
       end
@@ -516,7 +516,7 @@ gem 'meowcop'
 EOF
 
       shell.push_dir(workspace.working_dir) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           shell.capture3!("bundle", "lock")
         end
       end
@@ -564,7 +564,7 @@ gem 'meowcop'
 EOF
 
       shell.push_dir(workspace.working_dir) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           shell.capture3!("bundle", "lock")
         end
       end
@@ -593,7 +593,7 @@ gem 'activerecord'
 EOF
 
       shell.push_dir(workspace.working_dir) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           shell.capture3!("bundle", "lock")
         end
       end
@@ -630,7 +630,7 @@ gem 'rubocop', '0.62.0'
 EOF
 
       shell.push_dir(workspace.working_dir) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           shell.capture3!("bundle", "lock")
         end
       end


### PR DESCRIPTION
Bundler 2 outputs some deprecation warnings toward the version 3 release.
(see <https://github.com/rubygems/bundler/blob/master/UPGRADING.md>)

- Fix the deprecated API usage such as `Bundler.with_clean_env`.
- Fix the deprecated CLI options such as `--system`.

Fix #741