### PR TITLE
Speed up `RubyTest`

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,9 +39,10 @@ module TestHelper
 
   def with_workspace(ssh_key: nil, **source_params)
     source = {
-      head: (Pathname(__dir__) + "data/foo.tgz").to_s,
+      head: data("foo.tgz"),
       **source_params
-    }.select { |_k, v| v }
+    }.compact
+
     with_runners_options_env(source: source, ssh_key: ssh_key) do
       options = Runners::Options.new(StringIO.new, StringIO.new)
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
- Replace a multi-deps gem with a no-deps gem, e.g. `rubocop` -> `multi_json`
- The `rubygems.cae.me.uk` mirror is too slow, but **I give up a local gem server** like [`geminabox`](https://github.com/geminabox/geminabox).
  Because the test code would be too complex.
- Replace `bundle show` with `bundle list` to fix the deprecation warning:
  "[DEPRECATED] use `bundle list` instead of `bundle show`"

Fix #841
