### PR TITLE
[Refactor] Remove `Processor#analyzer_name` override

### DIFF
--- a/lib/runners/processor/code_sniffer.rb
+++ b/lib/runners/processor/code_sniffer.rb
@@ -52,10 +52,6 @@ module Runners
       yield additional_options, directory
     end
 
-    def analyzer_name
-      "code_sniffer"
-    end
-
     def analyzer_bin
       "phpcs"
     end

--- a/lib/runners/processor/detekt.rb
+++ b/lib/runners/processor/detekt.rb
@@ -44,10 +44,6 @@ module Runners
       end
     end
 
-    def analyzer_name
-      'detekt'
-    end
-
     def detekt_config
       @detekt_config
     end

--- a/lib/runners/processor/javasee.rb
+++ b/lib/runners/processor/javasee.rb
@@ -35,10 +35,6 @@ module Runners
       @analyzer_version ||= extract_version! analyzer_bin, "version"
     end
 
-    def analyzer_name
-      'javasee'
-    end
-
     def analyze(changes)
       analyzer_version
 

--- a/lib/runners/processor/ktlint.rb
+++ b/lib/runners/processor/ktlint.rb
@@ -157,10 +157,6 @@ module Runners
       end
     end
 
-    def analyzer_name
-      'ktlint'
-    end
-
     def analyze(changes)
       delete_unchanged_files changes, only: [".kt", ".kts"]
 

--- a/lib/runners/processor/pmd_java.rb
+++ b/lib/runners/processor/pmd_java.rb
@@ -35,10 +35,6 @@ module Runners
       @analyzer_version ||= capture3!("show_pmd_version").yield_self { |stdout,| stdout.strip }
     end
 
-    def analyzer_name
-      'pmd_java'
-    end
-
     def analyzer_bin
       "pmd"
     end

--- a/lib/runners/processor/tslint.rb
+++ b/lib/runners/processor/tslint.rb
@@ -51,10 +51,6 @@ module Runners
       yield
     end
 
-    def analyzer_name
-      'TSLint'
-    end
-
     def analyze(_changes)
       options = [tslint_config, exclude, project, rules_dir, type_check].flatten.compact
       run_analyzer(target_glob, options)

--- a/test/smokes/code_sniffer/expectations.rb
+++ b/test/smokes/code_sniffer/expectations.rb
@@ -17,7 +17,7 @@ Smoke.add_test(
         git_blame_info: nil
       }
     ],
-    analyzer: { name: "code_sniffer", version: "3.5.4" }
+    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
   }
 )
 
@@ -38,7 +38,7 @@ Smoke.add_test(
         git_blame_info: nil
       }
     ],
-    analyzer: { name: "code_sniffer", version: "3.5.4" }
+    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
   },
   warnings: [
     {
@@ -58,14 +58,22 @@ Smoke.add_test(
 Smoke.add_test(
   "sideci_php_sandbox",
   {
-    guid: "test-guid", timestamp: :_, type: "success", issues: :_, analyzer: { name: "code_sniffer", version: "3.5.4" }
+    guid: "test-guid",
+    timestamp: :_,
+    type: "success",
+    issues: :_,
+    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
   }
 )
 
 Smoke.add_test(
   "with_php_version",
   {
-    guid: "test-guid", timestamp: :_, type: "success", issues: :_, analyzer: { name: "code_sniffer", version: "3.5.4" }
+    guid: "test-guid",
+    timestamp: :_,
+    type: "success",
+    issues: :_,
+    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
   }
 )
 
@@ -98,7 +106,7 @@ Smoke.add_test(
         git_blame_info: nil
       }
     ],
-    analyzer: { name: "code_sniffer", version: "3.5.4" }
+    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
   },
   warnings: [
     {
@@ -126,7 +134,7 @@ Smoke.add_test(
         git_blame_info: nil
       }
     ],
-    analyzer: { name: "code_sniffer", version: "3.5.4" }
+    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
   }
 )
 
@@ -156,6 +164,6 @@ Smoke.add_test(
         git_blame_info: nil
       }
     ],
-    analyzer: { name: "code_sniffer", version: "3.5.4" }
+    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
   }
 )

--- a/test/smokes/code_sniffer/phpcs3/expectations.rb
+++ b/test/smokes/code_sniffer/phpcs3/expectations.rb
@@ -17,7 +17,7 @@ Smoke.add_test(
         git_blame_info: nil
       }
     ],
-    analyzer: { name: "code_sniffer", version: "3.5.4" }
+    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
   }
 )
 
@@ -38,7 +38,7 @@ Smoke.add_test(
         git_blame_info: nil
       }
     ],
-    analyzer: { name: "code_sniffer", version: "3.5.4" }
+    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
   }
 )
 
@@ -68,7 +68,7 @@ Smoke.add_test(
         git_blame_info: nil
       }
     ],
-    analyzer: { name: "code_sniffer", version: "3.5.4" }
+    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
   }
 )
 
@@ -125,7 +125,7 @@ Smoke.add_test(
         git_blame_info: nil
       }
     ],
-    analyzer: { name: "code_sniffer", version: "3.5.4" }
+    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
   }
 )
 
@@ -156,7 +156,7 @@ Smoke.add_test(
         git_blame_info: nil
       }
     ],
