### PR TITLE
Improve warning in `Nodejs#install_nodejs_deps` method

### DIFF
--- a/lib/runners/nodejs.rb
+++ b/lib/runners/nodejs.rb
@@ -54,12 +54,16 @@ module Runners
 
       return if install_option == INSTALL_OPTION_NONE
 
-      if install_option && !package_json_path.exist?
-        file = package_json_path.basename.to_path
-        add_warning <<~MSG, file: file
-          The `npm_install` option is specified, but a `#{file}` file is not found. In this case, Sider does not install any npm packages.
-        MSG
-        return
+      unless package_json_path.exist?
+        if install_option
+          file = package_json_path.basename.to_path
+          add_warning <<~MSG, file: file
+            The `npm_install` option is specified in your `#{config.path_name}`, but a `#{file}` file is not found in the repository.
+            In this case, any npm packages are not installed.
+          MSG
+        end
+
+        return # not install
       end
 
       install_option = INSTALL_OPTION_ALL if install_option.nil?

--- a/test/nodejs_test.rb
+++ b/test/nodejs_test.rb
@@ -190,7 +190,8 @@ class NodejsTest < Minitest::Test
         processor.install_nodejs_deps(defaults, constraints: constraints, install_option: INSTALL_OPTION_ALL)
 
         assert_warnings [{ message: <<~MSG.strip, file: "package.json" }]
-          The `npm_install` option is specified, but a `package.json` file is not found. In this case, Sider does not install any npm packages.
+          The `npm_install` option is specified in your `sider.yml`, but a `package.json` file is not found in the repository.
+          In this case, any npm packages are not installed.
         MSG
       end
     end
@@ -209,6 +210,7 @@ class NodejsTest < Minitest::Test
         refute processor.package_json_path.exist?
         assert_equal "5.15.0", processor.analyzer_version
         assert_warning_count 0
+        assert_equal [], trace_writer.writer.filter { |e| e.key? :command_line }
       end
     end
   end


### PR DESCRIPTION
- Do not run any extra `npm install`.
- Improve the warning message.

Follow up #844