### PR TITLE
Normalize strings written to `TraceWriter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.21.5...HEAD)
 
 - Do not write the output of git-diff(1) [#837](https://github.com/sider/runners/pull/837)
+- Normalize strings written to `TraceWriter` [#838](https://github.com/sider/runners/pull/838)
 
 ## 0.21.5
 

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -78,7 +78,7 @@ module Runners
           end
         end
       rescue Config::Error => exn
-        trace_writer.error <<~MSG.strip
+        trace_writer.error <<~MSG
           #{exn.message}
           ---
           #{exn.raw_content}

--- a/lib/runners/nodejs.rb
+++ b/lib/runners/nodejs.rb
@@ -138,7 +138,7 @@ module Runners
         if subcommand == "ci"
           subcommand = "install"
           cli_options << "--package-lock=false"
-          add_warning <<~MSG.strip, file: "package.json"
+          add_warning <<~MSG, file: "package.json"
             The `npm ci --only=development` command does not install anything, so `npm install --only=development` will be used instead.
             If you want to use `npm ci`, please change your install option from `#{INSTALL_OPTION_DEVELOPMENT}` to `#{INSTALL_OPTION_ALL}`.
             For details about the npm behavior, see https://npm.community/t/npm-ci-only-dev-does-not-install-anything/3068
@@ -178,7 +178,7 @@ module Runners
       when INSTALL_OPTION_PRODUCTION
         cli_options << "--production"
       when INSTALL_OPTION_DEVELOPMENT
-        add_warning <<~MSG.strip, file: "yarn.lock"
+        add_warning <<~MSG, file: "yarn.lock"
           Yarn does not have a same feature as `npm install --only=development`, so the option `#{INSTALL_OPTION_DEVELOPMENT}` will be ignored.
           See https://github.com/yarnpkg/yarn/issues/3254 for details.
         MSG
@@ -205,7 +205,7 @@ module Runners
       return unless installed_deps
 
       warn_about_fallback_to_default = -> {
-        add_warning <<~MSG.strip, file: "package.json"
+        add_warning <<~MSG, file: "package.json"
           No required dependencies for analysis were installed. Instead, the pre-installed `#{default_dependency}` will be used.
         MSG
       }

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -137,6 +137,7 @@ module Runners
     end
 
     def add_warning(message, file: nil)
+      message = message.strip
       trace_writer.warning(message, file: file)
       @warnings << {message: message, file: file}
     end
@@ -144,7 +145,7 @@ module Runners
     def add_warning_if_deprecated_version(minimum:, file: nil, deadline: nil)
       unless Gem::Version.create(minimum) <= Gem::Version.create(analyzer_version)
         deadline_str = deadline ? deadline.strftime('on %B %-d, %Y') : 'in the near future'
-        add_warning <<~MSG.strip, file: file
+        add_warning <<~MSG, file: file
           DEPRECATION WARNING!!!
           The #{analyzer_version} and older versions are deprecated. Sider will drop these versions #{deadline_str}.
           Please consider upgrading to #{minimum} or a newer version.
@@ -157,7 +158,7 @@ module Runners
         .map { |k| "`#{config_field_path(k)}`" }
 
       unless deprecated_keys.empty?
