### PR TITLE
Improve performance for `Changes` class

### DIFF
--- a/lib/runners/changes.rb
+++ b/lib/runners/changes.rb
@@ -6,9 +6,9 @@ module Runners
     attr_reader :patches
 
     def initialize(changed_paths:, unchanged_paths:, untracked_paths:, patches:)
-      @changed_paths = changed_paths
-      @unchanged_paths = unchanged_paths
-      @untracked_paths = untracked_paths
+      @changed_paths = Set.new(changed_paths).freeze
+      @unchanged_paths = Set.new(unchanged_paths).freeze
+      @untracked_paths = Set.new(untracked_paths).freeze
       @patches = patches
     end
 
@@ -42,7 +42,7 @@ module Runners
           false
         end
       else
-        Set.new(changed_paths).member?(issue.path)
+        changed_paths.member?(issue.path)
       end
     end
 

--- a/lib/runners/changes.rb
+++ b/lib/runners/changes.rb
@@ -16,6 +16,7 @@ module Runners
       unchanged_paths
         .filter { |file| deletable?(dir, file, except, only) }
         .each { |file| dir.join(file).delete }
+        .to_a
     end
 
     def deletable?(dir, file, except, only)

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -205,3 +205,7 @@ end
 # HACK: To avoid receiving the error message `Unknown alias: untyped`,
 #       define `untyped` alias here. Such a hack is required until the migration to Steep 0.14 or later completes.
 type untyped = any
+
+extension Set<'a> (Polyfill)
+  def filter: { ('a) -> any } -> Set<'a>
+end

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -86,9 +86,9 @@ class Runners::Results::Error < Runners::Results::Base
 end
 
 class Runners::Changes
-  attr_reader changed_paths: Array<Pathname>
-  attr_reader unchanged_paths: Array<Pathname>
-  attr_reader untracked_paths: Array<Pathname>
+  attr_reader changed_paths: Set<Pathname>
+  attr_reader unchanged_paths: Set<Pathname>
+  attr_reader untracked_paths: Set<Pathname>
   attr_reader patches: GitDiffParser::Patches | nil
 
   def initialize: (changed_paths: Array<Pathname>,

--- a/test/changes_test.rb
+++ b/test/changes_test.rb
@@ -58,9 +58,9 @@ index 740c016..cc737a5 100644
 
           changes = Changes.calculate(base_dir: base_path, head_dir: head_path, working_dir: working_path, patches: nil)
 
-          assert_equal [Pathname("changed1.rb"), Pathname("changed2.rb")], changes.changed_paths
-          assert_equal [Pathname("unchanged.rb")], changes.unchanged_paths
-          assert_equal [Pathname("built1.rb"), Pathname("built2.rb")], changes.untracked_paths
+          assert_equal Set[Pathname("changed1.rb"), Pathname("changed2.rb")], changes.changed_paths
+          assert_equal Set[Pathname("unchanged.rb")], changes.unchanged_paths
+          assert_equal Set[Pathname("built1.rb"), Pathname("built2.rb")], changes.untracked_paths
         end
       end
     end
@@ -89,9 +89,9 @@ index 740c016..cc737a5 100644
 
           changes = Changes.calculate(base_dir: base_path, head_dir: head_path, working_dir: working_path, patches: nil)
 
-          assert_equal [Pathname("changed1.rb"), Pathname("changed2.rb"), Pathname("unchanged.rb")], changes.changed_paths
-          assert_equal [], changes.unchanged_paths
-          assert_equal [Pathname("built1.rb"), Pathname("built2.rb")], changes.untracked_paths
+          assert_equal Set[Pathname("changed1.rb"), Pathname("changed2.rb"), Pathname("unchanged.rb")], changes.changed_paths
+          assert_equal Set[], changes.unchanged_paths
+          assert_equal Set[Pathname("built1.rb"), Pathname("built2.rb")], changes.untracked_paths
         end
       end
     end


### PR DESCRIPTION
`Changes#include?` is called in the following loop:

https://github.com/sider/runners/blob/ba501d8c1423cdec467df1ac3b5572e508d28a15/lib/runners/results.rb#L64-L68

This avoids the creation of a `Set` instance on each loop iteration.
