### PR TITLE
Delete noisy warning on `npm install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Fix #patches and use ... for git-diff(1) [#955](https://github.com/sider/runners/pull/955)
 - Fix Changes#include? to return false for unchanged files [#954](https://github.com/sider/runners/pull/954)
+- Delete noisy warning on `npm install` [#957](https://github.com/sider/runners/pull/957)
 
 ## 0.22.3
 

--- a/lib/runners/nodejs.rb
+++ b/lib/runners/nodejs.rb
@@ -227,17 +227,11 @@ module Runners
 
       return if installed_deps.empty?
 
-      warn_about_fallback_to_default = -> {
-        add_warning <<~MSG, file: "package.json"
-          No required dependencies for analysis were installed. Instead, the pre-installed `#{default_dependency}` will be used.
-        MSG
-      }
-
       all_constraints_satisfied = true
 
       constraints.each do |name, constraint|
         unless installed_deps.key? name
-          warn_about_fallback_to_default.call
+          # NOTE: No required dependencies. Instead, use the default version.
           break
         end
 

--- a/test/nodejs_test.rb
+++ b/test/nodejs_test.rb
@@ -627,14 +627,12 @@ class NodejsTest < Minitest::Test
       ### assert warnings output
 
       expected_warnings = [
-        "No required dependencies for analysis were installed. Instead, the pre-installed `eslint@5.1.0` will be used.",
         "The required dependency `eslint` may not have been correctly installed. It may be a missing peer dependency."
       ]
       actual_warnings = trace_writer.writer.select { |e| e[:trace] == :warning }.map { |e| e[:message] }
       assert_equal expected_warnings, actual_warnings
       assert_equal [
         { message: expected_warnings[0], file: "package.json" },
-        { message: expected_warnings[1], file: "package.json" },
       ], processor.warnings
 
       expected_errors = [

--- a/test/smokes/tslint/expectations.rb
+++ b/test/smokes/tslint/expectations.rb
@@ -319,23 +319,13 @@ Smoke.add_test(
 Smoke.add_test(
   "without-tslint-in-package-json",
   { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "TSLint", version: "6.0.0" } },
-  {
-    warnings: [
-      { message: /The support for TSLint is deprecated/, file: "sider.yml" },
-      { message: /No required dependencies for analysis were installed/, file: "package.json" }
-    ]
-  }
+  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
 )
 
 Smoke.add_test(
   "without-tslint-and-with-typescript-in-package-json",
   { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "TSLint", version: "6.0.0" } },
-  {
-    warnings: [
-      { message: /The support for TSLint is deprecated/, file: "sider.yml" },
-      { message: /No required dependencies for analysis were installed/, file: "package.json" }
-    ]
-  }
+  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
 )
 
 Smoke.add_test(

--- a/test/smokes/tyscan/expectations.rb
+++ b/test/smokes/tyscan/expectations.rb
@@ -91,8 +91,7 @@ Smoke.add_test(
       }
     ],
     analyzer: { name: "TyScan", version: "0.3.1" }
-  },
-  { warnings: [{ message: /No required dependencies for analysis were installed/, file: "package.json" }] }
+  }
 )
 
 Smoke.add_test(


### PR DESCRIPTION
This removed warning is not useful for most users.

Fix #956 