-        add_warning <<~MSG.strip, file: config.path_name
+        add_warning <<~MSG, file: config.path_name
           DEPRECATION WARNING!!!
           The #{deprecated_keys.join(", ")} option(s) in your `#{config.path_name}` are deprecated and will be removed in the near future.
           Please update to the new option(s) according to our documentation (see #{analyzer_doc} ).
@@ -167,7 +168,7 @@ module Runners
 
     def add_warning_for_deprecated_linter(alternative:, ref:, deadline: nil)
       deadline_str = deadline ? deadline.strftime("on %B %-d, %Y") : "in the near future"
-      add_warning <<~MSG.strip, file: config.path_name
+      add_warning <<~MSG, file: config.path_name
         DEPRECATION WARNING!!!
         The support for #{analyzer_name} is deprecated. Sider will drop these versions #{deadline_str}.
         Please consider using an alternative tool #{alternative}. See #{ref}

--- a/lib/runners/processor/flake8.rb
+++ b/lib/runners/processor/flake8.rb
@@ -84,9 +84,7 @@ module Runners
 
     def python2_version
       @python2_version ||= capture3!('pyenv', 'versions', '--bare').first.match(/^2[0-9\.]+$/m).to_s.tap do
-        add_warning(<<~MESSAGE.chomp)
-          Python 2 is deprecated. Consider migrating to Python 3.
-        MESSAGE
+        add_warning "Python 2 is deprecated. Consider migrating to Python 3."
       end
     end
 

--- a/lib/runners/processor/goodcheck.rb
+++ b/lib/runners/processor/goodcheck.rb
@@ -41,9 +41,7 @@ module Runners
       stdout, stderr, status = capture3(*ruby_analyzer_bin, "test", *cli_options)
 
       if !status.success? && !stdout.empty?
-        msg = <<~MESSAGE.chomp
-          The validation of your Goodcheck configuration file failed. Check the output of `goodcheck test` command.
-        MESSAGE
+        msg = "The validation of your Goodcheck configuration file failed. Check the output of `goodcheck test` command."
         add_warning(msg, file: goodcheck_config_file)
       end
 

--- a/lib/runners/processor/jshint.rb
+++ b/lib/runners/processor/jshint.rb
@@ -62,7 +62,7 @@ module Runners
             path: relative_path(file[:name]),
             location: Location.new(start_line: error[:line]),
             id: error[:source] || Digest::SHA1.hexdigest(message),
-            message: message.strip,
+            message: message,
           )
         end
       end

--- a/lib/runners/processor/phinder.rb
+++ b/lib/runners/processor/phinder.rb
@@ -36,7 +36,7 @@ module Runners
         # Skip other configuration errors.
         # These errors should be reported when running `phinder find`.
       when 2
-        add_warning(<<~MESSAGE.chomp, file: config_linter[:rule] || DEFAULT_RULE_FILE)
+        add_warning(<<~MESSAGE, file: config_linter[:rule] || DEFAULT_RULE_FILE)
           Phinder configuration validation failed.
           Check the following output by `phinder test` command.
 

--- a/lib/runners/processor/scss_lint.rb
+++ b/lib/runners/processor/scss_lint.rb
@@ -80,7 +80,7 @@ module Runners
         end
       when EXIT_CODE_FILES_NOT_EXIST
         # NOTE: If there are no analysis target files, returns `Success` with a warning.
-        add_warning(stdout.chomp)
+        add_warning(stdout)
         Results::Success.new(guid: guid, analyzer: analyzer)
       else
         Results::Failure.new(guid: guid, message: <<~MESSAGE, analyzer: analyzer)

--- a/lib/runners/processor/tyscan.rb
+++ b/lib/runners/processor/tyscan.rb
@@ -77,16 +77,12 @@ module Runners
       args.unshift("-t", config_linter[:tsconfig]) if config_linter[:tsconfig]
       args.unshift("-c", config_linter[:config]) if config_linter[:config]
 
-      stdout, stderr, status = capture3(nodejs_analyzer_bin, "scan", "--json", *args)
+      stdout, _stderr, status = capture3(nodejs_analyzer_bin, "scan", "--json", *args)
 
       # TyScan exited with 0 when finishing an analysis correctly.
       unless status.exitstatus == 0
-        return Results::Failure.new(guid: guid, message: <<~MESSAGE, analyzer: analyzer)
-          TyScan was failed with status #{status.exitstatus} since an unexpected error occurred.
-
-          STDERR:
-          #{stderr}
-        MESSAGE
+        msg = "TyScan was failed with the exit status #{status.exitstatus} since an unexpected error occurred."
+        return Results::Failure.new(guid: guid, message: msg, analyzer: analyzer)
       end
 
       json = JSON.parse(stdout, symbolize_names: true)

--- a/lib/runners/processor/tyscan.rb
+++ b/lib/runners/processor/tyscan.rb
@@ -66,9 +66,7 @@ module Runners
       _, _, status = capture3(nodejs_analyzer_bin, "test", *args)
 
       if status.nil? || !status.success?
