### PR TITLE
Add RuboCop plugins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,4 @@
 require:
-  - rubocop-md
   - rubocop-minitest
   - rubocop-performance
   - rubocop-rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,10 @@
+require:
+  - rubocop-md
+  - rubocop-minitest
+  - rubocop-performance
+  - rubocop-rake
+  - rubocop-rubycw
+
 inherit_gem:
   meowcop:
     - config/rubocop.yml

--- a/sider.yml
+++ b/sider.yml
@@ -1,6 +1,11 @@
 linter:
   rubocop:
     gems:
+      - rubocop-md
+      - rubocop-minitest
+      - rubocop-performance
+      - rubocop-rake
+      - rubocop-rubycw
       - meowcop
 
 ignore:

--- a/sider.yml
+++ b/sider.yml
@@ -1,7 +1,6 @@
 linter:
   rubocop:
     gems:
-      - rubocop-md
       - rubocop-minitest
       - rubocop-performance
       - rubocop-rake


### PR DESCRIPTION
This adds the [official RuboCop plugins](https://github.com/rubocop-hq?q=rubocop-&type=source&language=ruby) to analyze the Runners codebase.

This is a kind of dogfooding.
