### PR TITLE
Show composer and composer packages' versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - [cpplint] Bump cpplint from 1.4.4 to 1.4.5 [#869](https://github.com/sider/runners/pull/869)
 - [GolangCI-Lint] Bump GolangCI-Lint from 1.23.6 to 1.24.0 [#871](https://github.com/sider/runners/pull/871)
 - [hadolint] Bump hadolint from 1.17.4 to 1.17.5 [#872](https://github.com/sider/runners/pull/872)
+- Show composer and composer packages' versions [#876](https://github.com/sider/runners/pull/876)
 
 ## 0.21.7
 

--- a/lib/runners/php.rb
+++ b/lib/runners/php.rb
@@ -2,6 +2,8 @@ module Runners
   module PHP
     def show_runtime_versions
       capture3! "php", "-version"
+      capture3! "composer", "--version"
+      capture3! "composer", "global", "info"
     end
   end
 end


### PR DESCRIPTION
This change aims to make debugging easier.

An output example:

```
{:trace=>"command_line",
 :command_line=>["composer", "--version"],
 :recorded_at=>"2020-03-18T09:46:00.000Z"}
{:trace=>"stdout",
 :string=>"Composer version 1.10.0 2020-03-10 14:08:05",
 :recorded_at=>"2020-03-18T09:46:00.120Z",
 :truncated=>false}
{:trace=>"status", :status=>0, :recorded_at=>"2020-03-18T09:46:00.120Z"}
{:trace=>"command_line",
 :command_line=>["composer", "global", "info"],
 :recorded_at=>"2020-03-18T09:46:00.120Z"}
{:trace=>"stdout",
 :string=>
  "cakephp/cakephp-codesniffer            3.3.0  CakePHP CodeSniffer Standards\n" +
  "escapestudios/symfony2-coding-standard 3.11.0 CodeSniffer ruleset for the Symfony 2+ coding standard\n" +
  "squizlabs/php_codesniffer              3.5.4  PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.\n" +
  "wp-coding-standards/wpcs               2.2.1  PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
 :recorded_at=>"2020-03-18T09:46:00.219Z",
 :truncated=>false}
```
