### PR TITLE
Add signature for Runners::Analyzer

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -3,6 +3,7 @@ target :lib do
   signature "sig_new"
 
   check "lib/runners.rb"
+  check "lib/runners/analyzer.rb"
   check "lib/runners/cli.rb"
   check "lib/runners/config.rb"
   check "lib/runners/errors.rb"

--- a/sig_new/runners/analyzer.rbs
+++ b/sig_new/runners/analyzer.rbs
@@ -1,0 +1,8 @@
+class Runners::Analyzer
+  attr_reader name: String
+  attr_reader version: String
+
+  def initialize: (name: String, version: String) -> untyped
+  def valid?: () -> bool
+  def as_json: () -> { name: String, version: String }
+end


### PR DESCRIPTION
I confirmed this signature worked after modifying `lib/runners.rb` like this:

```console
$ cat -n lib/runners.rb | tail  &&  BUNDLE_GEMFILE=Gemfile.steep bundle exec steep check lib/runners.rb                                                     (git)-[steep]-
   114
   115  module Runners
   116    def f
   117      Analyzer.new(name: 'ok', version: 'df').valid?
   118      Analyzer.new(name: 'ok', version: 'df').as_json
   119      Analyzer.new(name: 'ok', version: 'df') == Analyzer.new(name: 'ok', version: 'df')
   120      Analyzer.new(name: 'ok') # Invalid
   121      Analyzer.new(name: 'ok', version: 'df').unknown # Invalid
   122    end
   123  end
lib/runners.rb:120:17: MissingKeyword: version (name: 'ok')
lib/runners.rb:121:4: NoMethodError: type=::Runners::Analyzer, method=unknown (Analyzer.new(name: 'ok', version: 'df').unknown)
```