### PR TITLE
[Actions] No fail fast on matrix builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_skip
     strategy:
+      fail-fast: false
       matrix:
         analyzer:
           - brakeman


### PR DESCRIPTION
The default value of `jobs.<job_id>.strategy.fail-fast` is `true`.
But I think we expect results of smoke tests as much as possible, even if some smoke tests fail.

See <https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast>.

See also #838