### PR TITLE
Improve string regexp in `Testing::Smoke#colored_pretty_inspect`

### DIFF
--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -135,7 +135,7 @@ module Runners
         hash.pretty_inspect
           .gsub(/(:\w+)=>/, Rainbow('\1').yellow + "=>")
           .gsub(/(nil|false|true)/, Rainbow('\1').cyan)
-          .gsub(/("[^"]+")/, Rainbow('\1').green)
+          .gsub(/("(?:[^\\"]|\\.)*")/, Rainbow('\1').green)
       end
 
       @tests = {}


### PR DESCRIPTION
According to <https://stackoverflow.com/questions/481282/how-can-i-match-double-quoted-strings-with-escaped-double-quote-characters>.
