### PR TITLE
[Test] Use `amazing_print` instead of `rainbow` for smoke test's colored output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :development, :test do
   gem 'rr'
   gem 'unification_assertion'
   gem 'parallel'
-  gem 'rainbow'
+  gem 'amazing_print'
   gem 'steep', "0.11.1"
   gem 'aufgaben', git: 'https://github.com/ybiquitous/aufgaben.git', tag: '0.5.0'
   gem 'lefthook', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
+    amazing_print (1.0.0)
     ast (2.4.0)
     ast_utils (0.3.0)
       parser (~> 2.4)
@@ -89,6 +90,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  amazing_print
   aufgaben!
   aws-sdk-s3
   bugsnag
@@ -100,7 +102,6 @@ DEPENDENCIES
   minitest
   parallel
   prettier
-  rainbow
   rake
   retryable
   rexml (>= 3.2, < 4.0)

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -2,7 +2,7 @@ require "minitest"
 require "unification_assertion"
 require "pp"
 require 'parallel'
-require "rainbow"
+require "amazing_print"
 
 module Runners
   module Testing
@@ -132,10 +132,7 @@ module Runners
       end
 
       def colored_pretty_inspect(hash)
-        hash.pretty_inspect
-          .gsub(/(:\w+)=>/, Rainbow('\1').yellow + "=>")
-          .gsub(/(nil|false|true)/, Rainbow('\1').cyan)
-          .gsub(/("(?:[^\\"]|\\.)*")/, Rainbow('\1').green)
+        hash.awesome_inspect(indent: 2, index: false)
       end
 
       @tests = {}


### PR DESCRIPTION
[amazing_print](https://github.com/amazing-print/amazing_print) is a fork of [awesome_print](https://github.com/awesome-print/awesome_print).
awesome_print is no longer maintained and does not support Ruby 2.7.

See also #908

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/473530/79087441-352f5d00-7d7a-11ea-8352-e2ea58b20612.png">


