### PR TITLE
[Refactor] Reduce common patter for `Dir.mktmpdir`

### DIFF
--- a/lib/runners.rb
+++ b/lib/runners.rb
@@ -36,6 +36,7 @@ require "strscan"
 
 require "runners/version"
 require "runners/errors"
+require "runners/tmpdir"
 require "runners/config"
 require "runners/options"
 require "runners/git_blame_info"

--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -2,6 +2,8 @@ require "optparse"
 
 module Runners
   class CLI
+    include Tmpdir
+
     # @dynamic stdout, stderr, guid, analyzer, options
     attr_reader :stdout
     attr_reader :stderr
@@ -26,10 +28,8 @@ module Runners
       @options = Options.new(stdout, stderr)
     end
 
-    def with_working_dir
-      Dir.mktmpdir do |dir|
-        yield Pathname(dir)
-      end
+    def with_working_dir(&block)
+      mktmpdir(&block)
     end
 
     def processor_class

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -1,5 +1,7 @@
 module Runners
   class Processor
+    include Tmpdir
+
     class CIConfigBroken < UserError; end
 
     attr_reader :guid, :workspace, :working_dir, :git_ssh_path, :trace_writer, :warnings, :config, :shell

--- a/lib/runners/ruby.rb
+++ b/lib/runners/ruby.rb
@@ -13,9 +13,7 @@ module Runners
 
       specs = GemInstaller::Spec.merge(default_specs, user_specs.size > 0 ? user_specs : optionals)
 
-      Dir.mktmpdir do |dir|
-        path = Pathname(dir)
-
+      mktmpdir do |path|
         installer = GemInstaller.new(shell: shell,
                                      home: path,
                                      config_path_name: config.path_name,

--- a/lib/runners/ruby/lockfile_loader.rb
+++ b/lib/runners/ruby/lockfile_loader.rb
@@ -1,6 +1,8 @@
 module Runners
   module Ruby
     class LockfileLoader
+      include Tmpdir
+
       class InvalidGemfileLock < InstallGemsFailure; end
 
       attr_reader :root_dir
@@ -18,8 +20,8 @@ module Runners
             shell.trace_writer.message "Gemfile and Gemfile.lock detected"
             gemfile_lock_path.read
           when gemfile_path.file?
-            Dir.mktmpdir do |dir|
-              generate_lockfile(Pathname(dir) / "Gemfile.lock")
+            mktmpdir do |dir|
+              generate_lockfile(dir / "Gemfile.lock")
             end
           end
 

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -9,6 +9,7 @@ module Runners
     class Smoke
       include Minitest::Assertions
       include UnificationAssertion
+      include Tmpdir
 
       ROOT_DATA_DIR = Pathname('/data')
 
@@ -116,8 +117,8 @@ module Runners
       def command_line(name, config)
         dir = data_smoke_path / name
         ssh_key = config.ssh_key&.yield_self do |file|
-          Dir.mktmpdir do |tmp_dir|
-            tmp_ssh_key_path = Pathname(tmp_dir) / 'ssh_key'
+          mktmpdir do |tmp_dir|
+            tmp_ssh_key_path = tmp_dir / 'ssh_key'
             system! "docker cp #{data_container}:#{dir.expand_path / file} #{tmp_ssh_key_path}"
             tmp_ssh_key_path.read
           end

--- a/lib/runners/tmpdir.rb
+++ b/lib/runners/tmpdir.rb
@@ -1,0 +1,14 @@
+module Runners
+  module Tmpdir
+    def mktmpdir
+      Dir.mktmpdir do |dir|
+        yield Pathname(dir)
+      end
+    end
+
+    # TODO: We should unify `#mktmpdir` and `mktmpdir_as_pathname` but Steep checking fails...
+    def mktmpdir_as_pathname
+      Pathname(Dir.mktmpdir)
+    end
+  end
+end

--- a/querly.yml
+++ b/querly.yml
@@ -54,6 +54,12 @@ rules:
           output_file = Pathname(Dir.tmpdir) / "output.json"
       - after: |
           output_file = working_dir / "output.json"
+  - id: sider.runners.mktmpdir
+    pattern: Dir.mktmpdir
+    message: The code probably may be more simple if using `Runners::Tmpdir` instead.
+    examples:
+      - before: Dir.mktmpdir { |dir| puts Pathname(dir) }
+        after: mktmpdir { |dir| puts dir }
   - id: sider.runners.tempfile_new
     pattern: Tempfile.new
     message: |

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -1,5 +1,6 @@
 class Pathname
   def self.glob: (String | Pathname | Array<Pathname> | Array<String>, ?Integer) -> Array<Pathname>
+  def initialize: (_ToS) -> void
   def glob: (String | Pathname | Array<Pathname> | Array<String>, ?Integer) -> Array<Pathname>
   def +: (Pathname | String) -> Pathname
   alias / +

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -1,6 +1,5 @@
 class Pathname
   def self.glob: (String | Pathname | Array<Pathname> | Array<String>, ?Integer) -> Array<Pathname>
-  def initialize: (_ToS) -> void
   def glob: (String | Pathname | Array<Pathname> | Array<String>, ?Integer) -> Array<Pathname>
   def +: (Pathname | String) -> Pathname
   alias / +

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -102,6 +102,8 @@ class Runners::Changes
 end
 
 class Runners::Processor
+  include Tmpdir
+
   attr_reader guid: String
   attr_reader workspace: Workspace
   attr_reader working_dir: Pathname
@@ -207,6 +209,8 @@ class Runners::Harness::InvalidResult < StandardError
 end
 
 class Runners::CLI
+  include Tmpdir
+
   attr_reader stdout: ::IO
   attr_reader stderr: ::IO
   attr_reader guid: String

--- a/sig/runners/ruby.rbi
+++ b/sig/runners/ruby.rbi
@@ -89,6 +89,8 @@ class Runners::Ruby::GemInstaller::Source::Git < Runners::Ruby::GemInstaller::So
 end
 
 class Runners::Ruby::LockfileLoader
+  include Tmpdir
+
   attr_reader root_dir: Pathname
   attr_reader shell: Shell
 

--- a/sig/runners/testing.rbi
+++ b/sig/runners/testing.rbi
@@ -1,6 +1,7 @@
 class Runners::Testing::Smoke
   include Minitest::Assertions
   include UnificationAssertion
+  include Tmpdir
 
   attr_reader argv: Array<String>
   attr_reader data_container: String

--- a/sig/runners/tmpdir.rbi
+++ b/sig/runners/tmpdir.rbi
@@ -1,0 +1,6 @@
+module Runners::Tmpdir
+  include Kernel
+
+  def mktmpdir: <'x> { (Pathname) -> 'x } -> 'x
+  def mktmpdir_as_pathname: -> Pathname
+end

