### PR TITLE
Fix the version of steep for Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :development, :test do
   gem 'minitest'
   gem 'rr'
   gem 'querly'
-  gem 'steep'
+  gem 'steep', "0.11.1"
   gem 'rubocop', require: false
   gem 'meowcop', require: false
   gem 'aufgaben', git: 'https://github.com/ybiquitous/aufgaben.git', tag: '0.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,12 +85,12 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
-    steep (0.14.0)
+    steep (0.11.1)
       activesupport (>= 5.1)
       ast_utils (~> 0.3.0)
-      language_server-protocol (~> 3.14.0.1)
+      language_server-protocol (~> 3.14.0)
       listen (~> 3.1)
-      parser (~> 2.7.0)
+      parser (~> 2.4)
       pry (~> 0.12.2)
       rainbow (>= 2.2.2, < 4.0)
     strong_json (2.1.0)
@@ -126,7 +126,7 @@ DEPENDENCIES
   rexml (>= 3.2, < 4.0)
   rr
   rubocop
-  steep
+  steep (= 0.11.1)
   strong_json
   unification_assertion
 


### PR DESCRIPTION
We are currently maintaining Steep v0.11.1 and v0.14.0, and `Gemfile`
should include Steep v0.11.1. v0.14.0 is declared in `Gemfile.steep`.

This is a revert of #882