### PR TITLE
Improve HTTP download

### DIFF
--- a/lib/runners/workspace/http.rb
+++ b/lib/runners/workspace/http.rb
@@ -73,7 +73,7 @@ module Runners
               max_redirects: max_redirects - 1,
             )
           else
-            raise DownloadError, "Download failed: #{response.inspect}"
+            raise DownloadError, "Download failed: #{response.code} #{response.message}"
           end
         end
       end

--- a/lib/runners/workspace/http.rb
+++ b/lib/runners/workspace/http.rb
@@ -26,7 +26,7 @@ module Runners
       end
     end
 
-    # NOTE: Some exceptions are handled by ``Net::HTTP` class.
+    # NOTE: Some exceptions are handled by `Net::HTTP` class.
     #
     # @see https://github.com/ruby/ruby/blob/v2_6_5/lib/net/http.rb#L1520-L1536
     def download_with_retry(uri, &block)
@@ -35,7 +35,6 @@ module Runners
           on: [
             DownloadError,
             Net::OpenTimeout,
-            Net::HTTPForbidden,
           ],
           tries: 5,
           sleep: method(:retryable_sleep),
@@ -46,7 +45,7 @@ module Runners
           file.flush
           block.call Pathname(file.path)
         ensure
-          file.close! if file
+          file.close!
         end
       end
     end

--- a/lib/runners/workspace/http.rb
+++ b/lib/runners/workspace/http.rb
@@ -43,6 +43,7 @@ module Runners
         ) do
           file = ::Tempfile.new
           download uri, dest: file, max_retries: 5, max_redirects: 10
+          file.flush
           block.call Pathname(file.path)
         ensure
           file.close! if file

--- a/lib/runners/workspace/http.rb
+++ b/lib/runners/workspace/http.rb
@@ -65,6 +65,7 @@ module Runners
           when Net::HTTPSuccess
             response.read_body(dest)
           when Net::HTTPRedirection
+            # @see https://ruby-doc.org/stdlib-2.6.5/libdoc/net/http/rdoc/Net/HTTP.html#class-Net::HTTP-label-Following+Redirection
             download(
               URI(response["Location"]),
               dest: dest,

--- a/lib/runners/workspace/http.rb
+++ b/lib/runners/workspace/http.rb
@@ -52,10 +52,13 @@ module Runners
       raise ArgumentError, "Too many HTTP redirects: #{uri}" if max_redirects == 0
 
       http_options = {
-        use_ssl: true,
+        use_ssl: uri.scheme == "https",
+
+        # @see https://ruby-doc.org/stdlib-2.6.5/libdoc/net/http/rdoc/Net/HTTP.html#method-i-max_retries-3D
         max_retries: max_retries,
       }
 
+      # @see https://ruby-doc.org/stdlib-2.6.5/libdoc/net/http/rdoc/Net/HTTP.html#method-c-start
       Net::HTTP.start(uri.hostname, uri.port, http_options) do |http|
         http.request_get(uri) do |response|
           case response

--- a/lib/runners/workspace/http.rb
+++ b/lib/runners/workspace/http.rb
@@ -19,40 +19,58 @@ module Runners
     # @param dest [Pathname]
     # @param key [String, nil]
     def provision(uri, dest, key)
-      # When OpenSSL::Cipher::CipherError, probably the downloading is failed.
-      # So retry downloading and decrypting
-      Retryable.retryable(
-        tries: 5,
-        on: [OpenSSL::Cipher::CipherError, OpenSSL::SSL::SSLError, DownloadError, Net::OpenTimeout, Errno::ECONNRESET, SocketError, Net::HTTPForbidden],
-        sleep: method(:retryable_sleep),
-        exception_cb: -> (_ex) { trace_writer.message "Retrying download..." }
-      ) do
-        ::Tempfile.open do |io|
-          trace_writer.message "Downloading source code..." do
-            download(uri) do |response|
-              response.read_body do |chunk|
-                io.write(chunk)
-              end
-            end
-            io.flush
-          end
+      file = download_with_retry(uri)
 
-          decrypt(Pathname(io.path), key) do |archive_path|
-            extract(archive_path, dest)
-          end
+      decrypt(file, key) do |archive_path|
+        extract(archive_path, dest)
+      end
+    end
+
+    # NOTE: Some exceptions are handled by ``Net::HTTP` class.
+    #
+    # @see https://github.com/ruby/ruby/blob/v2_6_5/lib/net/http.rb#L1520-L1536
+    def download_with_retry(uri)
+      trace_writer.message "Downloading source code..." do
+        Retryable.retryable(
+          on: [
+            DownloadError,
+            Net::OpenTimeout,
+            Net::HTTPForbidden,
+          ],
+          tries: 5,
+          sleep: method(:retryable_sleep),
+          log_method: -> (retries, _exn) { trace_writer.message "Retrying download... (attempt: #{retries})" },
+        ) do
+          file = ::Tempfile.new
+          download(uri, dest: file, max_retries: 5, max_redirects: 10)
+          return Pathname(file.path)
         end
       end
     end
 
-    def download(uri, &block)
-      Net::HTTP.get_response(uri) do |response|
-        case response.code
-        when /^2/
-          yield response
-        when "301", "302"
-          download(URI.parse(response['location']), &block)
-        else
-          raise DownloadError, "Download is failed. #{response.inspect}"
+    def download(uri, dest:, max_retries:, max_redirects:)
+      raise ArgumentError, "Too many HTTP redirects: #{uri}" if max_redirects == 0
+
+      http_options = {
+        use_ssl: true,
+        max_retries: max_retries,
+      }
+
+      Net::HTTP.start(uri.hostname, uri.port, http_options) do |http|
+        http.request_get(uri) do |response|
+          case response
+          when Net::HTTPSuccess
+            response.read_body(dest)
+          when Net::HTTPRedirection
+            download(
+              URI(response["Location"]),
+              dest: dest,
+              max_retries: max_retries,
+              max_redirects: max_redirects - 1,
+            )
+          else
+            raise DownloadError, "Download failed: #{response.inspect}"
+          end
         end
       end
     end

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -124,6 +124,9 @@ end
 class Net::HTTPResponse
   include Net::HTTPHeader
 
+  attr_reader code: String
+  attr_reader message: String
+
   def read_body: (::IO) -> void
 end
 

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -111,11 +111,24 @@ class URI
   def path: -> String
   def scheme: -> String
   def host: -> String
+  def hostname: -> String
+  def port: -> Integer
   def userinfo=: (String) -> String
 end
 
 class Net::HTTP
-  def self.get_response: <'a> (URI) { (any) -> 'a } -> 'a
+  def self.start: <'a> (String, Integer, Hash<Symbol, any>) { (HTTP) -> 'a } -> 'a
+  def request_get: (URI) { (Net::HTTPResponse) -> void } -> void
+end
+
+class Net::HTTPResponse
+  include Net::HTTPHeader
+
+  def read_body: (::IO) -> void
+end
+
+module Net::HTTPHeader
+  def []: (String) -> String
 end
 
 class Open3
