### PR TITLE
Add Actions `on.push.tags` for `docker push`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build
 on:
   push:
     branches: ["master"]
+    tags: ["**"]
   pull_request:
     branches: ["**"]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.21.6...HEAD)
 
+- Add Actions `on.push.tags` for `docker push` [#842](https://github.com/sider/runners/pull/842)
+
 ## 0.21.6
 
 [Full diff](https://github.com/sider/runners/compare/0.21.5...0.21.6)


### PR DESCRIPTION
Currently, `docker push` is not triggered... 😢 

https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags

