### PR TITLE
Push Docker images with `master` tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,12 @@ runner_job: &runner_job
     - deploy:
         command: |
           if [ -n "${CIRCLE_TAG}" ]; then
-            bundle exec rake docker:push
+            bundle exec rake docker:push "TAG=${CIRCLE_TAG}"
+            bundle exec rake docker:push TAG=latest
+          elif [ "${CIRCLE_BRANCH}" == 'master' ]; then
+            bundle exec rake docker:push "TAG=${CIRCLE_BRANCH}"
+          else
+            echo 'No push.'
           fi
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.21.2...HEAD)
 
+- Push Docker images with `master` tag [#825](https://github.com/sider/runners/pull/825)
+
 ## 0.21.2
 
 [Full diff](https://github.com/sider/runners/compare/0.21.1...0.21.2)

--- a/Rakefile
+++ b/Rakefile
@@ -85,8 +85,8 @@ namespace :dockerfile do
 end
 
 namespace :docker do
-  def image_name(image_tag = tag)
-    "sider/runner_#{analyzer}:#{image_tag}"
+  def image_name
+    "sider/runner_#{analyzer}:#{tag}"
   end
 
   def build_context
@@ -105,7 +105,7 @@ namespace :docker do
   end
 
   def tag
-    ENV.fetch('TAG', 'dev')
+    ENV.fetch('TAG') { 'dev' }
   end
 
   def docker_user
@@ -127,14 +127,11 @@ namespace :docker do
   end
 
   desc 'Run docker push'
-  task :push, [:tag] do |_task, args|
-    arg_tag = args.fetch(:tag, "latest")
-
+  task :push do
     sh "docker", "login", "--username", docker_user, "--password", docker_password
     begin
-      sh "docker", "tag", image_name, image_name(arg_tag)
+      sh "docker", "tag", image_name
       sh "docker", "push", image_name
-      sh "docker", "push", image_name(arg_tag)
     ensure
       sh "docker", "logout"
     end


### PR DESCRIPTION
It assumes that Docker images with a `master` tag will be used only for development.