### PR TITLE
Fix typo for GolangCI-Lint

### DIFF
--- a/lib/runners/processor/go_vet.rb
+++ b/lib/runners/processor/go_vet.rb
@@ -13,7 +13,7 @@ module Runners
     end
 
     def setup
-      add_warning_for_deprecated_linter(alternative: "GolangCi-Lint",
+      add_warning_for_deprecated_linter(alternative: analyzers.name(:golangci_lint),
                                         ref: analyzer_doc,
                                         deadline: Time.new(2020, 4, 30))
       yield

--- a/lib/runners/processor/golint.rb
+++ b/lib/runners/processor/golint.rb
@@ -13,7 +13,7 @@ module Runners
     end
 
     def setup
-      add_warning_for_deprecated_linter(alternative: "GolangCi-Lint",
+      add_warning_for_deprecated_linter(alternative: analyzers.name(:golangci_lint),
                                         ref: analyzer_doc,
                                         deadline: Time.new(2020, 4, 30))
       yield

--- a/lib/runners/processor/gometalinter.rb
+++ b/lib/runners/processor/gometalinter.rb
@@ -31,7 +31,7 @@ module Runners
     register_config_schema(name: :gometalinter, schema: Schema.runner_config)
 
     def setup
-      add_warning_for_deprecated_linter(alternative: "GolangCi-Lint",
+      add_warning_for_deprecated_linter(alternative: analyzers.name(:golangci_lint),
                                         ref: "https://github.com/alecthomas/gometalinter/issues/590",
                                         deadline: Time.new(2020, 4, 30))
 

--- a/test/smokes/go_vet/expectations.rb
+++ b/test/smokes/go_vet/expectations.rb
@@ -24,7 +24,7 @@ Smoke.add_test(
       message: <<~MSG
         DEPRECATION WARNING!!!
         The support for go vet is deprecated. Sider will drop these versions on April 30, 2020.
-        Please consider using an alternative tool GolangCi-Lint. See https://help.sider.review/tools/go/govet
+        Please consider using an alternative tool GolangCI-Lint. See https://help.sider.review/tools/go/govet
       MSG
         .strip,
       file: "sider.yml"

--- a/test/smokes/golint/expectations.rb
+++ b/test/smokes/golint/expectations.rb
@@ -24,7 +24,7 @@ Smoke.add_test(
       message: <<~MSG
         DEPRECATION WARNING!!!
         The support for Golint is deprecated. Sider will drop these versions on April 30, 2020.
-        Please consider using an alternative tool GolangCi-Lint. See https://help.sider.review/tools/go/golint
+        Please consider using an alternative tool GolangCI-Lint. See https://help.sider.review/tools/go/golint
       MSG
         .strip,
       file: "sider.yml"

--- a/test/smokes/gometalinter/expectations.rb
+++ b/test/smokes/gometalinter/expectations.rb
@@ -14,7 +14,7 @@ Smoke.add_test(
       message: <<~MSG
         DEPRECATION WARNING!!!
         The support for Go Meta Linter is deprecated. Sider will drop these versions on April 30, 2020.
-        Please consider using an alternative tool GolangCi-Lint. See https://github.com/alecthomas/gometalinter/issues/590
+        Please consider using an alternative tool GolangCI-Lint. See https://github.com/alecthomas/gometalinter/issues/590
       MSG
         .strip,
       file: "sider.yml"


### PR DESCRIPTION
"GolangCi-Lint" -> "GolangCI-Lint"