### PR TITLE
Add `--quiet` option to `git fetch`

### DIFF
--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -34,7 +34,7 @@ module Runners
         shell.capture3!("git", "init")
         shell.capture3!("git", "config", "gc.auto", "0")
         shell.capture3!("git", "remote", "add", "origin", remote_url.to_s)
-        shell.capture3!("git", *git_fetch_args)
+        shell.capture3!("git", "fetch", *git_fetch_args)
       end
     end
 
@@ -46,7 +46,7 @@ module Runners
     end
 
     def git_fetch_args
-      @git_fetch_args ||= %w[fetch --no-tags --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/*].tap do |command|
+      @git_fetch_args ||= %w[--quiet --no-tags --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/*].tap do |command|
         pull_number = git_source.pull_number
         command << "+refs/pull/#{pull_number}/head:refs/remotes/pull/#{pull_number}/head" if pull_number
       end

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -51,14 +51,14 @@ class WorkspaceGitTest < Minitest::Test
     with_workspace(head: "998bc02a913e3899f3a1cd327e162dd54d489a4b",
                    git_http_url: "https://github.com", owner: "sider", repo: "runners", pull_number: 533) do |workspace|
       assert_instance_of Runners::Workspace::Git, workspace
-      assert_equal %w[fetch --no-tags --no-recurse-submodules origin
+      assert_equal %w[--quiet --no-tags --no-recurse-submodules origin
                           +refs/heads/*:refs/remotes/origin/* +refs/pull/533/head:refs/remotes/pull/533/head], workspace.send(:git_fetch_args)
     end
 
     with_workspace(head: "998bc02a913e3899f3a1cd327e162dd54d489a4b",
                    git_http_url: "https://github.com", owner: "sider", repo: "runners") do |workspace|
       assert_instance_of Runners::Workspace::Git, workspace
-      assert_equal %w[fetch --no-tags --no-recurse-submodules origin
+      assert_equal %w[--quiet --no-tags --no-recurse-submodules origin
                           +refs/heads/*:refs/remotes/origin/*], workspace.send(:git_fetch_args)
     end
   end


### PR DESCRIPTION
This aims to reduce output to the trace output.
Not quiet `git fetch` outputs too much (including the progress bar).

https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt---quiet
