### PR TITLE
Fix `rake bump:analyzers` task

### DIFF
--- a/analyzers.yml
+++ b/analyzers.yml
@@ -25,7 +25,6 @@ analyzers:
     name: cpplint
     github: cpplint/cpplint
     doc: tools/cplusplus/cpplint
-    dependabot: false
   detekt:
     name: detekt
     github: arturbosch/detekt

--- a/images/golangci_lint/Dockerfile
+++ b/images/golangci_lint/Dockerfile
@@ -4,7 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM sider/devon_rex_go:master
 
-ARG LINT_TOOL_VERSION="1.23.6"
+ARG LINT_TOOL_VERSION=1.23.6
 
 USER root
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v${LINT_TOOL_VERSION}

--- a/images/golangci_lint/Dockerfile.erb
+++ b/images/golangci_lint/Dockerfile.erb
@@ -1,6 +1,6 @@
 FROM sider/devon_rex_go:master
 
-ARG LINT_TOOL_VERSION="1.23.6"
+ARG LINT_TOOL_VERSION=1.23.6
 
 USER root
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v${LINT_TOOL_VERSION}

--- a/images/hadolint/Dockerfile
+++ b/images/hadolint/Dockerfile
@@ -4,7 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM sider/devon_rex_base:master
 
-ARG HADOLINT_VERSION="1.17.4"
+ARG HADOLINT_VERSION=1.17.4
 
 USER root
 

--- a/images/hadolint/Dockerfile.erb
+++ b/images/hadolint/Dockerfile.erb
@@ -1,6 +1,6 @@
 FROM sider/devon_rex_base:master
 
-ARG HADOLINT_VERSION="1.17.4"
+ARG HADOLINT_VERSION=1.17.4
 
 USER root
 


### PR DESCRIPTION
- The regex to detect a version does not work. So this fixes the script and Dockerfiles.
- Add `DRY_RUN` option to help us test the task locally.
  (usage: `rake bump:analyzers DRY_RUN=1`)
- Manage cpplint via Dependabot. (it has `Pipfile`)
  See #869 
