### PR TITLE
[GolangCI-Lint] Warn no Go files instead of failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.21.0...HEAD)
 
+- [GolangCI-Lint] Warn no Go files instead of failing [#815](https://github.com/sider/runners/pull/815)
+
 ## 0.21.0
 
 [Full diff](https://github.com/sider/runners/compare/0.20.0...0.21.0)

--- a/lib/runners/processor/golangci_lint.rb
+++ b/lib/runners/processor/golangci_lint.rb
@@ -67,7 +67,8 @@ module Runners
       end
 
       if status.exitstatus == 5
-        return Results::Failure.new(guid: guid, analyzer: analyzer, message: "No go files to analyze")
+        add_warning "No Go files to analyze"
+        return Results::Success.new(guid: guid, analyzer: analyzer)
       end
 
       Results::Failure.new(guid: guid, analyzer: analyzer, message: "Running error")

--- a/test/smokes/golangci_lint/expectations.rb
+++ b/test/smokes/golangci_lint/expectations.rb
@@ -79,10 +79,11 @@ Smoke.add_test(
   {
     guid: "test-guid",
     timestamp: :_,
-    type: "failure",
-    message: "No go files to analyze",
+    type: "success",
+    issues: [],
     analyzer: { name: "GolangCI-Lint", version: "1.23.6" }
-  }
+  },
+  { warnings: [{ message: "No Go files to analyze", file: nil }] }
 )
 
 Smoke.add_test(


### PR DESCRIPTION
Making it a failure is too strict.