-        msg = <<~MESSAGE.chomp
-          `tyscan test` failed. It may cause an unintended match.
-        MESSAGE
+        msg = "`tyscan test` failed. It may cause an unintended match."
         add_warning(msg, file: config_linter[:config] || "tyscan.yml")
       end
     end

--- a/lib/runners/ruby/gem_installer.rb
+++ b/lib/runners/ruby/gem_installer.rb
@@ -34,7 +34,7 @@ module Runners
             shell.capture3!("bundle", "install")
             shell.capture3!("bundle", "list")
           rescue Shell::ExecError
-            raise InstallationFailure.new(<<~MESSAGE)
+            raise InstallationFailure.new(<<~MESSAGE.strip)
               Failed to install gems. Sider automatically installs gems according to `#{config_path_name}` and `Gemfile.lock`.
               You can select the version of gems you want to install via `#{config_path_name}`.
               See https://help.sider.review/getting-started/custom-configuration#gems-option

--- a/lib/runners/trace_writer.rb
+++ b/lib/runners/trace_writer.rb
@@ -16,23 +16,26 @@ module Runners
     end
 
     def stdout(string, recorded_at: now, max_length: 4_000)
-      unless string.empty?
-        each_slice(masked_string(string), size: max_length) do |text, truncated|
-          self << { trace: :stdout, string: text, recorded_at: recorded_at, truncated: truncated }
-        end
+      string = string.strip
+      return if string.empty?
+
+      each_slice(masked_string(string), size: max_length) do |text, truncated|
+        self << { trace: :stdout, string: text, recorded_at: recorded_at, truncated: truncated }
       end
     end
 
     def stderr(string, recorded_at: now, max_length: 4_000)
-      unless string.empty?
-        each_slice(masked_string(string), size: max_length) do |text, truncated|
-          self << { trace: :stderr, string: text, recorded_at: recorded_at, truncated: truncated }
-        end
+      string = string.strip
+      return if string.empty?
+
+      each_slice(masked_string(string), size: max_length) do |text, truncated|
+        self << { trace: :stderr, string: text, recorded_at: recorded_at, truncated: truncated }
       end
     end
 
     def message(message, recorded_at: now, max_length: 4_000, limit: 40_000, omission: "...(truncated)")
-      string = masked_string(message)
+      string = masked_string(message.strip)
+
       if string.size > limit
         string = string[0, limit] + omission
         all_truncated = true
@@ -58,11 +61,11 @@ module Runners
     end
 
     def header(message, recorded_at: now)
-      self << { trace: :header, message: masked_string(message), recorded_at: recorded_at }
+      self << { trace: :header, message: masked_string(message.strip), recorded_at: recorded_at }
     end
 
     def warning(message, file: nil, recorded_at: now)
-      self << { trace: :warning, file: file, message: masked_string(message), recorded_at: recorded_at }
+      self << { trace: :warning, file: file, message: masked_string(message.strip), recorded_at: recorded_at }
     end
 
     def ci_config(content, raw_content:, file:, recorded_at: now)
@@ -70,7 +73,7 @@ module Runners
     end
 
     def error(message, recorded_at: now, max_length: 4_000)
-      each_slice(masked_string(message), size: max_length) do |text, truncated|
+      each_slice(masked_string(message.strip), size: max_length) do |text, truncated|
         self << { trace: :error, message: text, recorded_at: recorded_at, truncated: truncated }
       end
     end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -58,11 +58,11 @@ class ProcessorTest < Minitest::Test
 
       # Returns status, stdout, and stderr
       assert_instance_of Process::Status, status
-      assert_match "1 2 3\n", stdout
+      assert_equal "1 2 3\n", stdout
       assert_equal "", stderr
 
-      assert trace_writer.writer.find {|hash| hash[:trace] == :command_line && hash[:command_line] == %w(/bin/echo 1 2 3) }
-      assert trace_writer.writer.find {|hash| hash[:trace] == :stdout && hash[:string] == "1 2 3\n" }
+      assert trace_writer.writer.find {|hash| hash[:trace] == :command_line && hash[:command_line] == ["/bin/echo", "1", "2", "3"] }
+      assert trace_writer.writer.find {|hash| hash[:trace] == :stdout && hash[:string] == "1 2 3" }
       refute trace_writer.writer.find {|hash| hash[:trace] == :stderr }
       assert trace_writer.writer.find {|hash| hash[:trace] == :status && hash[:status] == 0 }
     end

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -160,7 +160,7 @@ class RubyTest < Minitest::Test
         assert_equal "1.32.0", hash["rubocop-rspec"]
       end
 
