### PR TITLE
[PHP_CodeSniffer] Deprecate `version` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - [GolangCI-Lint] Bump GolangCI-Lint from 1.23.6 to 1.24.0 [#871](https://github.com/sider/runners/pull/871)
 - [hadolint] Bump hadolint from 1.17.4 to 1.17.5 [#872](https://github.com/sider/runners/pull/872)
 - Show composer and composer packages' versions [#876](https://github.com/sider/runners/pull/876)
+- [PHP_CodeSniffer] Deprecate `version` option [#878](https://github.com/sider/runners/pull/878)
 
 ## 0.21.7
 

--- a/lib/runners/processor/code_sniffer.rb
+++ b/lib/runners/processor/code_sniffer.rb
@@ -33,24 +33,16 @@ module Runners
 
     def setup
       add_warning_if_deprecated_options([:options])
+      add_warning_if_deprecated_options([:version])
+
       yield
     end
 
     def analyze(changes)
-      check_runner_config do |options, target|
-        run_analyzer(options, target)
-      end
+      run_analyzer additional_options, directory
     end
 
     private
-
-    def check_runner_config
-      if config_linter[:version].to_i == 2
-        add_warning("Sider has no longer supported PHP_CodeSniffer v2. Sider executes v3 even if putting `2` as `version` option.", file: config.path_name)
-      end
-
-      yield additional_options, directory
-    end
 
     def analyzer_name
       "code_sniffer"

--- a/test/smokes/code_sniffer/expectations.rb
+++ b/test/smokes/code_sniffer/expectations.rb
@@ -102,8 +102,7 @@ Smoke.add_test(
   },
   warnings: [
     {
-      message:
-        "Sider has no longer supported PHP_CodeSniffer v2. Sider executes v3 even if putting `2` as `version` option.",
+      message: /The `\$\.linter\.code_sniffer\.version` option\(s\) in your `sider\.yml` are deprecated/,
       file: "sider.yml"
     }
   ]

--- a/test/smokes/code_sniffer/phpcs3/cakephp/sideci.yml
+++ b/test/smokes/code_sniffer/phpcs3/cakephp/sideci.yml
@@ -1,4 +1,3 @@
 linter:
   code_sniffer:
-    version: 3
     standard: CakePHP

--- a/test/smokes/code_sniffer/phpcs3/custom_argument/sideci.yml
+++ b/test/smokes/code_sniffer/phpcs3/custom_argument/sideci.yml
@@ -1,5 +1,4 @@
 linter:
   code_sniffer:
-    version: 3
     standard: ruleset.xml
     ignore: vendor

--- a/test/smokes/code_sniffer/phpcs3/specified_dir/sideci.yml
+++ b/test/smokes/code_sniffer/phpcs3/specified_dir/sideci.yml
@@ -1,4 +1,3 @@
 linter:
   code_sniffer:
-    version: 3
     dir: app/

--- a/test/smokes/code_sniffer/phpcs3/success/sideci.yml
+++ b/test/smokes/code_sniffer/phpcs3/success/sideci.yml
@@ -1,3 +1,0 @@
-linter:
-  code_sniffer:
-    version: 3

--- a/test/smokes/code_sniffer/phpcs3/symfony/sideci.yml
+++ b/test/smokes/code_sniffer/phpcs3/symfony/sideci.yml
@@ -1,4 +1,3 @@
 linter:
   code_sniffer:
-    version: 3
     standard: Symfony

--- a/test/smokes/code_sniffer/phpcs3/with_php_version/sideci.yml
+++ b/test/smokes/code_sniffer/phpcs3/with_php_version/sideci.yml
@@ -1,3 +1,0 @@
-linter:
-  code_sniffer:
-    version: 3

--- a/test/smokes/code_sniffer/phpcs3/wordpress/sideci.yml
+++ b/test/smokes/code_sniffer/phpcs3/wordpress/sideci.yml
@@ -1,4 +1,3 @@
 linter:
   code_sniffer:
-    version: 3
     standard: WordPress


### PR DESCRIPTION
The current `version` option supports only the value `3` and it's meaningless.
I've confirmed that there are no repositories using `version: 2`, so this change does the following:

- Remove the `version: 2` warning.
- Deprecate the usage of the `version` option.

## To-do

- [x] Update the [document](https://github.com/sider/sider-docs/blob/be82aa8ad71782b508e9f9c9577298baba616faf/docs/tools/php/codesniffer.md#version).
  => Open PR https://github.com/sider/sider-docs/pull/327