### PR TITLE
[Refactor] Handle output file from each analyzer

### DIFF
--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -187,5 +187,39 @@ module Runners
     def show_runtime_versions
       # noop by default
     end
+
+    def read_output_file(file_path)
+      file_path_s = file_path.to_s
+      trace_writer.message "Reading output from #{file_path_s}..."
+      File.read(file_path_s).tap do |output|
+        if output.empty?
+          trace_writer.message "No output"
+        else
+          trace_writer.message output, limit: 24_000 # Prevent timeout
+        end
+      end
+    end
+
+    class InvalidXML < SystemError; end
+
+    def read_output_xml(file_path)
+      output = read_output_file(file_path)
+      REXML::Document.new(output).tap do |document|
+        unless document.root
+          message = "Output XML is invalid from #{file_path}"
+          trace_writer.error message
+          raise InvalidXML, message
+        end
+      end
+    end
+
+    def read_output_json(file_path, &block)
+      output = read_output_file(file_path)
+      if output.empty? && block_given?
+        block.call
+      else
+        JSON.parse(output, symbolize_names: true)
+      end
+    end
   end
 end

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -213,10 +213,10 @@ module Runners
       end
     end
 
-    def read_output_json(file_path, &block)
+    def read_output_json(file_path)
       output = read_output_file(file_path)
       if output.empty? && block_given?
-        block.call
+        yield
       else
         JSON.parse(output, symbolize_names: true)
       end

--- a/lib/runners/processor/ktlint.rb
+++ b/lib/runners/processor/ktlint.rb
@@ -87,7 +87,7 @@ module Runners
 
       output_file = gradle_config[:output]
       output = if output_file
-                 read_output_file(output_file)
+                 read_output_file(current_dir / output_file)
                else
                  stdout
                end
@@ -102,7 +102,7 @@ module Runners
       capture3("mvn", maven_config[:goal], *mvn_options)
 
       output_file = maven_config[:output]
-      read_output_file(current_dir / output_file)
+      output = read_output_file(current_dir / output_file)
 
       construct_result(maven_config[:reporter], output)
     end

--- a/lib/runners/processor/ktlint.rb
+++ b/lib/runners/processor/ktlint.rb
@@ -87,10 +87,7 @@ module Runners
 
       output_file = gradle_config[:output]
       output = if output_file
-                 trace_writer.message "Reading output from #{output_file}..."
-                 (current_dir + output_file).read.tap do |out|
-                   trace_writer.message out
-                 end
+                 read_output_file(output_file)
                else
                  stdout
                end
@@ -105,16 +102,7 @@ module Runners
       capture3("mvn", maven_config[:goal], *mvn_options)
 
       output_file = maven_config[:output]
-      output_file_path = current_dir / output_file
-      if output_file_path.exist?
-        trace_writer.message "Reading output from #{output_file}..."
-        output = output_file_path.read
-        trace_writer.message output
-      else
-        msg = "#{output_file} does not exist because an unexpected error occurred!"
-        trace_writer.error msg
-        raise msg
-      end
+      read_output_file(current_dir / output_file)
 
       construct_result(maven_config[:reporter], output)
     end

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -79,7 +79,7 @@ module Runners
     end
 
     def run_analyzer(changes, targets, rule, options)
-      report_file = Pathname(Tempfile.new("phpmd-report-").path)
+      report_file = Tempfile.new(["phpmd-", ".xml"]).path
 
       # PHPMD exits 1 when some violations are found.
       # The `--ignore-violation-on-exit` will exit with a zero code, even if any violations are found.
@@ -90,7 +90,7 @@ module Runners
         "xml",
         rule,
         "--ignore-violations-on-exit",
-        "--report-file", report_file.to_path,
+        "--report-file", report_file,
         *options
       )
 
@@ -102,17 +102,8 @@ module Runners
         end
       end
 
-      output_xml =
-        if report_file.exist?
-          report_file.read
-        else
-          raise "Failed to output a report file"
-        end
-
-      trace_writer.message output_xml
-
       begin
