### PR TITLE
Add smoke test cases about `*.gemspec` files

### DIFF
--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -476,3 +476,13 @@ Smoke.add_test(
     }
   ]
 )
+
+Smoke.add_test(
+  "old_bundler_via_gemspec",
+  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "RuboCop", version: "0.80.1" } }
+)
+
+Smoke.add_test(
+  "latest_bundler_via_gemspec",
+  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "RuboCop", version: "0.80.1" } }
+)

--- a/test/smokes/rubocop/latest_bundler_via_gemspec/Gemfile
+++ b/test/smokes/rubocop/latest_bundler_via_gemspec/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/test/smokes/rubocop/latest_bundler_via_gemspec/foo.gemspec
+++ b/test/smokes/rubocop/latest_bundler_via_gemspec/foo.gemspec
@@ -1,0 +1,8 @@
+Gem::Specification.new do |spec|
+  spec.name    = "foo"
+  spec.version = "1.0.0"
+  spec.authors = ["Sider"]
+  spec.summary = "A summary"
+
+  spec.add_development_dependency "bundler", ">= 2.1"
+end

--- a/test/smokes/rubocop/old_bundler_via_gemspec/Gemfile
+++ b/test/smokes/rubocop/old_bundler_via_gemspec/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/test/smokes/rubocop/old_bundler_via_gemspec/foo.gemspec
+++ b/test/smokes/rubocop/old_bundler_via_gemspec/foo.gemspec
@@ -1,0 +1,8 @@
+Gem::Specification.new do |spec|
+  spec.name    = "foo"
+  spec.version = "1.0.0"
+  spec.authors = ["Sider"]
+  spec.summary = "A summary"
+
+  spec.add_development_dependency "bundler", "= 2.0.0"
+end


### PR DESCRIPTION
The new `old_bundler_via_gemspec` case outputs an error message as follows, but the analysis continues.

```
{:trace=>"stderr",
 :string=>
  "Bundler could not find compatible versions for gem \"bundler\":\n" +
  "  In Gemfile:\n" +
  "    bundler (= 2.0.0)\n" +
  "\n" +
  "  Current Bundler version:\n" +
  "    bundler (2.1.4)\n" +
  "This Gemfile requires a different version of Bundler.\n" +
  "Perhaps you need to update Bundler by running `gem install bundler`?\n" +
  "\n" +
  "Could not find gem 'bundler (= 2.0.0)' in any of the relevant sources:\n" +
  "  the local ruby installation",
 :recorded_at=>"2020-03-18T09:21:41.047Z",
 :truncated=>false}
{:trace=>"status", :status=>6, :recorded_at=>"2020-03-18T09:21:41.047Z"}
{:trace=>"error",
 :message=>
  "An error was found in your Gemfile but Sider continues the analysis by ignoring your dependencies.\n" +
  "If you want to make Sider aware of your dependencies, please fix the Gemfile according to the above error message, or commit your Gemfile.lock.",
 :recorded_at=>"2020-03-18T09:21:41.047Z",
 :truncated=>false}
 ```

Close #652
