### PR TITLE
Do not write the output of git-diff(1)

### DIFF
--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -58,7 +58,7 @@ module Runners
       if base && head
         git_directory.yield_self do |path|
           shell = Shell.new(current_dir: path, trace_writer: trace_writer, env_hash: {})
-          stdout, _ = shell.capture3!("git", "diff", base, head)
+          stdout, _ = shell.capture3!("git", "diff", base, head, trace_stdout: false)
           GitDiffParser.parse(stdout)
         end
       else


### PR DESCRIPTION
Sometimes, `Shell#capture3!` fails with the error message "source sequence is illegal/malformed utf-8."

In the first place, the output of git-diff(1) is unnecessary, so I make the caller use `:trace_stdout`.