-    analyzer: { name: "code_sniffer", version: "3.5.4" }
+    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
   }
 )
 
@@ -204,13 +204,17 @@ Smoke.add_test(
         git_blame_info: nil
       }
     ],
-    analyzer: { name: "code_sniffer", version: "3.5.4" }
+    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
   }
 )
 
 Smoke.add_test(
   "phpcs3/with_php_version",
   {
-    guid: "test-guid", timestamp: :_, type: "success", issues: :_, analyzer: { name: "code_sniffer", version: "3.5.4" }
+    guid: "test-guid",
+    timestamp: :_,
+    type: "success",
+    issues: :_,
+    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
   }
 )

--- a/test/smokes/javasee/expectations.rb
+++ b/test/smokes/javasee/expectations.rb
@@ -6,7 +6,7 @@ Smoke.add_test(
     guid: "test-guid",
     timestamp: :_,
     type: "success",
-    analyzer: { name: "javasee", version: "0.1.3" },
+    analyzer: { name: "JavaSee", version: "0.1.3" },
     issues: [
       {
         id: "hello",
@@ -27,7 +27,7 @@ Smoke.add_test(
     guid: "test-guid",
     timestamp: :_,
     type: "success",
-    analyzer: { name: "javasee", version: :_ },
+    analyzer: { name: "JavaSee", version: :_ },
     issues: [
       {
         id: "hello",
@@ -48,7 +48,7 @@ Smoke.add_test(
     guid: "test-guid",
     timestamp: :_,
     type: "failure",
-    analyzer: { name: "javasee", version: :_ },
+    analyzer: { name: "JavaSee", version: :_ },
     message: /java.lang.ClassCastException: class java.lang.Integer cannot be cast/
   }
 )
@@ -67,7 +67,7 @@ Smoke.add_test(
 
 Smoke.add_test(
   "no_config_file",
-  { guid: "test-guid", timestamp: :_, type: "success", analyzer: { name: "javasee", version: :_ }, issues: [] },
+  { guid: "test-guid", timestamp: :_, type: "success", analyzer: { name: "JavaSee", version: :_ }, issues: [] },
   {
     warnings: [
       {
@@ -84,5 +84,5 @@ Smoke.add_test(
 
 Smoke.add_test(
   "no_linting_files",
-  { guid: "test-guid", timestamp: :_, type: "success", analyzer: { name: "javasee", version: :_ }, issues: [] }
+  { guid: "test-guid", timestamp: :_, type: "success", analyzer: { name: "JavaSee", version: :_ }, issues: [] }
 )

--- a/test/smokes/pmd_java/expectations.rb
+++ b/test/smokes/pmd_java/expectations.rb
@@ -6,7 +6,7 @@ Smoke.add_test(
     guid: "test-guid",
     timestamp: :_,
     type: "success",
-    analyzer: { name: "pmd_java", version: "6.21.0" },
+    analyzer: { name: "PMD Java", version: "6.21.0" },
     issues: [
       {
         message: "System.out.println is used",
@@ -74,7 +74,7 @@ Smoke.add_test(
     guid: "test-guid",
     timestamp: :_,
     type: "success",
-    analyzer: { name: "pmd_java", version: "6.21.0" },
+    analyzer: { name: "PMD Java", version: "6.21.0" },
     issues: [
       {
         message: "Parameter 'args' is not assigned and could be declared final",
@@ -157,7 +157,7 @@ Smoke.add_test(
     guid: "test-guid",
     timestamp: :_,
     type: "success",
-    analyzer: { name: "pmd_java", version: "6.21.0" },
+    analyzer: { name: "PMD Java", version: "6.21.0" },
     issues: [
       {
         message: "Parameter 'args' is not assigned and could be declared final",
@@ -187,7 +187,7 @@ Smoke.add_test(
     guid: "test-guid",
     timestamp: :_,
     type: "success",
-    analyzer: { name: "pmd_java", version: "6.21.0" },
+    analyzer: { name: "PMD Java", version: "6.21.0" },
     issues: [
       {
         message: "Comment is too large: Too many lines",
@@ -217,7 +217,7 @@ Smoke.add_test(
     guid: "test-guid",
     timestamp: :_,
     type: "failure",
-    analyzer: { name: "pmd_java", version: "6.21.0" },
+    analyzer: { name: "PMD Java", version: "6.21.0" },
     message: "Unexpected error occurred. Please see the analysis log."
   }
 )
@@ -228,7 +228,7 @@ Smoke.add_test(
     guid: "test-guid",
     timestamp: :_,
     type: "success",
-    analyzer: { name: "pmd_java", version: "6.21.0" },
+    analyzer: { name: "PMD Java", version: "6.21.0" },
     issues: [
       {
         message: "violation message",
@@ -267,7 +267,7 @@ Smoke.add_test(
     guid: "test-guid",
     timestamp: :_,
     type: "success",
-    analyzer: { name: "pmd_java", version: "6.21.0" },
+    analyzer: { name: "PMD Java", version: "6.21.0" },
     issues: [
       {
         message: "The String literal \"Howdy\" appears 4 times in this file; the first occurrence is on line 3",


### PR DESCRIPTION
Note: the `analyzer_name` is not actually used in Sider.
