### PR TITLE
Improve `:chdir` option of `Shell#capture3_trace` method

### DIFF
--- a/lib/runners/shell.rb
+++ b/lib/runners/shell.rb
@@ -96,7 +96,7 @@ module Runners
       trace_stderr = options.fetch(:trace_stderr, true)
       trace_command_line = options.fetch(:trace_command_line, true)
       raise_on_failure = options.fetch(:raise_on_failure, false)
-      chdir = options.fetch(:chdir) { current_dir }
+      chdir = options[:chdir] || current_dir
       is_success = options.fetch(:is_success) { ->(status) { status.success? } }
 
       command_line = [command] + args

--- a/test/shell_test.rb
+++ b/test/shell_test.rb
@@ -138,4 +138,15 @@ class ShellTest < Minitest::Test
       assert_equal "Number: 2", stdout
     end
   end
+
+  def test_capture3_trace_with_chdir_nil
+    mktmpdir do |path|
+      shell = Shell.new(current_dir: path, trace_writer: trace_writer, env_hash: {})
+      (path / "1.txt").write("Number: 1")
+
+      stdout, _, status = shell.capture3_trace("cat", "1.txt", chdir: nil)
+      assert status.success?
+      assert_equal "Number: 1", stdout
+    end
+  end
 end


### PR DESCRIPTION
This change allows `chdir: nil` also.