-      assert_equal([<<~MSG], trace_writer.writer.select { |m| m[:trace] == :message }.map { |m| m[:message] })
+      assert_equal([<<~MSG.strip], trace_writer.writer.select { |m| m[:trace] == :message }.map { |m| m[:message] })
         source "https://rubygems.org"
 
         gem "strong_json", "0.5.0", "<= 0.8.0"
@@ -639,7 +639,7 @@ EOF
       processor.install_gems([Spec.new(name: "rubocop", version: ["0.66.0"])],
                              constraints: { "rubocop" => ["> 0.65.0"] }) do
         assert_equal 1, processor.warnings.count
-        assert_equal <<~MESSAGE, processor.warnings.first[:message]
+        assert_equal <<~MESSAGE.strip, processor.warnings.first[:message]
           Sider tried to install `rubocop 0.62.0` according to your `Gemfile.lock`, but it installs `0.66.0` instead.
           Because `0.62.0` does not satisfy the Sider constraints ["> 0.65.0"].
 

--- a/test/shell_test.rb
+++ b/test/shell_test.rb
@@ -27,7 +27,7 @@ class ShellTest < Minitest::Test
       assert status.success?
       assert_trace_writer [
         { trace: :command_line, command_line: ["echo", "Hello"] },
-        { trace: :stdout, string: "Hello\n", truncated: false },
+        { trace: :stdout, string: "Hello", truncated: false },
         { trace: :status, status: 0 },
       ]
     end
@@ -60,7 +60,7 @@ class ShellTest < Minitest::Test
       assert status.success?
       assert_trace_writer [
         { trace: :command_line, command_line: ["echo Hello | tee /dev/stderr"] },
-        { trace: :stdout, string: "Hello\n", truncated: false },
+        { trace: :stdout, string: "Hello", truncated: false },
         { trace: :status, status: 0 },
       ]
     end
@@ -83,8 +83,8 @@ class ShellTest < Minitest::Test
       assert_equal path, error.dir
       assert_trace_writer [
         { trace: :command_line, command_line: ["echo Error | tee /dev/stderr && exit 1"] },
-        { trace: :stdout, string: "Error\n", truncated: false },
-        { trace: :stderr, string: "Error\n", truncated: false },
+        { trace: :stdout, string: "Error", truncated: false },
+        { trace: :stderr, string: "Error", truncated: false },
         { trace: :status, status: 1 },
       ]
 
@@ -113,7 +113,7 @@ class ShellTest < Minitest::Test
       assert_equal 1, status.exitstatus
       assert_trace_writer [
         { trace: :command_line, command_line: ["echo Hello && exit 1"] },
-        { trace: :stdout, string: "Hello\n", truncated: false },
+        { trace: :stdout, string: "Hello", truncated: false },
         { trace: :status, status: 1 },
       ]
     end

