### PR TITLE
Remove `querly` and `rubocop` from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,7 @@ group :development, :test do
   gem 'rake'
   gem 'minitest'
   gem 'rr'
-  gem 'querly'
   gem 'steep', "0.11.1"
-  gem 'rubocop', require: false
   gem 'meowcop', require: false
   gem 'aufgaben', git: 'https://github.com/ybiquitous/aufgaben.git', tag: '0.4.1'
   gem 'lefthook', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ group :development, :test do
   gem 'minitest'
   gem 'rr'
   gem 'steep', "0.11.1"
-  gem 'meowcop', require: false
   gem 'aufgaben', git: 'https://github.com/ybiquitous/aufgaben.git', tag: '0.4.1'
   gem 'lefthook', require: false
   gem 'prettier', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,12 +62,6 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    querly (1.0.0)
-      activesupport (>= 5.0)
-      parallel (~> 1.17)
-      parser (>= 2.5.0)
-      rainbow (>= 2.1)
-      thor (>= 0.19.0, < 0.21.0)
     rainbow (3.0.0)
     rake (13.0.1)
     rb-fsevent (0.10.3)
@@ -120,12 +114,10 @@ DEPENDENCIES
   minitest
   parallel
   prettier
-  querly
   rake
   retryable
   rexml (>= 3.2, < 4.0)
   rr
-  rubocop
   steep (= 0.11.1)
   strong_json
   unification_assertion

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,6 @@ GEM
     git_diff_parser (3.2.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
-    jaro_winkler (1.5.4)
     jmespath (1.4.0)
     jsonseq (0.2.0)
     language_server-protocol (3.14.0.1)
@@ -51,8 +50,6 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     locale (2.1.3)
-    meowcop (2.8.0)
-      rubocop (>= 0.80.0, < 1.0.0)
     method_source (0.9.2)
     minitest (5.14.0)
     parallel (1.19.1)
@@ -70,15 +67,6 @@ GEM
     retryable (3.0.5)
     rexml (3.2.4)
     rr (1.2.1)
-    rubocop (0.80.1)
-      jaro_winkler (~> 1.5.1)
-      parallel (~> 1.10)
-      parser (>= 2.7.0.1)
-      rainbow (>= 2.2.2, < 4.0)
-      rexml
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
-    ruby-progressbar (1.10.1)
     steep (0.11.1)
       activesupport (>= 5.1)
       ast_utils (~> 0.3.0)
@@ -92,7 +80,6 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
-    unicode-display_width (1.6.1)
     unification_assertion (0.0.1)
       minitest (~> 5)
     zeitwerk (2.3.0)
@@ -110,7 +97,6 @@ DEPENDENCIES
   jsonseq
   lefthook
   locale
-  meowcop
   minitest
   parallel
   prettier


### PR DESCRIPTION
We are running them on Sider. This removal will reduce our update task of Gemfile.
