### PR TITLE
Add raw content of config file to trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.21.1...HEAD)
 
 - More kindful error message on invalid configuration [#818](https://github.com/sider/runners/pull/818)
+- Add raw content of config file to trace [#819](https://github.com/sider/runners/pull/819)
 
 ## 0.21.1
 

--- a/lib/runners/config.rb
+++ b/lib/runners/config.rb
@@ -1,25 +1,30 @@
 module Runners
   class Config
-    class Error < UserError; end
-    class BrokenYAML < Error; end
-    class InvalidConfiguration < Error
-      attr_reader :input_string
+    class Error < UserError
+      attr_reader :raw_content
 
-      def initialize(message, input_string)
+      def initialize(message, raw_content)
         super(message)
-        @input_string = input_string
+        @raw_content = raw_content
       end
     end
+
+    class BrokenYAML < Error; end
+    class InvalidConfiguration < Error; end
 
     CONFIG_FILE_NAME = "sider.yml".freeze
     OLD_CONFIG_FILE_NAME = "sideci.yml".freeze
 
-    attr_reader :working_dir, :input_string, :content
+    attr_reader :working_dir, :raw_content, :content
 
     def initialize(working_dir)
       @working_dir = working_dir
-      @input_string = path&.read
+      @raw_content = path&.read
       @content = check_schema(parse_yaml).freeze
+    end
+
+    def raw_content!
+      raw_content or raise "No raw content!"
     end
 
     def path_name
@@ -48,20 +53,20 @@ module Runners
     end
 
     def parse_yaml
-      input_string&.yield_self { |s| YAML.safe_load(s, symbolize_names: true) }
+      raw_content&.yield_self { |s| YAML.safe_load(s, symbolize_names: true) }
     rescue Psych::SyntaxError => exn
       message = "Your `#{path_name}` is broken at line #{exn.line} and column #{exn.column}. Please fix and retry."
-      raise BrokenYAML, message
+      raise BrokenYAML.new(message, raw_content!)
     end
 
     def check_schema(object)
       object ? Schema::Config.payload.coerce(object) : {}
     rescue StrongJSON::Type::UnexpectedAttributeError => exn
       message = "The attribute `#{exn.path}.#{exn.attribute}` in your `#{path_name}` is unsupported. Please fix and retry."
-      raise InvalidConfiguration.new(message, input_string)
+      raise InvalidConfiguration.new(message, raw_content!)
     rescue StrongJSON::Type::TypeError => exn
       message = "The value of the attribute `#{exn.path}` in your `#{path_name}` is invalid. Please fix and retry."
-      raise InvalidConfiguration.new(message, input_string)
+      raise InvalidConfiguration.new(message, raw_content!)
     end
   end
 end

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -78,7 +78,11 @@ module Runners
           end
         end
       rescue Config::Error => exn
-        trace_writer.error exn.message
+        trace_writer.error <<~MSG.strip
+          #{exn.message}
+          ---
+          #{exn.raw_content}
+        MSG
         Results::Failure.new(guid: guid, message: exn.message)
       rescue UserError => exn
         Results::Failure.new(guid: guid, message: exn.message)

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -19,7 +19,10 @@ module Runners
       @trace_writer = trace_writer
       @warnings = []
       @config = config
-      trace_writer.ci_config(config.content, file: config.path_name) if config.path_exist?
+
+      if config.path_exist?
+        trace_writer.ci_config(config.content, raw_content: config.raw_content!, file: config.path_name)
+      end
 
       hash = {
         "RUBYOPT" => nil,

--- a/lib/runners/schema/trace.rb
+++ b/lib/runners/schema/trace.rb
@@ -12,7 +12,7 @@ module Runners
       )
       let :header, object(trace: literal(:header), message: string, recorded_at: string)
       let :warning, object(trace: literal(:warning), message: string, file: string?, recorded_at: string)
-      let :ci_config, object(trace: literal(:ci_config), content: any, file: string, recorded_at: string)
+      let :ci_config, object(trace: literal(:ci_config), content: any, raw_content: string, file: string, recorded_at: string)
       let :error, object(trace: literal(:error), message: string, recorded_at: string, truncated: boolean)
       let :anything, enum(command_line, status, stdout, stderr, message, header, warning, ci_config, error)
     end

--- a/lib/runners/trace_writer.rb
+++ b/lib/runners/trace_writer.rb
@@ -65,8 +65,8 @@ module Runners
       self << { trace: :warning, file: file, message: masked_string(message), recorded_at: recorded_at }
     end
 
-    def ci_config(content, file:, recorded_at: now)
-      self << { trace: :ci_config, content: content, file: file, recorded_at: recorded_at }
+    def ci_config(content, raw_content:, file:, recorded_at: now)
+      self << { trace: :ci_config, content: content, raw_content: raw_content, file: file, recorded_at: recorded_at }
     end
 
     def error(message, recorded_at: now, max_length: 4_000)

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -29,7 +29,7 @@ class Runners::TraceWriter
   def message: (String, ?recorded_at: Time, ?max_length: Integer, ?limit: Integer, ?omission: String) ?{ -> any } -> any
   def header: (String, ?recorded_at: Time) -> void
   def warning: (String, ?file: String?, ?recorded_at: Time) -> void
-  def ci_config: (Hash<any, any>, file: String, ?recorded_at: Time) -> void
+  def ci_config: (Hash<any, any>, raw_content: String, file: String, ?recorded_at: Time) -> void
   def error: (String, ?recorded_at: Time, ?max_length: Integer) -> void
   def <<: (Hash<Symbol, any>) -> void
   def now: -> Time

--- a/sig/runners/config.rbi
+++ b/sig/runners/config.rbi
@@ -1,9 +1,10 @@
 class Runners::Config
   attr_reader working_dir: Pathname
-  attr_reader input_string: String?
+  attr_reader raw_content: String?
   attr_reader content: Hash<Symbol, any>
 
   def initialize: (Pathname) -> any
+  def raw_content!: () -> String
   def path_name: -> String
   def path_exist?: -> bool
   def ignore: -> Array<String>
@@ -13,13 +14,16 @@ class Runners::Config
   def check_schema: (String?) -> Hash<Symbol, any>
 end
 
-class Runners::Config::BrokenYAML < UserError
+class Runners::Config::Error < UserError
+  attr_reader raw_content: String
+
+  def initialize: (String, String) -> any
 end
 
-class Runners::Config::InvalidConfiguration < UserError
-  attr_reader input_string: String?
+class Runners::Config::BrokenYAML < Config::Error
+end
 
-  def initialize: (String, String?) -> any
+class Runners::Config::InvalidConfiguration < Config::Error
 end
 
 Runners::Config::CONFIG_FILE_NAME: String

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -109,7 +109,7 @@ class ConfigTest < Minitest::Test
         Runners::Config.new(path)
       end
       assert_equal "The attribute `$.linter.unknown_linter` in your `sider.yml` is unsupported. Please fix and retry.", exn.message
-      assert_equal yaml, exn.input_string
+      assert_equal yaml, exn.raw_content
     end
 
     mktmpdir do |path|
@@ -122,7 +122,7 @@ class ConfigTest < Minitest::Test
         Runners::Config.new(path)
       end
       assert_equal "The value of the attribute `$.linter` in your `sider.yml` is invalid. Please fix and retry.", exn.message
-      assert_equal yaml, exn.input_string
+      assert_equal yaml, exn.raw_content
     end
   end
 

--- a/test/trace_writer_test.rb
+++ b/test/trace_writer_test.rb
@@ -77,8 +77,8 @@ class TraceWriterTest < Minitest::Test
 
   def test_ci_config
     content = {'linter' => {'rubocop' => {'config' => 'myrubocop.yml'}}}
-    writer.ci_config(content, file: "foo.yml", recorded_at: now)
-    assert_equal [{ trace: :ci_config, content: content, file: "foo.yml", recorded_at: "2017-08-01T22:34:51.200Z" }], writer.writer
+    writer.ci_config(content, raw_content: "foo", file: "foo.yml", recorded_at: now)
+    assert_equal [{ trace: :ci_config, content: content, raw_content: "foo", file: "foo.yml", recorded_at: "2017-08-01T22:34:51.200Z" }], writer.writer
   end
 
   def test_error


### PR DESCRIPTION
This change aims to make it easier for users to tackle a configuration error by themselves.

See also #818 