### PR TITLE
Fix failures due to Ruby 2.7

### DIFF
--- a/lib/runners/processor/goodcheck.rb
+++ b/lib/runners/processor/goodcheck.rb
@@ -38,7 +38,11 @@ module Runners
     end
 
     def goodcheck_test
-      stdout, stderr, status = capture3(*ruby_analyzer_bin, "test", *cli_options)
+      # NOTE: Suppress Ruby 2.7 warning to prevent `stderr` from getting dirty.
+      #       See https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released
+      stdout, stderr, status = push_env_hash({ "RUBYOPT" => "-W:no-deprecated" }) do
+        capture3(*ruby_analyzer_bin, "test", *cli_options)
+      end
 
       if !status.success? && !stdout.empty?
         msg = "The validation of your Goodcheck configuration file failed. Check the output of `goodcheck test` command."

--- a/test/smokes/jshint/expectations.rb
+++ b/test/smokes/jshint/expectations.rb
@@ -124,7 +124,7 @@ Smoke.add_test(
 Smoke.add_test(
   "broken_package_json",
   { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "JSHint", version: "2.11.0" } },
-  { warnings: [{ message: /`package.json` is broken: 767: unexpected token at/, file: "package.json" }] }
+  { warnings: [{ message: /`package.json` is broken: \d+: unexpected token at/, file: "package.json" }] }
 )
 
 Smoke.add_test(


### PR DESCRIPTION
> If you want to disable the deprecation warnings, please use a command-line argument `-W:no-deprecated` or add `Warning[:deprecated] = false` to your code.

-- https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/
