### PR TITLE
[Refactor] Use explicit long option names for `mvn` command

### DIFF
--- a/images/Dockerfile.java.erb
+++ b/images/Dockerfile.java.erb
@@ -6,7 +6,7 @@ FROM sider/devon_rex_java:2.15.0 AS builder
 #       See https://maven.apache.org/plugins/maven-dependency-plugin/copy-dependencies-mojo.html
 COPY --chown=<%= chown %> images/<%= analyzer %>/pom.xml ${RUNNER_USER_HOME}/<%= analyzer %>/pom.xml
 RUN cd "${RUNNER_USER_HOME}/<%= analyzer %>" && \
-    mvn -ntp -B -T 4 dependency:copy-dependencies -DoutputDirectory=.
+    mvn --no-transfer-progress --batch-mode --threads 4 dependency:copy-dependencies -DoutputDirectory=.
 
 FROM sider/devon_rex_java:2.15.0
 

--- a/images/checkstyle/Dockerfile
+++ b/images/checkstyle/Dockerfile
@@ -10,7 +10,7 @@ FROM sider/devon_rex_java:2.15.0 AS builder
 #       See https://maven.apache.org/plugins/maven-dependency-plugin/copy-dependencies-mojo.html
 COPY --chown=${RUNNER_USER}:nogroup images/checkstyle/pom.xml ${RUNNER_USER_HOME}/checkstyle/pom.xml
 RUN cd "${RUNNER_USER_HOME}/checkstyle" && \
-    mvn -ntp -B -T 4 dependency:copy-dependencies -DoutputDirectory=.
+    mvn --no-transfer-progress --batch-mode --threads 4 dependency:copy-dependencies -DoutputDirectory=.
 
 FROM sider/devon_rex_java:2.15.0
 

--- a/images/detekt/Dockerfile
+++ b/images/detekt/Dockerfile
@@ -10,7 +10,7 @@ FROM sider/devon_rex_java:2.15.0 AS builder
 #       See https://maven.apache.org/plugins/maven-dependency-plugin/copy-dependencies-mojo.html
 COPY --chown=${RUNNER_USER}:nogroup images/detekt/pom.xml ${RUNNER_USER_HOME}/detekt/pom.xml
 RUN cd "${RUNNER_USER_HOME}/detekt" && \
-    mvn -ntp -B -T 4 dependency:copy-dependencies -DoutputDirectory=.
+    mvn --no-transfer-progress --batch-mode --threads 4 dependency:copy-dependencies -DoutputDirectory=.
 
 FROM sider/devon_rex_java:2.15.0
 

--- a/images/ktlint/Dockerfile
+++ b/images/ktlint/Dockerfile
@@ -10,7 +10,7 @@ FROM sider/devon_rex_java:2.15.0 AS builder
 #       See https://maven.apache.org/plugins/maven-dependency-plugin/copy-dependencies-mojo.html
 COPY --chown=${RUNNER_USER}:nogroup images/ktlint/pom.xml ${RUNNER_USER_HOME}/ktlint/pom.xml
 RUN cd "${RUNNER_USER_HOME}/ktlint" && \
-    mvn -ntp -B -T 4 dependency:copy-dependencies -DoutputDirectory=.
+    mvn --no-transfer-progress --batch-mode --threads 4 dependency:copy-dependencies -DoutputDirectory=.
 
 FROM sider/devon_rex_java:2.15.0
 

--- a/images/pmd_java/Dockerfile
+++ b/images/pmd_java/Dockerfile
@@ -10,7 +10,7 @@ FROM sider/devon_rex_java:2.15.0 AS builder
 #       See https://maven.apache.org/plugins/maven-dependency-plugin/copy-dependencies-mojo.html
 COPY --chown=${RUNNER_USER}:nogroup images/pmd_java/pom.xml ${RUNNER_USER_HOME}/pmd_java/pom.xml
 RUN cd "${RUNNER_USER_HOME}/pmd_java" && \
-    mvn -ntp -B -T 4 dependency:copy-dependencies -DoutputDirectory=.
+    mvn --no-transfer-progress --batch-mode --threads 4 dependency:copy-dependencies -DoutputDirectory=.
 
 FROM sider/devon_rex_java:2.15.0
 


### PR DESCRIPTION
Short option names are hard to remember for us.