### PR TITLE
Fix #patches and use ... for git-diff(1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.22.3...HEAD)
 
+- Fix #patches and use ... for git-diff(1) [#955](https://github.com/sider/runners/pull/955)
+
 ## 0.22.3
 
 [Full diff](https://github.com/sider/runners/compare/0.22.2...0.22.3)

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -58,7 +58,7 @@ module Runners
       if base && head
         git_directory.yield_self do |path|
           shell = Shell.new(current_dir: path, trace_writer: trace_writer, env_hash: {})
-          stdout, _ = shell.capture3!("git", "diff", base, head, trace_stdout: false)
+          stdout, _ = shell.capture3!("git", "diff", "#{base}...#{head}", trace_stdout: false)
           GitDiffParser.parse(stdout)
         end
       else

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -58,6 +58,7 @@ module Runners
       if base && head
         git_directory.yield_self do |path|
           shell = Shell.new(current_dir: path, trace_writer: trace_writer, env_hash: {})
+          # NOTE: We should use `...` (triple-dot) instead of `..` (double-dot). See https://git-scm.com/docs/git-diff
           stdout, _ = shell.capture3!("git", "diff", "#{base}...#{head}", trace_stdout: false)
           GitDiffParser.parse(stdout)
         end


### PR DESCRIPTION
https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-Comparingbranches

According to this document, comparing branches with `...` means like
this:

> Changes that occurred on the master branch since when the topic branch
> was started off it.

I think using `...` is appropriate for our use case.