@@ -153,13 +166,6 @@ class OpenSSL::Cipher
   def random_key: -> String
   def reset: -> self
   def update: (String) -> String
-end
-
-class Tempfile
-  def self.open: <'a> { (File) -> 'a } -> 'a
-end
-
-class OpenSSL::Cipher::CipherError
 end
 
 class Net::OpenTimeout

--- a/sig/polyfills/kernel.rbi
+++ b/sig/polyfills/kernel.rbi
@@ -7,4 +7,5 @@ extension Kernel (Polyfill)
   def __dir__: -> String
   def Array: (any) -> Array<any>
   def Pathname: (String | Pathname) -> Pathname
+  def URI: (any) -> URI
 end

--- a/sig/runners/workspace.rbi
+++ b/sig/runners/workspace.rbi
@@ -23,7 +23,7 @@ class Runners::Workspace::HTTP < Workspace
   def prepare_base_source: (Pathname) -> void
   def prepare_head_source: (Pathname) -> void
   def provision: (URI, Pathname, String?) -> void
-  def download_with_retry: (URI) -> Pathname
+  def download_with_retry: (URI) { (Pathname) -> void } -> void
   def download: (URI, dest: ::IO, max_retries: Integer, max_redirects: Integer) -> void
   def retryable_sleep: (Integer) -> Integer
 end

--- a/sig/runners/workspace.rbi
+++ b/sig/runners/workspace.rbi
@@ -23,7 +23,8 @@ class Runners::Workspace::HTTP < Workspace
   def prepare_base_source: (Pathname) -> void
   def prepare_head_source: (Pathname) -> void
   def provision: (URI, Pathname, String?) -> void
-  def download: <'a> (URI) { (any) -> 'a } -> 'a
+  def download_with_retry: (URI) -> Pathname
+  def download: (URI, dest: ::IO, max_retries: Integer, max_redirects: Integer) -> void
   def retryable_sleep: (Integer) -> Integer
 end
 


### PR DESCRIPTION
We are currently using [`Net::HTTP`](https://ruby-doc.org/stdlib-2.6.5/libdoc/net/http/rdoc/Net/HTTP.html) to download a user's source code.

Because the `Net::HTTP` has own retry mechanism, this change aims to make our retrying more simple.

