### PR TITLE
Do not use base for git-blame(1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.21.4...HEAD)
 
+- Do not use base for git-blame(1) [#830](https://github.com/sider/runners/pull/830)
+
 ## 0.21.4
 
 [Full diff](https://github.com/sider/runners/compare/0.21.3...0.21.4)

--- a/lib/runners/git_blame_info.rb
+++ b/lib/runners/git_blame_info.rb
@@ -1,10 +1,10 @@
 module Runners
   GitBlameInfo = Struct.new(:commit, :original_line, :final_line, :line_hash, keyword_init: true) do
-    # @param porelain_output [String] The output of git-blame(1) with -p option
+    # @param porcelain_output [String] The output of git-blame(1) with -p option
     # @see https://www.git-scm.com/docs/git-blame#_the_porcelain_format
-    def self.parse(porelain_output)
-      headers = porelain_output.scan(/^([a-z0-9]{40}) (\d+) (\d+)/)
-      contents = porelain_output.scan(/^\t(.*)$/).flatten
+    def self.parse(porcelain_output)
+      headers = porcelain_output.scan(/^([a-z0-9]{40}) (\d+) (\d+)/)
+      contents = porcelain_output.scan(/^\t(.*)$/).flatten
       headers.zip(contents).map do |item|
         commit, original_line, final_line, content = item.flatten
         new(commit: commit, original_line: Integer(original_line), final_line: Integer(final_line), line_hash: Digest::SHA1.hexdigest(content))

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -1,15 +1,9 @@
 module Runners
   class Workspace::Git < Workspace
     def range_git_blame_info(path_string, start_line, end_line)
-      base = git_source.base
-      head = git_source.head
-      if base && head
-        shell = Shell.new(current_dir: git_directory, trace_writer: trace_writer, env_hash: {})
-        stdout, _ = shell.capture3!("git", "blame", "-p", "-L", "#{start_line},#{end_line}", "#{base}...#{head}", "--", path_string, trace_stdout: false, trace_stderr: true)
-        GitBlameInfo.parse(stdout)
-      else
-        []
-      end
+      shell = Shell.new(current_dir: git_directory, trace_writer: trace_writer, env_hash: {})
+      stdout, _ = shell.capture3!("git", "blame", "-p", "-L", "#{start_line},#{end_line}", git_source.head, "--", path_string, trace_stdout: false, trace_stderr: true)
+      GitBlameInfo.parse(stdout)
     end
 
     private

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -85,7 +85,7 @@ class WorkspaceGitTest < Minitest::Test
       info = workspace.range_git_blame_info('test/smokes/haml_lint/expectations.rb', 137, 140)
       assert_equal(
         [
-          GitBlameInfo.new(commit: "abe1cfc294c8d39de7484954bf8c3d7792fd8ad1", original_line: 137, final_line: 137, line_hash: "c57a7c8a63aa22b9aa40625f019fe097c3a23ab8"),
+          GitBlameInfo.new(commit: "839d63e3a4b0c9654a501474b5fe922d4f3f8842", original_line: 126, final_line: 137, line_hash: "c57a7c8a63aa22b9aa40625f019fe097c3a23ab8"),
           GitBlameInfo.new(commit: "998bc02a913e3899f3a1cd327e162dd54d489a4b", original_line: 138, final_line: 138, line_hash: "a77048541cecbd797666107ed16818e10cc594cb"),
           GitBlameInfo.new(commit: "998bc02a913e3899f3a1cd327e162dd54d489a4b", original_line: 139, final_line: 139, line_hash: "aa9e4a8125d41d419481f799965c6a8e98392502"),
           GitBlameInfo.new(commit: "998bc02a913e3899f3a1cd327e162dd54d489a4b", original_line: 140, final_line: 140, line_hash: "03ad52e876f71079c3e662b6d5aac4b47f33698c"),


### PR DESCRIPTION
Fix #828 