--- a/sig/runners/workspace.rbi
+++ b/sig/runners/workspace.rbi
@@ -1,4 +1,6 @@
 class Runners::Workspace
+  include Tmpdir
+
   attr_reader options: Options
   attr_reader working_dir: Pathname
   attr_reader trace_writer: TraceWriter

--- a/sig_new/runners/cli.rbs
+++ b/sig_new/runners/cli.rbs
@@ -1,4 +1,6 @@
 class Runners::CLI
+  include Tmpdir
+
   attr_reader stdout: ::IO
   attr_reader stderr: ::IO
   attr_reader guid: String

--- a/sig_new/runners/tmpdir.rbs
+++ b/sig_new/runners/tmpdir.rbs
@@ -1,0 +1,6 @@
+module Runners::Tmpdir
+  include Kernel
+
+  def mktmpdir: [X] { (Pathname) -> X } -> X
+  def mktmpdir_as_pathname: -> Pathname
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,12 +8,7 @@ require "rr"
 
 module TestHelper
   include UnificationAssertion
-
-  def mktmpdir
-    Dir.mktmpdir do |dir|
-      yield Pathname(dir)
-    end
-  end
+  include Runners::Tmpdir
 
   def data(file)
     Pathname(__dir__).join("data", file)
@@ -45,9 +40,8 @@ module TestHelper
 
     with_runners_options_env(source: source, ssh_key: ssh_key) do
       options = Runners::Options.new(StringIO.new, StringIO.new)
-      Dir.mktmpdir do |dir|
-        workspace = Runners::Workspace.prepare(options: options, working_dir: Pathname(dir), trace_writer: Runners::TraceWriter.new(writer: []))
-        yield workspace
+      mktmpdir do |dir|
+        yield Runners::Workspace.prepare(options: options, working_dir: dir, trace_writer: Runners::TraceWriter.new(writer: []))
       end
     end
   end


### PR DESCRIPTION
This change introduces a new `Runners::Tmpdir` module to reduce the duplication.

For example:

```diff
+include Tmpdir

-Dir.mktmpdir do |dir|
-  generate_lockfile(Pathname(dir) / "Gemfile.lock")
+mktmpdir do |dir|
+  generate_lockfile(dir / "Gemfile.lock")
 end
```

