### PR TITLE
Improve warnings for Node.js runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.21.7...HEAD)
 
+- Improve warnings for Node.js runners [#844](https://github.com/sider/runners/pull/844)
+
 ## 0.21.7
 
 [Full diff](https://github.com/sider/runners/compare/0.21.6...0.21.7)

--- a/test/nodejs_test.rb
+++ b/test/nodejs_test.rb
@@ -11,6 +11,11 @@ class NodejsTest < Minitest::Test
   NpmInstallFailed = Runners::Nodejs::NpmInstallFailed
   YarnInstallFailed = Runners::Nodejs::YarnInstallFailed
 
+  INSTALL_OPTION_NONE = Runners::Nodejs::INSTALL_OPTION_NONE
+  INSTALL_OPTION_ALL = Runners::Nodejs::INSTALL_OPTION_ALL
+  INSTALL_OPTION_PRODUCTION = Runners::Nodejs::INSTALL_OPTION_PRODUCTION
+  INSTALL_OPTION_DEVELOPMENT = Runners::Nodejs::INSTALL_OPTION_DEVELOPMENT
+
   def processor_class
     @processor_class ||= Class.new(Runners::Processor) do
       include Runners::Nodejs
@@ -33,8 +38,20 @@ class NodejsTest < Minitest::Test
     trace_writer.writer.select { |entry| entry[:trace] == :error }.map { |entry| entry[:message] }
   end
 
+  def assert_warning_count(expected)
+    assert_equal expected, processor.warnings.size
+  end
+
+  def assert_warnings(expected)
+    assert_equal expected, processor.warnings
+  end
+
+  def processor
+    @processor
+  end
+
   def new_processor(workspace:)
-    processor_class.new(
+    @processor = processor_class.new(
       guid: SecureRandom.uuid,
       workspace: workspace,
       config: config,
@@ -55,7 +72,7 @@ class NodejsTest < Minitest::Test
 
   def test_nodejs_analyzer_local_command
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       assert_equal "node_modules/.bin/eslint", processor.nodejs_analyzer_local_command
     end
@@ -63,7 +80,7 @@ class NodejsTest < Minitest::Test
 
   def test_nodejs_analyzer_bin
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       assert_equal "eslint", processor.nodejs_analyzer_bin
 
@@ -75,7 +92,7 @@ class NodejsTest < Minitest::Test
 
   def test_analyzer_version_with_global
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       processor.stub :nodejs_analyzer_locally_installed?, false do
         processor.stub :nodejs_analyzer_global_version, "1.0.0" do
@@ -87,7 +104,7 @@ class NodejsTest < Minitest::Test
 
   def test_analyzer_version_with_local
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       processor.stub :nodejs_analyzer_locally_installed?, true do
         processor.stub :nodejs_analyzer_local_version, "2.0.0" do
@@ -99,7 +116,7 @@ class NodejsTest < Minitest::Test
 
   def test_package_json_path
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       assert_equal(workspace.working_dir / "package.json", processor.package_json_path)
     end
@@ -107,7 +124,7 @@ class NodejsTest < Minitest::Test
 
   def test_package_json
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       assert_raises Errno::ENOENT do
         processor.package_json
@@ -120,7 +137,7 @@ class NodejsTest < Minitest::Test
 
   def test_package_lock_json_path
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       assert_equal(workspace.working_dir / "package-lock.json", processor.package_lock_json_path)
     end
@@ -128,7 +145,7 @@ class NodejsTest < Minitest::Test
 
   def test_yarn_lock_path
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       assert_equal(workspace.working_dir / "yarn.lock", processor.yarn_lock_path)
     end
@@ -136,146 +153,166 @@ class NodejsTest < Minitest::Test
 
   def test_install_nodejs_deps
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
-      deps = { "eslint" => "5.0.0", "eslint-plugin-react" => "7.10.0" }
-      processor.package_json_path.write(JSON.generate(devDependencies: deps))
-
+      processor.package_json_path.write(JSON.generate(devDependencies: {
+        "eslint" => "5.0.0", "eslint-plugin-react" => "7.10.0"
+      }))
       defaults = DefaultDependencies.new(
         main: Dependency.new(name: "eslint", version: "5.15.0"),
         extras: [
           Dependency.new(name: "eslint-plugin-react", version: "7.14.2"),
         ],
       )
-
       constraints = {
         "eslint" => Constraint.new(">= 5.0.0", "< 7.0.0"),
         "eslint-plugin-react" => Constraint.new(">= 4.2.1", "< 8.0.0"),
       }
 
-      option = Runners::Nodejs::INSTALL_OPTION_ALL
-
-      processor.stub :nodejs_analyzer_global_version, defaults.main.version do
-        processor.install_nodejs_deps(defaults, constraints: constraints, install_option: option)
+      processor.stub :nodejs_analyzer_global_version, "5.15.0" do
+        processor.install_nodejs_deps(defaults, constraints: constraints, install_option: INSTALL_OPTION_ALL)
 
         stdout, _ = processor.capture3!(processor.nodejs_analyzer_bin, "-v")
         assert_equal "v5.0.0\n", stdout
-
-        assert_equal(0, trace_writer.writer.count { |e| e[:trace] == :warning })
+        assert_warning_count 0
       end
     end
   end
 
-  def test_install_nodejs_deps_with_option_nil
+  def test_install_nodejs_deps_without_package_json
     with_workspace do |workspace|
+      new_processor(workspace: workspace)
+
       defaults = DefaultDependencies.new(main: Dependency.new(name: "eslint", version: "5.15.0"))
       constraints = { "eslint" => Constraint.new(">= 5.0.0", "< 7.0.0") }
-      option = nil
 
-      # Without package.json
-      processor = new_processor(workspace: workspace)
+      processor.stub :nodejs_analyzer_global_version, defaults.main.version do
+        processor.install_nodejs_deps(defaults, constraints: constraints, install_option: INSTALL_OPTION_ALL)
+
+        assert_warnings [{ message: <<~MSG.strip, file: "package.json" }]
+          The `npm_install` option is specified, but a `package.json` file is not found. In this case, Sider does not install any npm packages.
+        MSG
+      end
+    end
+  end
+
+  def test_install_nodejs_deps_with_option_nil_and_without_package_json
+    with_workspace do |workspace|
+      new_processor(workspace: workspace)
+
+      defaults = DefaultDependencies.new(main: Dependency.new(name: "eslint", version: "5.15.0"))
+      constraints = { "eslint" => Constraint.new(">= 5.0.0", "< 7.0.0") }
+
       processor.stub :nodejs_analyzer_global_version, "5.15.0" do
-        processor.install_nodejs_deps(defaults, constraints: constraints, install_option: option)
+        processor.install_nodejs_deps(defaults, constraints: constraints, install_option: nil)
+
         refute processor.package_json_path.exist?
         assert_equal "5.15.0", processor.analyzer_version
+        assert_warning_count 0
       end
+    end
+  end
 
-      # With package.json
-      processor = new_processor(workspace: workspace)
+  def test_install_nodejs_deps_with_option_nil_and_with_package_json
+    with_workspace do |workspace|
+      new_processor(workspace: workspace)
+
+      processor.package_json_path.write(JSON.generate(dependencies: { "eslint" => "6.0.0" }))
+      defaults = DefaultDependencies.new(main: Dependency.new(name: "eslint", version: "5.15.0"))
+      constraints = { "eslint" => Constraint.new(">= 5.0.0", "< 7.0.0") }
+
       processor.stub :nodejs_analyzer_global_version, "5.15.0" do
-        processor.package_json_path.write(JSON.generate(dependencies: { "eslint" => "6.0.0" }))
-        processor.install_nodejs_deps(defaults, constraints: constraints, install_option: option)
+        processor.install_nodejs_deps(defaults, constraints: constraints, install_option: nil)
+
         assert processor.package_json_path.exist?
         assert_equal "6.0.0", processor.analyzer_version
+        assert_warning_count 0
       end
     end
   end
 
-  def test_install_nodejs_deps_with_option_none
+  def test_install_nodejs_deps_with_option_none_and_without_package_json
     with_workspace do |workspace|
+      new_processor(workspace: workspace)
+
       defaults = DefaultDependencies.new(main: Dependency.new(name: "eslint", version: "5.15.0"))
       constraints = { "eslint" => Constraint.new(">= 5.0.0", "< 7.0.0") }
-      option = Runners::Nodejs::INSTALL_OPTION_NONE
 
-      # Without package.json
-      processor = new_processor(workspace: workspace)
       processor.stub :nodejs_analyzer_global_version, "5.15.0" do
-        processor.install_nodejs_deps(defaults, constraints: constraints, install_option: option)
+        processor.install_nodejs_deps(defaults, constraints: constraints, install_option: INSTALL_OPTION_NONE)
+
         refute processor.package_json_path.exist?
         assert_equal "5.15.0", processor.analyzer_version
+        assert_warning_count 0
       end
+    end
+  end
 
-      # With package.json
-      processor = new_processor(workspace: workspace)
+  def test_install_nodejs_deps_with_option_none_and_with_package_json
+    with_workspace do |workspace|
+      new_processor(workspace: workspace)
+
+      processor.package_json_path.write(JSON.generate(dependencies: { "eslint" => "6.0.0" }))
+      defaults = DefaultDependencies.new(main: Dependency.new(name: "eslint", version: "5.15.0"))
+      constraints = { "eslint" => Constraint.new(">= 5.0.0", "< 7.0.0") }
+
       processor.stub :nodejs_analyzer_global_version, "5.15.0" do
-        processor.package_json_path.write(JSON.generate(dependencies: { "eslint" => "6.0.0" }))
-        processor.install_nodejs_deps(defaults, constraints: constraints, install_option: option)
+        processor.install_nodejs_deps(defaults, constraints: constraints, install_option: INSTALL_OPTION_NONE)
+
         assert processor.package_json_path.exist?
         assert_equal "5.15.0", processor.analyzer_version
+        assert_warning_count 0
       end
     end
   end
 
   def test_install_nodejs_deps_using_yarn
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       processor.package_json_path.write(JSON.generate(dependencies: { "eslint" => "6.0.1" }))
       FileUtils.cp data("yarn.lock"), processor.yarn_lock_path
 
-      defaults = DefaultDependencies.new(
-        main: Dependency.new(name: "eslint", version: "5.15.0"),
-      )
-      constraints = {
-        "eslint" => Constraint.new(">= 5.0.0", "< 7.0.0"),
-      }
-      option = Runners::Nodejs::INSTALL_OPTION_ALL
+      defaults = DefaultDependencies.new(main: Dependency.new(name: "eslint", version: "5.15.0"))
+      constraints = { "eslint" => Constraint.new(">= 5.0.0", "< 7.0.0") }
 
       processor.stub :nodejs_analyzer_global_version, "5.15.0" do
-        processor.install_nodejs_deps(defaults, constraints: constraints, install_option: option)
+        processor.install_nodejs_deps(defaults, constraints: constraints, install_option: INSTALL_OPTION_ALL)
 
         stdout, _ = processor.capture3!(processor.nodejs_analyzer_bin, "-v")
         assert_equal "v6.0.1\n", stdout
-
-        assert_equal(0, trace_writer.writer.count { |e| e[:trace] == :warning })
+        assert_warning_count 0
       end
     end
   end
 
   def test_install_nodejs_deps_with_duplicate_lockfiles
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       processor.package_json_path.write(JSON.generate(dependencies: { "eslint" => "6.0.1" }))
       FileUtils.cp data("yarn.lock"), processor.yarn_lock_path
       FileUtils.cp data("package-lock.json"), processor.package_lock_json_path
 
-      defaults = DefaultDependencies.new(
-        main: Dependency.new(name: "eslint", version: "5.15.0"),
-      )
-      constraints = {
-        "eslint" => Constraint.new(">= 5.0.0", "< 7.0.0"),
-      }
-      option = Runners::Nodejs::INSTALL_OPTION_ALL
+      defaults = DefaultDependencies.new(main: Dependency.new(name: "eslint", version: "5.15.0"))
+      constraints = { "eslint" => Constraint.new(">= 5.0.0", "< 7.0.0") }
 
       processor.stub :nodejs_analyzer_global_version, "5.15.0" do
-        processor.install_nodejs_deps(defaults, constraints: constraints, install_option: option)
+        processor.install_nodejs_deps(defaults, constraints: constraints, install_option: INSTALL_OPTION_ALL)
 
         stdout, _ = processor.capture3!(processor.nodejs_analyzer_bin, "-v")
         assert_equal "v6.0.1\n", stdout
 
-        expected_warning =
-          "Two lock files `package-lock.json` and `yarn.lock` are found. " \
-          "Sider uses `yarn.lock` in this case, but please consider deleting either file for more accurate analysis."
-        actual_warnings = trace_writer.writer.select { |e| e[:trace] == :warning }.map { |e| e[:message] }
-        assert_equal [expected_warning], actual_warnings
+        assert_warnings [{ message: <<~MSG.strip, file: "yarn.lock" }]
+          Two lock files `package-lock.json` and `yarn.lock` are found. Sider uses `yarn.lock` in this case, but please consider deleting either file for more accurate analysis.
+        MSG
       end
     end
   end
 
   def test_check_nodejs_default_deps
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       defaults = DefaultDependencies.new(
         main: Dependency.new(name: "eslint", version: "5.15.0"),
@@ -325,7 +362,7 @@ class NodejsTest < Minitest::Test
 
   def test_npm_install
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       node_modules = workspace.working_dir / "node_modules"
       typescript = node_modules / "typescript"
@@ -338,22 +375,22 @@ class NodejsTest < Minitest::Test
       processor.package_json_path.write(JSON.generate(package_json))
       (workspace.working_dir / ".npmrc").write("engine-strict = true")
 
-      processor.send(:npm_install, Runners::Nodejs::INSTALL_OPTION_NONE)
+      processor.send(:npm_install, INSTALL_OPTION_NONE)
       refute node_modules.exist?
 
-      processor.send(:npm_install, Runners::Nodejs::INSTALL_OPTION_ALL)
+      processor.send(:npm_install, INSTALL_OPTION_ALL)
       assert typescript.exist?
 
       node_modules.rmtree
-      processor.send(:npm_install, Runners::Nodejs::INSTALL_OPTION_PRODUCTION)
+      processor.send(:npm_install, INSTALL_OPTION_PRODUCTION)
       assert typescript.exist?
 
       node_modules.rmtree
-      processor.send(:npm_install, Runners::Nodejs::INSTALL_OPTION_DEVELOPMENT)
+      processor.send(:npm_install, INSTALL_OPTION_DEVELOPMENT)
       refute node_modules.exist?
 
       processor.package_json_path.write(JSON.generate(devDependencies: { "typescript" => "3.5.3" }))
-      processor.send(:npm_install, Runners::Nodejs::INSTALL_OPTION_DEVELOPMENT)
+      processor.send(:npm_install, INSTALL_OPTION_DEVELOPMENT)
       assert typescript.exist?
 
       expected_commands = [
@@ -368,7 +405,7 @@ class NodejsTest < Minitest::Test
 
   def test_npm_install_using_ci
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       node_modules = workspace.working_dir / "node_modules"
       typescript = node_modules / "typescript"
@@ -376,28 +413,28 @@ class NodejsTest < Minitest::Test
       processor.package_json_path.write(JSON.generate(dependencies: { "typescript" => "3.5.3" }))
       FileUtils.cp data("package-lock.json"), processor.package_lock_json_path
 
-      processor.send(:npm_install, Runners::Nodejs::INSTALL_OPTION_ALL)
+      processor.send(:npm_install, INSTALL_OPTION_ALL)
       assert typescript.exist?
 
       node_modules.rmtree
-      processor.send(:npm_install, Runners::Nodejs::INSTALL_OPTION_PRODUCTION)
+      processor.send(:npm_install, INSTALL_OPTION_PRODUCTION)
       assert typescript.exist?
 
       node_modules.rmtree
-      processor.send(:npm_install, Runners::Nodejs::INSTALL_OPTION_DEVELOPMENT)
+      processor.send(:npm_install, INSTALL_OPTION_DEVELOPMENT)
       refute typescript.exist?
 
       processor.package_json_path.write(JSON.generate(devDependencies: { "typescript" => "3.5.3" }))
       FileUtils.cp data("package-lock.dev.json"), processor.package_lock_json_path
 
-      processor.send(:npm_install, Runners::Nodejs::INSTALL_OPTION_ALL)
+      processor.send(:npm_install, INSTALL_OPTION_ALL)
       assert typescript.exist?
 
       node_modules.rmtree
-      processor.send(:npm_install, Runners::Nodejs::INSTALL_OPTION_PRODUCTION)
+      processor.send(:npm_install, INSTALL_OPTION_PRODUCTION)
       refute typescript.exist?
 
-      processor.send(:npm_install, Runners::Nodejs::INSTALL_OPTION_DEVELOPMENT)
+      processor.send(:npm_install, INSTALL_OPTION_DEVELOPMENT)
       assert typescript.exist?
 
       expected_commands = [
@@ -410,28 +447,23 @@ class NodejsTest < Minitest::Test
       ]
       assert_equal expected_commands, actual_commands
 
-      expected_warning = <<~MSG.strip
+      expected_warning = { message: <<~MSG.strip, file: "package.json" }
         The `npm ci --only=development` command does not install anything, so `npm install --only=development` will be used instead.
         If you want to use `npm ci`, please change your install option from `development` to `true`.
         For details about the npm behavior, see https://npm.community/t/npm-ci-only-dev-does-not-install-anything/3068
       MSG
-      actual_warnings = trace_writer.writer.select { |e| e[:trace] == :warning }.map { |e| e[:message] }
-      assert_equal [expected_warning, expected_warning], actual_warnings
-      assert_equal [
-        { message: expected_warning, file: "package.json" },
-        { message: expected_warning, file: "package.json" },
-      ], processor.warnings
+      assert_warnings [expected_warning, expected_warning]
     end
   end
 
   def test_npm_install_failed
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       processor.package_json_path.write(JSON.generate(dependencies: { "foo" => "github:sider/foo" }))
 
       error = assert_raises NpmInstallFailed do
-        processor.send(:npm_install, Runners::Nodejs::INSTALL_OPTION_ALL)
+        processor.send(:npm_install, INSTALL_OPTION_ALL)
       end
       expected_error_message = <<~MSG.strip
         `npm install` failed. Please check the log for details.
@@ -444,7 +476,7 @@ class NodejsTest < Minitest::Test
 
   def test_yarn_install
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       node_modules = workspace.working_dir / "node_modules"
       eslint = node_modules / "eslint"
@@ -452,18 +484,18 @@ class NodejsTest < Minitest::Test
       processor.package_json_path.write(JSON.generate(dependencies: { "eslint" => "6.0.1" }))
       FileUtils.cp data("yarn.lock"), processor.yarn_lock_path
 
-      processor.send(:yarn_install, Runners::Nodejs::INSTALL_OPTION_NONE)
+      processor.send(:yarn_install, INSTALL_OPTION_NONE)
       refute eslint.exist?
 
-      processor.send(:yarn_install, Runners::Nodejs::INSTALL_OPTION_ALL)
+      processor.send(:yarn_install, INSTALL_OPTION_ALL)
       assert eslint.exist?
 
       eslint.rmtree
-      processor.send(:yarn_install, Runners::Nodejs::INSTALL_OPTION_PRODUCTION)
+      processor.send(:yarn_install, INSTALL_OPTION_PRODUCTION)
       assert eslint.exist?
 
       node_modules.rmtree
-      processor.send(:yarn_install, Runners::Nodejs::INSTALL_OPTION_DEVELOPMENT)
+      processor.send(:yarn_install, INSTALL_OPTION_DEVELOPMENT)
       assert eslint.exist?
 
       expected_commands = [
@@ -485,14 +517,14 @@ class NodejsTest < Minitest::Test
 
   def test_yarn_install_failed
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       # 'yarn install' fails because of incorrect package settings between yarn.lock and package.json
       FileUtils.cp incorrect_yarn_data("yarn.lock"), processor.yarn_lock_path
       FileUtils.cp incorrect_yarn_data("package.json"), processor.package_json_path
 
       error = assert_raises YarnInstallFailed do
-        processor.send(:yarn_install, Runners::Nodejs::INSTALL_OPTION_ALL)
+        processor.send(:yarn_install, INSTALL_OPTION_ALL)
       end
       expected_error_message = <<~MSG.strip
         `yarn install` failed. Please confirm `yarn.lock` is consistent with `package.json`.
@@ -504,11 +536,11 @@ class NodejsTest < Minitest::Test
 
   def test_check_installed_nodejs_deps
     with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
+      new_processor(workspace: workspace)
 
       npm_install = ->(json) {
         processor.package_json_path.write(JSON.generate(json))
-        processor.send(:npm_install, Runners::Nodejs::INSTALL_OPTION_ALL)
+        processor.send(:npm_install, INSTALL_OPTION_ALL)
       }
 
       default = Dependency.new(name: "eslint", version: "5.1.0")

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -431,5 +431,5 @@ Smoke.add_test(
 Smoke.add_test(
   "duplicate_lock_files",
   { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "ESLint", version: "5.16.0" } },
-  { warnings: [{ message: /Two lock files `package-lock.json` and `yarn.lock` are found/, file: nil }] }
+  { warnings: [{ message: /Two lock files `package-lock.json` and `yarn.lock` are found/, file: "yarn.lock" }] }
 )


### PR DESCRIPTION
- Add warning if `package.json` is not found and `npm_install` option is specified.
- Refactor unit test for `Runners::Nodejs` module.