### PR TITLE
Required constraints for Node.js tools

### DIFF
--- a/lib/runners/nodejs.rb
+++ b/lib/runners/nodejs.rb
@@ -106,8 +106,12 @@ module Runners
     def check_nodejs_default_deps(defaults, constraints)
       defaults.all.each do |dependency|
         constraint = constraints[dependency.name]
-        if constraint&.unsatisfied_by?(dependency)
-          raise InvalidDefaultDependencies, "The default dependency `#{dependency}` must satisfy the constraint `#{constraint}`"
+        if constraint
+          unless constraint.satisfied_by?(dependency)
+            raise InvalidDefaultDependencies, "The default dependency `#{dependency}` must satisfy the constraint `#{constraint}`"
+          end
+        else
+          raise InvalidDefaultDependencies, "The default dependency `#{dependency}` must have a constraint"
         end
       end
 

--- a/lib/runners/nodejs/constraint.rb
+++ b/lib/runners/nodejs/constraint.rb
@@ -14,10 +14,6 @@ module Runners
         version = Gem::Version.create(dependency.version)
         @requirements.all? { |requirement| requirement.satisfied_by? version }
       end
-
-      def unsatisfied_by?(dependency)
-        !satisfied_by?(dependency)
-      end
     end
   end
 end

--- a/sig/runners/nodejs.rbi
+++ b/sig/runners/nodejs.rbi
@@ -45,5 +45,4 @@ end
 class Runners::Nodejs::Constraint
   def initialize: (String, *String) -> any
   def satisfied_by?: (Dependency) -> bool
-  def unsatisfied_by?: (Dependency) -> bool
 end

--- a/test/nodejs_test.rb
+++ b/test/nodejs_test.rb
@@ -321,8 +321,10 @@ class NodejsTest < Minitest::Test
       )
 
       processor.stub :nodejs_analyzer_global_version, "5.15.0" do
-        processor.send(:check_nodejs_default_deps, defaults, {})
-        pass "with an empty constraint"
+        error = assert_raises InvalidDefaultDependencies do
+          processor.send(:check_nodejs_default_deps, defaults, {})
+        end
+        assert_equal "The default dependency `eslint@5.15.0` must have a constraint", error.message
 
         constraints = { "eslint" => Constraint.new(">= 5.0.0", "< 7.0.0") }
         processor.send(:check_nodejs_default_deps, defaults, constraints)


### PR DESCRIPTION
This change requires the default version constraints for Node.js tools.
Actually, all tools have a default version constraints, so the change should have no effects (internal changes).

Also, this change removes the `Runners::Nodejs::Constraint#unsatisfied_by?` method, which can be replaced with more simple `satisfied_by?`.
