### PR TITLE
Add `:merge_output` option to `Shell#capture3_trace`

### DIFF
--- a/lib/runners/shell.rb
+++ b/lib/runners/shell.rb
@@ -102,11 +102,18 @@ module Runners
       chdir = options[:chdir] || current_dir
       is_success = options.fetch(:is_success) { ->(status) { status.success? } }
       stdin_data = options.fetch(:stdin_data, nil)
+      merge_output = options.fetch(:merge_output, false)
 
       command_line = [command] + args
       trace_writer.command_line(command_line) if trace_command_line
 
-      Open3.capture3(env_hash, command, *args, chdir: chdir.to_s, stdin_data: stdin_data).tap do |stdout_str, stderr_str, status|
+      method = merge_output ? :capture2e : :capture3
+      Open3.public_send(method, env_hash, command, *args, chdir: chdir.to_s, stdin_data: stdin_data).then do |stdout_str, stderr_str, status|
+        if merge_output
+          status = stderr_str
+          stderr_str = nil
+        end
+
         trace_writer.stdout stdout_str if trace_stdout
         trace_writer.stderr stderr_str if trace_stderr
 
@@ -118,7 +125,7 @@ module Runners
 
         unless is_success.call(status)
           if raise_on_failure
-            raise ExecError.new(type: :capture3,
+            raise ExecError.new(type: method,
                                 args: command_line,
                                 stdout_str: stdout_str,
                                 stderr_str: stderr_str,
@@ -126,6 +133,8 @@ module Runners
                                 dir: current_dir)
           end
         end
+
+        [stdout_str, stderr_str, status]
       end
     end
   end

--- a/lib/runners/shell.rb
+++ b/lib/runners/shell.rb
@@ -111,7 +111,7 @@ module Runners
       Open3.public_send(method, env_hash, command, *args, chdir: chdir.to_s, stdin_data: stdin_data).then do |stdout_str, stderr_str, status|
         if merge_output
           status = stderr_str
-          stderr_str = nil
+          stderr_str = ""
         end
 
         trace_writer.stdout stdout_str if trace_stdout

--- a/lib/runners/trace_writer.rb
+++ b/lib/runners/trace_writer.rb
@@ -16,6 +16,8 @@ module Runners
     end
 
     def stdout(string, recorded_at: now, max_length: 4_000)
+      return unless string
+
       string = string.strip
       return if string.empty?
 
@@ -25,6 +27,8 @@ module Runners
     end
 
     def stderr(string, recorded_at: now, max_length: 4_000)
+      return unless string
+
       string = string.strip
       return if string.empty?
 

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -27,6 +27,7 @@ end
 extension Object (Polyfill)
   def instance_of?: (any) -> bool
   def then: <'a> () { (self) -> 'a } -> 'a
+  def public_send: (String | Symbol, *any) -> any
 end
 
 class UnboundMethod

--- a/test/shell_test.rb
+++ b/test/shell_test.rb
@@ -173,7 +173,7 @@ class ShellTest < Minitest::Test
       stdout_and_stderr, stderr, status = shell.capture3_trace(output_to_both, merge_output: true)
 
       assert_equal "stdout\nstderr\n", stdout_and_stderr
-      assert_nil stderr
+      assert_equal "", stderr
       assert status.success?
       assert_equal [
         { trace: :command_line, command_line: ["echo 'stdout' ; echo 'stderr' >&2"] },
@@ -194,7 +194,7 @@ class ShellTest < Minitest::Test
       assert_equal :capture2e, error.type
       assert_equal ["echo 'Hello' ; exit 1"], error.args
       assert_equal "Hello\n", error.stdout_str
-      assert_nil error.stderr_str
+      assert_equal "", error.stderr_str
       assert_equal 1, error.status.exitstatus
       assert_equal path, error.dir
     end

--- a/test/shell_test.rb
+++ b/test/shell_test.rb
@@ -164,4 +164,39 @@ class ShellTest < Minitest::Test
       assert_equal "Number: 1", stdout
     end
   end
+
+  def test_capture3_trace_with_merge_output
+    mktmpdir do |path|
+      shell = Shell.new(current_dir: path, trace_writer: trace_writer, env_hash: {})
+
+      output_to_both = "echo 'stdout' ; echo 'stderr' >&2"
+      stdout_and_stderr, stderr, status = shell.capture3_trace(output_to_both, merge_output: true)
+
+      assert_equal "stdout\nstderr\n", stdout_and_stderr
+      assert_nil stderr
+      assert status.success?
+      assert_equal [
+        { trace: :command_line, command_line: ["echo 'stdout' ; echo 'stderr' >&2"] },
+        { trace: :stdout, string: "stdout\n" + "stderr", truncated: false },
+        { trace: :status, status: 0 },
+      ], trace_writer.writer.each { |entry| entry.delete(:recorded_at) }
+    end
+  end
+
+  def test_capture3_trace_with_merge_output_and_errored
+    mktmpdir do |path|
+      shell = Shell.new(current_dir: path, trace_writer: trace_writer, env_hash: {})
+
+      error = assert_raises Shell::ExecError do
+        shell.capture3_trace("echo 'Hello' ; exit 1", merge_output: true, raise_on_failure: true)
+      end
+
+      assert_equal :capture2e, error.type
+      assert_equal ["echo 'Hello' ; exit 1"], error.args
+      assert_equal "Hello\n", error.stdout_str
+      assert_nil error.stderr_str
+      assert_equal 1, error.status.exitstatus
+      assert_equal path, error.dir
+    end
+  end
 end


### PR DESCRIPTION
Usage:

```ruby
stdout_and_stderr, _, status = shell.capture3_trace(some_command, merge_output: true)
```

I will use this new option for #787.

Note: [`Open3.capture2e`](https://ruby-doc.org/stdlib-2.7.1/libdoc/open3/rdoc/Open3.html#method-c-capture2e) is used internally.