-        xml_doc = REXML::Document.new(output_xml)
+        xml_doc = read_output_xml(report_file)
       rescue REXML::ParseException => exn
         trace_writer.error exn.message
         return Results::Failure.new(guid: guid, analyzer: analyzer,

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -79,7 +79,7 @@ module Runners
     end
 
     def run_analyzer(changes, targets, rule, options)
-      report_file = Tempfile.new(["phpmd-", ".xml"]).path
+      report_file = Tempfile.create(["phpmd-", ".xml"]).path
 
       # PHPMD exits 1 when some violations are found.
       # The `--ignore-violation-on-exit` will exit with a zero code, even if any violations are found.

--- a/querly.yml
+++ b/querly.yml
@@ -54,3 +54,17 @@ rules:
           output_file = Pathname(Dir.tmpdir) / "output.json"
       - after: |
           output_file = working_dir / "output.json"
+  - id: sider.runners.tempfile_new
+    pattern: Tempfile.new
+    message: |
+      Consider using `Tempfile.create` instead of `Tempfile.new`.
+
+      `Tempfile.create` does **not** automatically remove the created file.
+      On the other hand, since `Tempfile.new` removes automatically the file, smoke tests can sometimes fail.
+
+      See https://ruby-doc.org/stdlib-2.7.0/libdoc/tempfile/rdoc/Tempfile.html
+    examples:
+      - before: |
+          Tempfile.new(["rubocop-", ".json"])
+      - after: |
+          Tempfile.create(["rubocop-", ".json"])

--- a/sig/polyfills/rexml.rbi
+++ b/sig/polyfills/rexml.rbi
@@ -1,0 +1,7 @@
+class REXML::Document
+  def initialize: (String) -> void
+  def root: () -> REXML::Element?
+end
+
+class REXML::Element
+end

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -149,7 +149,9 @@ class Runners::Processor
   def root_dir: -> Pathname
   def directory_traversal_attack?: (String) -> bool
   def show_runtime_versions: -> void
-  def git_blame_info: (String, Integer, Integer) -> Array<GitBlameInfo>
+  def read_output_file: (_ToS) -> String
+  def read_output_xml: (_ToS) -> REXML::Document
+  def read_output_json: <'x> (_ToS) { () -> 'x } -> (Hash<Symbol, any> | 'x)
 end
 
 type capture3_options = bool | Proc

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -381,4 +381,73 @@ class ProcessorTest < Minitest::Test
       assert_equal "Not found version from 'foo -v'", error.message
     end
   end
+
+  def test_read_output_file
+    with_workspace do |workspace|
+      file = (workspace.working_dir / "a_file").tap { |f| f.write "foo" }
+
+      processor = new_processor(workspace: workspace)
+      assert_equal "foo", processor.read_output_file(file)
+      assert_equal "foo", processor.read_output_file(file.to_path)
+    end
+  end
+
+  def test_read_output_file_failed
+    with_workspace do |workspace|
+      processor = new_processor(workspace: workspace)
+      assert_raises(Errno::ENOENT) { processor.read_output_file("not_found") }
+    end
+  end
+
+  def test_read_output_xml
+    with_workspace do |workspace|
+      file = (workspace.working_dir / "a_file.xml").tap { |f| f.write "<foo></foo>" }
+
+      processor = new_processor(workspace: workspace)
+      assert_instance_of REXML::Document, processor.read_output_xml(file)
+      assert_instance_of REXML::Document, processor.read_output_xml(file.to_path)
+    end
+  end
+
+  def test_read_output_xml_failed
+    with_workspace do |workspace|
+      file = (workspace.working_dir / "a_file.xml").tap { |f| f.write "" }
+
+      processor = new_processor(workspace: workspace)
+      error = assert_raises(Processor::InvalidXML) { processor.read_output_xml(file) }
+      assert_equal "Output XML is invalid from #{file}", error.message
+
+      file.write "<foo"
+      assert_raises(REXML::ParseException) { processor.read_output_xml(file) }
+    end
+  end
+
+  def test_read_output_json
+    with_workspace do |workspace|
+      file = (workspace.working_dir / "a_file.json").tap { |f| f.write '{"a":1}' }
+
+      processor = new_processor(workspace: workspace)
+      assert_equal({ a: 1 }, processor.read_output_json(file))
+    end
+  end
+
+  def test_read_output_json_empty
+    with_workspace do |workspace|
+      file = (workspace.working_dir / "a_file.json").tap { |f| f.write '' }
+
+      processor = new_processor(workspace: workspace)
+      assert_raises(JSON::ParserError) { processor.read_output_json(file) }
+      assert_nil processor.read_output_json(file) { nil }
+      assert_equal [], processor.read_output_json(file) { [] }
+    end
+  end
+
+  def test_read_output_json_failed
+    with_workspace do |workspace|
+      file = (workspace.working_dir / "a_file.json").tap { |f| f.write '{' }
+
+      processor = new_processor(workspace: workspace)
+      assert_raises(JSON::ParserError) { processor.read_output_json(file) }
+    end
+  end
 end


### PR DESCRIPTION
This change extracts the following common methods from each analyzer implementation:

- `Processor#read_output_file`
- `Processor#read_output_xml`
- `Processor#read_output_json`

Also, since recent smoke tests on CI are unstable due to the usage of `Tempfile.new`,
this fixes it to `Tempfile.create` and adds a Querly rule about the usage.

See also <https://ruby-doc.org/stdlib-2.7.0/libdoc/tempfile/rdoc/Tempfile.html>
