### PR TITLE
Migration to new Steep 0.14.0 gradually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,8 @@ jobs:
   typecheck_new:
     runs-on: ubuntu-latest
     needs: check_skip
+    env:
+      BUNDLE_GEMFILE: Gemfile.steep
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
@@ -85,7 +87,7 @@ jobs:
         run: |
           gem install bundler --no-document
           bundle config set --local path vendor/bundle
-          bundle install --jobs 4 --retry 3 --gemfile Gemfile.steep
+          bundle install --jobs 4 --retry 3
       - run: bundle exec steep check
 
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
           gem install bundler --no-document
           bundle config set --local path vendor/bundle
           bundle install --jobs 4 --retry 3 --gemfile Gemfile.steep
-      - run: bundle exec rake typecheck
+      - run: bundle exec steep check
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,22 @@ jobs:
           bundle install --jobs 4 --retry 3
       - run: bundle exec rake typecheck
 
+  # TODO: Rename to `typecheck` when the migration will complete.
+  typecheck_new:
+    runs-on: ubuntu-latest
+    needs: check_skip
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+      - name: Install gems
+        run: |
+          gem install bundler --no-document
+          bundle config set --local path vendor/bundle
+          bundle install --jobs 4 --retry 3 --gemfile Gemfile.steep
+      - run: bundle exec rake typecheck
+
   build:
     runs-on: ubuntu-latest
     needs: check_skip

--- a/Gemfile.steep
+++ b/Gemfile.steep
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'steep', '= 0.14.0'

--- a/Gemfile.steep
+++ b/Gemfile.steep
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'steep', '= 0.14.0'
+gem 'rake'

