### PR TITLE
[PHPMD] Some improvements

### DIFF
--- a/images/phpmd/sider_config.xml
+++ b/images/phpmd/sider_config.xml
@@ -1,35 +1,36 @@
-<?xml version="1.0"?>
-<ruleset name="SideCI Recommended rule set"
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="Sider Recommended Ruleset"
          xmlns="http://pmd.sf.net/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
-                     http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="
-                     http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+
   <description>
-    This rule set is recommended by SideCI.
+    This rule set is recommended by Sider.
     It contains only generic rules in all projects.
   </description>
 
+  <rule ref="rulesets/codesize.xml">
+    <exclude name="NPathComplexity" />
+  </rule>
+
+  <rule ref="rulesets/controversial.xml">
+    <exclude name="CamelCaseClassName" />
+    <exclude name="CamelCasePropertyName" />
+    <exclude name="CamelCaseMethodName" />
+    <exclude name="CamelCaseParameterName" />
+    <exclude name="CamelCaseVariableName" />
+  </rule>
+
+  <rule ref="rulesets/design.xml" />
+
+  <rule ref="rulesets/unusedcode.xml">
+    <exclude name="UnusedFormalParameter" />
+  </rule>
+
   <!--
   <rule ref="rulesets/cleancode.xml" />
-  -->
-  <rule ref="rulesets/codesize.xml">
-    <exclude name="NPathComplexity"></exclude>
-  </rule>
-  <rule ref="rulesets/controversial.xml">
-    <exclude name="CamelCaseClassName"></exclude>
-    <exclude name="CamelCasePropertyName"></exclude>
-    <exclude name="CamelCaseMethodName"></exclude>
-    <exclude name="CamelCaseParameterName"></exclude>
-    <exclude name="CamelCaseVariableName"></exclude>
-  </rule>
-  <rule ref="rulesets/design.xml" />
-  <!--
-    We think Naming rule is not important. So, we exclude it.
   <rule ref="rulesets/naming.xml" />
   -->
-  <rule ref="rulesets/unusedcode.xml">
-    <exclude name="UnusedFormalParameter"></exclude>
-  </rule>
+
 </ruleset>

--- a/test/smokes/phpmd/expectations.rb
+++ b/test/smokes/phpmd/expectations.rb
@@ -23,7 +23,13 @@ Smoke.add_test(
 
 Smoke.add_test(
   "invalid_rule",
-  { guid: "test-guid", timestamp: :_, type: "error", class: "Runners::Shell::ExecError", backtrace: :_, inspect: :_ }
+  {
+    guid: "test-guid",
+    timestamp: :_,
+    type: "failure",
+    message: "Invalid rule: \"invalid_rule\"",
+    analyzer: { name: "PHPMD", version: "2.8.1" }
+  }
 )
 
 Smoke.add_test(
@@ -33,6 +39,16 @@ Smoke.add_test(
     timestamp: :_,
     type: "success",
     issues: [
+      {
+        path: "app/index.php",
+        location: { start_line: 23, end_line: 23 },
+        id: "BooleanArgumentFlag",
+        message:
+          "The method bar has a boolean flag argument $flag, which is a certain sign of a Single Responsibility Principle violation.",
+        links: %w[https://phpmd.org/rules/cleancode.html#booleanargumentflag],
+        object: nil,
+        git_blame_info: nil
+      },
       {
         path: "app/index.php",
         location: { start_line: 20, end_line: 20 },
@@ -58,10 +74,10 @@ Smoke.add_test(
     warnings: [
       {
         message: <<~MSG
-    DEPRECATION WARNING!!!
-    The `$.linter.phpmd.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-    Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/php/phpmd ).
-  MSG
+          DEPRECATION WARNING!!!
+          The `$.linter.phpmd.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+          Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/php/phpmd ).
+        MSG
           .strip,
         file: "sideci.yml"
       }
@@ -71,7 +87,13 @@ Smoke.add_test(
 
 Smoke.add_test(
   "syntax_error",
-  { guid: "test-guid", timestamp: :_, type: "failure", message: :_, analyzer: { name: "PHPMD", version: "2.8.1" } }
+  {
+    guid: "test-guid",
+    timestamp: :_,
+    type: "failure",
+    message: /Unexpected end of token stream in file:/,
+    analyzer: { name: "PHPMD", version: "2.8.1" }
+  }
 )
 
 Smoke.add_test(

--- a/test/smokes/phpmd/valid_options/app/index.php
+++ b/test/smokes/phpmd/valid_options/app/index.php
@@ -19,4 +19,8 @@ class Main {
     function __construct(){
         $hoge = "hoge";
     }
+
+    function bar($flag = true) {
+        return $flag;
+    }
 }

--- a/test/smokes/phpmd/valid_options/sideci.yml
+++ b/test/smokes/phpmd/valid_options/sideci.yml
@@ -2,5 +2,6 @@ linter:
   phpmd:
     exclude: app/Controller/
     strict: true
+    rule: cleancode,codesize,controversial,design,naming,unusedcode
     options:
       suffixes: php,phtml


### PR DESCRIPTION
This change includes some improvements but they are not breaking:

- Refactor the default ruleset file.
- Change error type for an invalid rule error: `error` -> `failure`
- Refactor the application code.
- Add some smoke test cases.
