### PR TITLE
Fix Changes#include? to return false for unchanged files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.22.3...HEAD)
 
 - Fix #patches and use ... for git-diff(1) [#955](https://github.com/sider/runners/pull/955)
+- Fix Changes#include? to return false for unchanged files [#954](https://github.com/sider/runners/pull/954)
 
 ## 0.22.3
 

--- a/lib/runners/changes.rb
+++ b/lib/runners/changes.rb
@@ -32,10 +32,11 @@ module Runners
       gdp = patches # NOTE: This assignment is required for typecheck by Steep
       if gdp
         location = issue.location
-        return true unless location
         patch = gdp.find_patch_by_file(issue.path.to_s)
         if patch && location
           patch.changed_lines.one? { |line| location.start_line == line.number }
+        elsif patch
+          true
         else
           false
         end


### PR DESCRIPTION
The current implementation always return `true` when the `issue.location` is `nil`. This is wrong, and I fixed the method.
