### PR TITLE
Fix tagging for Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,7 @@ runner_job: &runner_job
     - deploy:
         command: |
           if [ -n "${CIRCLE_TAG}" ]; then
-            bundle exec rake docker:push "TAG=${CIRCLE_TAG}"
-            bundle exec rake docker:push TAG=latest
+            bundle exec rake 'docker:push[latest]' "TAG=${CIRCLE_TAG}"
           elif [ "${CIRCLE_BRANCH}" == 'master' ]; then
             bundle exec rake docker:push "TAG=${CIRCLE_BRANCH}"
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.21.3...HEAD)
 
+- Fix tagging for Docker images [#826](https://github.com/sider/runners/pull/826)
+
 ## 0.21.3
 
 [Full diff](https://github.com/sider/runners/compare/0.21.2...0.21.3)

--- a/Rakefile
+++ b/Rakefile
@@ -85,8 +85,8 @@ namespace :dockerfile do
 end
 
 namespace :docker do
-  def image_name
-    "sider/runner_#{analyzer}:#{tag}"
+  def image_name(t = tag)
+    "sider/runner_#{analyzer}:#{t}"
   end
 
   def build_context
@@ -127,11 +127,15 @@ namespace :docker do
   end
 
   desc 'Run docker push'
-  task :push do
+  task :push, [:tag] do |_task, args|
     sh "docker", "login", "--username", docker_user, "--password", docker_password
     begin
-      sh "docker", "tag", image_name
       sh "docker", "push", image_name
+      if args.key? :tag
+        image_name_with_new_tag = image_name(args.fetch(:tag))
+        sh "docker", "tag", image_name, image_name_with_new_tag
+        sh "docker", "push", image_name_with_new_tag
+      end
     ensure
       sh "docker", "logout"
     end


### PR DESCRIPTION
Follow up #825

This fixes the following error:

> docker tag sider/runner_brakeman:master
> "docker tag" requires exactly 2 arguments.
> See 'docker tag --help'.
>
> Usage:  docker tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]

https://app.circleci.com/jobs/github/sider/runners/83435