--- a/Gemfile.steep.lock
+++ b/Gemfile.steep.lock
@@ -28,6 +28,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rainbow (3.0.0)
+    rake (13.0.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -49,6 +50,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  rake
   steep (= 0.14.0)
 
 BUNDLED WITH

--- a/Gemfile.steep.lock
+++ b/Gemfile.steep.lock
@@ -1,0 +1,55 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.0.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
+    ast (2.4.0)
+    ast_utils (0.3.0)
+      parser (~> 2.4)
+      thor (>= 0.19)
+    coderay (1.1.2)
+    concurrent-ruby (1.1.6)
+    ffi (1.12.2)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
+    language_server-protocol (3.14.0.1)
+    listen (3.2.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    method_source (0.9.2)
+    minitest (5.14.0)
+    parser (2.7.0.4)
+      ast (~> 2.4.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    rainbow (3.0.0)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    steep (0.14.0)
+      activesupport (>= 5.1)
+      ast_utils (~> 0.3.0)
+      language_server-protocol (~> 3.14.0.1)
+      listen (~> 3.1)
+      parser (~> 2.7.0)
+      pry (~> 0.12.2)
+      rainbow (>= 2.2.2, < 4.0)
+    thor (1.0.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.6)
+      thread_safe (~> 0.1)
+    zeitwerk (2.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  steep (= 0.14.0)
+
+BUNDLED WITH
+   2.1.4

--- a/Steepfile
+++ b/Steepfile
@@ -1,0 +1,17 @@
+target :lib do
+  # TODO: Rename to `sig` when the migration will complete.
+  signature "sig_new"
+
+  check "lib/runners.rb"
+  check "lib/runners/cli.rb"
+  check "lib/runners/config.rb"
+  check "lib/runners/errors.rb"
+  # TODO: Add checking...
+
+  # FIXME: Cannot resolve errors about `Struct`.
+  ignore "lib/runners/options.rb"
+
+  library "pathname"
+  library "set"
+  library "tmpdir"
+end

--- a/lib/runners/options.rb
+++ b/lib/runners/options.rb
@@ -1,6 +1,7 @@
 module Runners
   class Options
     GitSource = Struct.new(:head, :base, :git_http_url, :owner, :repo, :git_http_userinfo, :pull_number, keyword_init: true)
+
     ArchiveSource = Struct.new(:head, :head_key, :base, :base_key, keyword_init: true) do
       def http?
         scheme = URI.parse(head).scheme
@@ -13,8 +14,8 @@ module Runners
       end
     end
 
-    attr_reader :stdout, :stderr
-    attr_reader :source, :ssh_key, :io
+    # @dynamic stdout, stderr, source, ssh_key, io
+    attr_reader :stdout, :stderr, :source, :ssh_key, :io
 
     def initialize(stdout, stderr)
       @stdout = stdout

--- a/sig_new/activesupport.rbs
+++ b/sig_new/activesupport.rbs
@@ -1,0 +1,12 @@
+module ActiveSupport
+end
+
+class ActiveSupport::Duration
+  attr_reader parts: Hash[Symbol, Numeric]
+
+  def self.build: (Numeric | Float) -> instance
+end
+
+extension Class (ActiveSupport)
+  def subclasses: () -> Array[Class]
+end

--- a/sig_new/jsonseq.rbs
+++ b/sig_new/jsonseq.rbs
@@ -1,0 +1,12 @@
+module JSONSEQ
+end
+
+interface JSONSEQ::_WriteIO
+  def write: (String) -> void
+  def flush: () -> void
+end
+
+class JSONSEQ::Writer
+  def initialize: (io: _WriteIO) -> void
+  def <<: (untyped) -> void
+end

--- a/sig_new/optparse.rbs
+++ b/sig_new/optparse.rbs
@@ -1,0 +1,5 @@
+class OptionParser
+  def initialize: { (OptionParser) -> void } -> void
+  def on: (String) { (String) -> void } -> void
+  def parse!: (Array[String]) -> void
+end

--- a/sig_new/runners.rbs
+++ b/sig_new/runners.rbs
@@ -1,0 +1,4 @@
+module Runners
+end
+
+Runners::VERSION: String

--- a/sig_new/runners/cli.rbs
+++ b/sig_new/runners/cli.rbs
@@ -1,0 +1,15 @@
+class Runners::CLI
+  attr_reader stdout: ::IO
+  attr_reader stderr: ::IO
+  attr_reader guid: String
+  attr_reader analyzer: String
+  attr_reader options: Options
+
+  def initialize: (argv: Array[String], stdout: ::IO, stderr: ::IO) -> void
+  def with_working_dir: [X] { (Pathname) -> X } -> X
+  def processor_class: () -> Class
+  def run: () -> untyped
+  def io: () -> Runners::IO
+  def sensitive_strings: () -> Array[String]
+  def format_duration: (Float duration_in_sec) -> String
+end

--- a/sig_new/runners/config.rbs
+++ b/sig_new/runners/config.rbs
@@ -1,0 +1,30 @@
+class Runners::Config
+  attr_reader working_dir: Pathname
+  attr_reader raw_content: String?
+  attr_reader content: Hash[Symbol, untyped]
+
+  def initialize: (Pathname working_dir) -> void
+  def raw_content!: () -> String
+  def path_name: () -> String
+  def path_exist?: () -> bool
+  def ignore: () -> Array[String]
+  def linter: (String) -> Hash[Symbol, untyped]
+  def path: () -> Pathname?
+  def parse_yaml: () -> String?
+  def check_schema: (String? object) -> Hash[Symbol, untyped]
+end
+
+class Runners::Config::Error < Runners::UserError
+  attr_reader raw_content: String
+
+  def initialize: (String message, String raw_content) -> void
+end
+
+class Runners::Config::BrokenYAML < Runners::Config::Error
+end
+
+class Runners::Config::InvalidConfiguration < Runners::Config::Error
+end
+
+Runners::Config::CONFIG_FILE_NAME: String
+Runners::Config::OLD_CONFIG_FILE_NAME: String

--- a/sig_new/runners/errors.rbs
+++ b/sig_new/runners/errors.rbs
@@ -1,0 +1,8 @@
+class Runners::Error < StandardError
+end
+
+class Runners::UserError < Runners::Error
+end
+
+class Runners::SystemError < Runners::Error
+end

--- a/sig_new/runners/harness.rbs
+++ b/sig_new/runners/harness.rbs
@@ -1,0 +1,18 @@
+class Runners::Harness
+  attr_reader guid: String
+  attr_reader processor_class: Class
+  attr_reader options: Options
+  attr_reader working_dir: Pathname
+  attr_reader trace_writer: TraceWriter
+  attr_reader warnings: Array[String]
+  attr_reader config: Config?
+
+  def initialize: (guid: String,
+                   processor_class: Class,
+                   options: Options,
+                   working_dir: Pathname,
+                   trace_writer: TraceWriter) -> void
+  def run: () -> untyped
+  def ensure_result: () { () -> untyped } -> untyped
+  def handle_error: (Exception exn) -> void
+end

--- a/sig_new/runners/io.rbs
+++ b/sig_new/runners/io.rbs
@@ -1,0 +1,10 @@
+class Runners::IO
+  attr_reader ios: Array[::IO]
+
+  def initialize: (*::IO ios) -> void
+  def write: (*untyped args) -> void
+  def flush: (*untyped args) -> void
+  def flush!: () -> void
+end
+
+Runners::IO::REQUIRED_METHODS_FOR_IOS: Array[Symbol]

--- a/sig_new/runners/options.rbs
+++ b/sig_new/runners/options.rbs
@@ -1,0 +1,39 @@
+class Runners::Options
+  attr_reader stdout: ::IO
+  attr_reader stderr: ::IO
+  attr_reader source: GitSource | ArchiveSource
+  attr_reader ssh_key: String?
+  attr_reader io: Runners::IO
+
+  def initialize: (::IO stdout, ::IO stderr) -> void
+  def parse_options: () -> Hash[Symbol, untyped]
+end
+
+class Runners::Options::GitSource
+  attr_reader head: String
+  attr_reader base: String?
+  attr_reader git_http_url: String
+  attr_reader owner: String
+  attr_reader repo: String
+  attr_reader git_http_userinfo: String?
+  attr_reader pull_number: Integer?
+
+  def initialize: (head: String,
+                   ?base: String?,
+                   git_http_url: String,
+                   owner: String,
+                   repo: String,
+                   ?git_http_userinfo: String?,
+                   ?pull_number: Integer?) -> void
+end
+
+class Runners::Options::ArchiveSource
+  attr_reader head: String
+  attr_reader head_key: String?
+  attr_reader base: String?
+  attr_reader base_key: String?
+
+  def initialize: (head: String, ?head_key: String?, ?base: String?, ?base_key: String?) -> void
+  def http?: () -> bool
+  def file?: () -> bool
+end

--- a/sig_new/runners/processor.rbs
+++ b/sig_new/runners/processor.rbs
@@ -1,0 +1,3 @@
+class Runners::Processor
+
+end

--- a/sig_new/runners/schema.rbs
+++ b/sig_new/runners/schema.rbs
@@ -1,0 +1,2 @@
+module Runners::Schema
+end

--- a/sig_new/runners/schema/result.rbs
+++ b/sig_new/runners/schema/result.rbs
@@ -1,0 +1,3 @@
+class Runners::Schema::Result
+  def self.envelope: () -> untyped
+end

--- a/sig_new/runners/trace_writer.rbs
+++ b/sig_new/runners/trace_writer.rbs
@@ -1,0 +1,25 @@
+interface Runners::TraceWriter::_Writer
+  def <<: (Hash[Symbol, untyped]) -> void
+end
+
+class Runners::TraceWriter
+  attr_reader writer: _Writer
+  attr_reader sensitive_strings: Array[String]
+
+  def initialize: (writer: _Writer, ?sensitive_strings: Array[String]) -> void
+  def command_line: (Array[String] command_line, ?recorded_at: Time) -> void
+  def status: (Process::Status status, ?recorded_at: Time) -> untyped
+  def stdout: (String string, ?recorded_at: Time, ?max_length: Integer) -> void
+  def stderr: (String string, ?recorded_at: Time, ?max_length: Integer) -> void
+  def message: (String message, ?recorded_at: Time, ?max_length: Integer, ?limit: Integer, ?omission: String) ?{ () -> untyped } -> untyped
+  def header: (String message, ?recorded_at: Time) -> void
+  def warning: (String message, ?file: String?, ?recorded_at: Time) -> void
+  def ci_config: (Hash[Symbol, untyped] content, raw_content: String, file: String, ?recorded_at: Time) -> void
+  def error: (String message, ?recorded_at: Time, ?max_length: Integer) -> void
+  def <<: (Hash[Symbol, untyped] object) -> void
+
+  private
+  def now: () -> untyped
+  def each_slice: (String string, size: Integer) { (String, bool) -> void } -> void
+  def masked_string: (String str) -> String
+end


### PR DESCRIPTION
The migration to Steep 0.14.0 is a big change because of the changes for the `.rbs` format and the syntax.
So, I think it better that we will migrate our code gradually and keep both for a while.

This change does mainly the two things:

1. Install the new version of Steep via another Gemfile, that is `Gemfile.steep`.
2. Run both type-checking (via the old and new version) on CI.

When we will complete the migration, we will be able to remove the old code.

Close #719 