--- a/test/smokes/brakeman/expectations.rb
+++ b/test/smokes/brakeman/expectations.rb
@@ -167,13 +167,14 @@ Smoke.add_test(
   },
   warnings: [
     {
-      message: <<~MESSAGE,
-    Sider tried to install `brakeman 4.4.0` according to your `Gemfile.lock`, but it installs `4.3.1` instead.
-    Because `4.4.0` does not satisfy the Sider constraints [\">= 4.0.0\", \"< 4.4.0\"].
+      message: <<~MESSAGE
+        Sider tried to install `brakeman 4.4.0` according to your `Gemfile.lock`, but it installs `4.3.1` instead.
+        Because `4.4.0` does not satisfy the Sider constraints [\">= 4.0.0\", \"< 4.4.0\"].
 
-    If you want to use a different version of `brakeman`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
-    See https://help.sider.review/getting-started/custom-configuration#gems-option
-  MESSAGE
+        If you want to use a different version of `brakeman`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
+        See https://help.sider.review/getting-started/custom-configuration#gems-option
+      MESSAGE
+        .strip,
       file: nil
     }
   ]

--- a/test/smokes/code_sniffer/expectations.rb
+++ b/test/smokes/code_sniffer/expectations.rb
@@ -43,10 +43,10 @@ Smoke.add_test(
   warnings: [
     {
       message: <<~MSG
-  DEPRECATION WARNING!!!
-  The `$.linter.code_sniffer.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-  Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/php/codesniffer ).
-MSG
+        DEPRECATION WARNING!!!
+        The `$.linter.code_sniffer.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/php/codesniffer ).
+      MSG
         .strip,
       file: "sideci.yml"
     }

--- a/test/smokes/coffeelint/expectations.rb
+++ b/test/smokes/coffeelint/expectations.rb
@@ -55,10 +55,10 @@ Smoke.add_test(
   warnings: [
     {
       message: <<~MSG
-    DEPRECATION WARNING!!!
-    The `$.linter.coffeelint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-    Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/coffeelint ).
-  MSG
+        DEPRECATION WARNING!!!
+        The `$.linter.coffeelint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/coffeelint ).
+      MSG
         .strip,
       file: "sideci.yml"
     }

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -177,7 +177,7 @@ Smoke.add_test(
           DEPRECATION WARNING!!!
           The `$.linter.eslint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
           Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/eslint ).
-  MSG
+        MSG
           .strip,
         file: "sideci.yml"
       }

--- a/test/smokes/goodcheck/expectations.rb
+++ b/test/smokes/goodcheck/expectations.rb
@@ -47,13 +47,14 @@ Smoke.add_test(
   { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Goodcheck", version: "2.5.0" } },
   warnings: [
     {
-      message: <<~MESSAGE,
-    Sider cannot find the required configuration file `goodcheck.yml`.
-    Please set up Goodcheck by following the instructions, or you can disable it in the repository settings.
+      message: <<~MESSAGE
+        Sider cannot find the required configuration file `goodcheck.yml`.
+        Please set up Goodcheck by following the instructions, or you can disable it in the repository settings.
 
-    - https://github.com/sider/goodcheck
-    - https://help.sider.review/tools/others/goodcheck
-  MESSAGE
+        - https://github.com/sider/goodcheck
+        - https://help.sider.review/tools/others/goodcheck
+      MESSAGE
+        .strip,
       file: nil
     }
   ]
@@ -153,10 +154,10 @@ Smoke.add_test(
         object: {
           id: "com.goodcheck.without_pattern",
           message: <<~MESSAGE
-          Check the following documentation when editing this file.
-            * https://example.com/path/to/note
-        MESSAGE
-            .chomp,
+            Check the following documentation when editing this file.
+              * https://example.com/path/to/note
+          MESSAGE
+            .strip,
           justifications: []
         },
         git_blame_info: nil,

--- a/test/smokes/javasee/expectations.rb
+++ b/test/smokes/javasee/expectations.rb
@@ -71,10 +71,11 @@ Smoke.add_test(
   {
     warnings: [
       {
-        message: <<~MSG,
-      Configuration file javasee.yml does not look a file.
-      Specify configuration file by -config option.
-    MSG
+        message: <<~MSG
+          Configuration file javasee.yml does not look a file.
+          Specify configuration file by -config option.
+        MSG
+          .strip,
         file: nil
       }
     ]

--- a/test/smokes/phinder/expectations.rb
+++ b/test/smokes/phinder/expectations.rb
@@ -93,13 +93,14 @@ Smoke.add_test(
   },
   warnings: [
     {
-      message: <<~MESSAGE,
+      message: <<~MESSAGE
         Phinder configuration validation failed.
         Check the following output by `phinder test` command.
 
         `in_array(2, $arr, false)` does not match the rule sample.in_array_without_3rd_param but should match that rule.
         `in_array(4, $arr)` matches the rule sample.in_array_without_3rd_param but should not match that rule.
-  MESSAGE
+      MESSAGE
+        .strip,
       file: "phinder.yml"
     }
   ]
@@ -115,7 +116,7 @@ Smoke.add_test(
       1 error occurred:
 
       InvalidRule: Invalid id value found in 1st rule in phinder.yml
-  MESSAGE
+    MESSAGE
     analyzer: { name: "Phinder", version: "0.9.2" }
   }
 )
@@ -161,13 +162,14 @@ Smoke.add_test(
   { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Phinder", version: "0.9.2" } },
   warnings: [
     {
-      message: <<~MESSAGE,
+      message: <<~MESSAGE
         Sider cannot find the required configuration file(s): `phinder.yml`.
         Please set up Phinder by following the instructions, or you can disable it in the repository settings.
 
         - https://github.com/sider/phinder
         - https://help.sider.review/tools/php/phinder
       MESSAGE
+        .strip,
       file: "phinder.yml"
     }
   ]

--- a/test/smokes/querly/expectations.rb
+++ b/test/smokes/querly/expectations.rb
@@ -45,13 +45,14 @@ Smoke.add_test(
   { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Querly", version: "1.0.0" } },
   warnings: [
     {
-      message: <<~MESSAGE,
-    Sider cannot find the required configuration file `querly.yml`.
-    Please set up Querly by following the instructions, or you can disable it in the repository settings.
+      message: <<~MESSAGE
+        Sider cannot find the required configuration file `querly.yml`.
+        Please set up Querly by following the instructions, or you can disable it in the repository settings.
 
-    - https://github.com/soutaro/querly
-    - https://help.sider.review/tools/ruby/querly
-  MESSAGE
+        - https://github.com/soutaro/querly
+        - https://help.sider.review/tools/ruby/querly
+      MESSAGE
+        .strip,
       file: nil
     }
   ]

--- a/test/smokes/rails_best_practices/expectations.rb
+++ b/test/smokes/rails_best_practices/expectations.rb
@@ -81,10 +81,10 @@ Smoke.add_test(
     warnings: [
       {
         message: <<~MSG
-    DEPRECATION WARNING!!!
-    The `$.linter.rails_best_practices.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-    Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rails-bestpractices ).
-  MSG
+          DEPRECATION WARNING!!!
+          The `$.linter.rails_best_practices.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+          Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rails-bestpractices ).
+        MSG
           .strip,
         file: "sideci.yml"
       }
@@ -224,13 +224,14 @@ Smoke.add_test(
   },
   warnings: [
     {
-      message: <<~MESSAGE,
-    Sider tried to install `rails_best_practices 1.16.0` according to your `Gemfile.lock`, but it installs `1.19.4` instead.
-    Because `1.16.0` does not satisfy the Sider constraints [">= 1.19.1", "< 2.0"].
+      message: <<~MESSAGE
+        Sider tried to install `rails_best_practices 1.16.0` according to your `Gemfile.lock`, but it installs `1.19.4` instead.
+        Because `1.16.0` does not satisfy the Sider constraints [">= 1.19.1", "< 2.0"].
 
-    If you want to use a different version of `rails_best_practices`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
-    See https://help.sider.review/getting-started/custom-configuration#gems-option
-  MESSAGE
+        If you want to use a different version of `rails_best_practices`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
+        See https://help.sider.review/getting-started/custom-configuration#gems-option
+      MESSAGE
+        .strip,
       file: nil
     }
   ]

--- a/test/smokes/reek/expectations.rb
+++ b/test/smokes/reek/expectations.rb
@@ -175,13 +175,14 @@ Smoke.add_test(
   },
   warnings: [
     {
-      message: <<~MESSAGE,
-      Sider tried to install `reek 4.0.0` according to your `Gemfile.lock`, but it installs `5.6.0` instead.
-      Because `4.0.0` does not satisfy the Sider constraints [\">= 4.4.0\", \"< 6.0\"].
+      message: <<~MESSAGE
+        Sider tried to install `reek 4.0.0` according to your `Gemfile.lock`, but it installs `5.6.0` instead.
+        Because `4.0.0` does not satisfy the Sider constraints [\">= 4.4.0\", \"< 6.0\"].
 
-      If you want to use a different version of `reek`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
-      See https://help.sider.review/getting-started/custom-configuration#gems-option
-    MESSAGE
+        If you want to use a different version of `reek`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
+        See https://help.sider.review/getting-started/custom-configuration#gems-option
+      MESSAGE
+        .strip,
       file: nil
     }
   ]

--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -258,10 +258,10 @@ Smoke.add_test(
     warnings: [
       {
         message: <<~MSG
-      DEPRECATION WARNING!!!
-      The `$.linter.rubocop.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-      Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rubocop ).
-    MSG
+          DEPRECATION WARNING!!!
+          The `$.linter.rubocop.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+          Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rubocop ).
+        MSG
           .strip,
         file: "sideci.yml"
       },
@@ -294,11 +294,12 @@ Smoke.add_test(
   },
   warnings: [
     {
-      message: <<~WARNING,
-    Rails cops will be removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
-    https://github.com/rubocop-hq/rubocop/blob/master/manual/migrate_rails_cops.md
-    https://help.sider.review/getting-started/custom-configuration#gems-option
-  WARNING
+      message: <<~WARNING
+        Rails cops will be removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
+        https://github.com/rubocop-hq/rubocop/blob/master/manual/migrate_rails_cops.md
+        https://help.sider.review/getting-started/custom-configuration#gems-option
+      WARNING
+        .strip,
       file: :_
     }
   ]
@@ -352,10 +353,11 @@ Smoke.add_test(
   },
   warnings: [
     {
-      message: <<~WARNING,
-      `rails` option is ignored because the option was removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
-      See https://help.sider.review/getting-started/custom-configuration#gems-option
-    WARNING
+      message: <<~WARNING
+        `rails` option is ignored because the option was removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
+        See https://help.sider.review/getting-started/custom-configuration#gems-option
+      WARNING
+        .strip,
       file: "sideci.yml"
     }
   ]
@@ -447,11 +449,12 @@ Smoke.add_test(
     guid: "test-guid",
     timestamp: :_,
     type: "failure",
-    message: <<~TEXT,
+    message: <<~MSG
       Failed to install gems. Sider automatically installs gems according to `sideci.yml` and `Gemfile.lock`.
       You can select the version of gems you want to install via `sideci.yml`.
       See https://help.sider.review/getting-started/custom-configuration#gems-option
-    TEXT
+    MSG
+      .strip,
     analyzer: nil
   }
 )
@@ -461,13 +464,14 @@ Smoke.add_test(
   { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "RuboCop", version: "0.80.1" } },
   warnings: [
     {
-      message: <<~MSG,
+      message: <<~MSG
         Sider tried to install `rubocop 0.60.0` according to your `Gemfile.lock`, but it installs `0.80.1` instead.
         Because `0.60.0` does not satisfy the Sider constraints [\">= 0.61.0\", \"< 1.0.0\"].
 
         If you want to use a different version of `rubocop`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
         See https://help.sider.review/getting-started/custom-configuration#gems-option
       MSG
+        .strip,
       file: nil
     }
   ]

--- a/test/smokes/tyscan/expectations.rb
+++ b/test/smokes/tyscan/expectations.rb
@@ -29,12 +29,13 @@ Smoke.add_test(
   { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "TyScan", version: "0.3.1" } },
   warnings: [
     {
-      message: <<~MESSAGE,
-    `tyscan.yml` does not exist in your repository.
+      message: <<~MESSAGE
+        `tyscan.yml` does not exist in your repository.
 
-    To start performing analysis, `tyscan.yml` is required.
-    See also: https://help.sider.review/tools/javascript/tyscan
-  MESSAGE
+        To start performing analysis, `tyscan.yml` is required.
+        See also: https://help.sider.review/tools/javascript/tyscan
+      MESSAGE
+        .strip,
       file: nil
     }
   ]
@@ -100,12 +101,7 @@ Smoke.add_test(
     guid: "test-guid",
     timestamp: :_,
     type: "failure",
-    message: <<~MESSAGE,
-    TyScan was failed with status 1 since an unexpected error occurred.
-
-    STDERR:
-
-  MESSAGE
+    message: "TyScan was failed with the exit status 1 since an unexpected error occurred.",
     analyzer: { name: "TyScan", version: "0.2.1" }
   },
   warnings: [{ message: "`tyscan test` failed. It may cause an unintended match.", file: "tyscan.yml" }]


### PR DESCRIPTION
This change aims to reduce the code using `strip` before passing a string to the `TraceWriter` class. (using `String#strip` internally)