### PR TITLE
[Refactor] Write a smoke test more easily

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,6 +35,7 @@ task :default => [:test, :typecheck]
 task :typecheck do
   # FIXME: Must check all files.
   files = Dir.glob("lib/runners/**/*.rb").reject { |f| f.include? "processor/" }
+  files += Dir.glob("test/smokes/**/expectations.rb")
   sh "steep", "check", *files
 end
 

--- a/docs/how-to-write-a-new-runner.md
+++ b/docs/how-to-write-a-new-runner.md
@@ -105,23 +105,19 @@ Smoke = Runners::Testing::Smoke
 
 Smoke.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "foo.rb",
-        location: { start_line: 81 },
-        id: "foo-rule-1",
-        message: "A violation is detected",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "foolint", version: "1.2.3" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "foo.rb",
+      location: { start_line: 81 },
+      id: "foo-rule-1",
+      message: "A violation is detected",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "foolint", version: "1.2.3" }
 )
 ```
 

--- a/docs/how-to-write-a-new-runner.md
+++ b/docs/how-to-write-a-new-runner.md
@@ -101,9 +101,9 @@ For example, you need to create a `test/smokes/foolint/expectations.rb` and add 
 
 ```ruby
 # test/smokes/foolint/expectations.rb
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
   type: "success",
   issues: [

--- a/lib/runners/results.rb
+++ b/lib/runners/results.rb
@@ -90,7 +90,7 @@ module Runners
       def as_json
         super.tap do |json|
           json[:type] = 'failure'
-          json[:message] = message&.strip
+          json[:message] = message
           json[:analyzer] = analyzer&.as_json
         end
       end

--- a/lib/runners/results.rb
+++ b/lib/runners/results.rb
@@ -90,7 +90,7 @@ module Runners
       def as_json
         super.tap do |json|
           json[:type] = 'failure'
-          json[:message] = message
+          json[:message] = message&.strip
           json[:analyzer] = analyzer&.as_json
         end
       end

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -137,28 +137,34 @@ module Runners
                         warnings: [], ci_config: :_, version: :_)
         return unless only? name
 
+        if issues.is_a? Array
+          # HACK: Steep does not work here...
+          _  = issues
+          _.each { |i| strip_message! i[:message] }
+        end
+
         optional = {
           issues: issues,
-          message: message.tap { |m|
-            if m.is_a? String
-              # @type var m: String
-              m.strip!
-            end
-          },
+          message: message.tap { |msg| strip_message! msg },
           analyzer: analyzer,
           class: binding.local_variable_get(:class),
           backtrace: backtrace,
           inspect: inspect,
         }.compact
 
-        warnings.each { |w| w[:message].strip! if w[:message].is_a? String }
-
         tests[name] = {
           result: { guid: guid, timestamp: timestamp, type: type, **optional },
-          warnings: warnings,
+          warnings: warnings.each { |w| strip_message! w[:message] },
           ci_config: ci_config,
           version: version,
         }
+      end
+
+      def self.strip_message!(msg)
+        if msg.is_a? String
+          # @type var msg: String
+          msg.strip!
+        end
       end
     end
   end

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -137,15 +137,9 @@ module Runners
                         warnings: [], ci_config: :_, version: :_)
         return unless only? name
 
-        if issues.is_a? Array
-          # HACK: Steep does not work here...
-          _  = issues
-          _.each { |i| strip_message! i[:message] }
-        end
-
         optional = {
           issues: issues,
-          message: message.tap { |msg| strip_message! msg },
+          message: message,
           analyzer: analyzer,
           class: binding.local_variable_get(:class),
           backtrace: backtrace,
@@ -154,17 +148,10 @@ module Runners
 
         tests[name] = {
           result: { guid: guid, timestamp: timestamp, type: type, **optional },
-          warnings: warnings.each { |w| strip_message! w[:message] },
+          warnings: warnings,
           ci_config: ci_config,
           version: version,
         }
-      end
-
-      def self.strip_message!(msg)
-        if msg.is_a? String
-          # @type var msg: String
-          msg.strip!
-        end
       end
     end
   end

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -117,6 +117,10 @@ module Runners
 
       @tests = {}
 
+      def self.tests
+        @tests
+      end
+
       # Comma-separated value is also available.
       def self.only?(name)
         value = ENV["ONLY"]
@@ -127,21 +131,34 @@ module Runners
         end
       end
 
-      def self.add_test(name, result, **others)
+      def self.add_test(name, type:, guid: "test-guid", timestamp: :_,
+                        issues: nil, message: nil, analyzer: nil,
+                        class: nil, backtrace: nil, inspect: nil,
+                        warnings: [], ci_config: :_, version: :_)
         return unless only? name
 
-        others[:warnings] ||= []
-        others[:ci_config] ||= :_
-        others[:version] ||= :_
+        optional = {
+          issues: issues,
+          message: message.tap { |m|
+            if m.is_a? String
+              # @type var m: String
+              m.strip!
+            end
+          },
+          analyzer: analyzer,
+          class: binding.local_variable_get(:class),
+          backtrace: backtrace,
+          inspect: inspect,
+        }.compact
 
-        @tests[name] = {
-          result: result,
-          **others,
+        warnings.each { |w| w[:message].strip! if w[:message].is_a? String }
+
+        tests[name] = {
+          result: { guid: guid, timestamp: timestamp, type: type, **optional },
+          warnings: warnings,
+          ci_config: ci_config,
+          version: version,
         }
-      end
-
-      def self.tests
-        @tests
       end
     end
   end

--- a/sig/polyfills/binding.rbi
+++ b/sig/polyfills/binding.rbi
@@ -1,0 +1,3 @@
+class Binding
+  def local_variable_get: (Symbol) -> any
+end

--- a/sig/polyfills/kernel.rbi
+++ b/sig/polyfills/kernel.rbi
@@ -3,6 +3,7 @@ extension Kernel (Polyfill)
   def exit: (Integer) -> void
   def system: (*String, exception: bool) -> void
   def load: (String) -> bool
+  def binding: -> Binding
   def __method__: -> Symbol?
   def __dir__: -> String
   def Array: (any) -> Array<any>

--- a/sig/runners/testing.rbi
+++ b/sig/runners/testing.rbi
@@ -20,7 +20,18 @@ class Runners::Testing::Smoke
   def colored_pretty_inspect: (any) -> String
 
   def self.only?: (String) -> bool
-  def self.add_test: (String, Hash, **any) -> void
+  def self.add_test: (String, type: String,
+                      ?guid: String | Symbol,
+                      ?timestamp: String | Symbol,
+                      ?issues: Array<Hash<Symbol, any>> | Symbol | nil,
+                      ?message: String | Symbol | Regexp | nil,
+                      ?analyzer: Hash<Symbol, any> | Symbol | nil,
+                      ?class: String | Symbol | nil,
+                      ?backtrace: Array<String> | Symbol | nil,
+                      ?inspect: String | Regexp | Symbol | nil,
+                      ?warnings: Array<Hash<Symbol, any>>,
+                      ?ci_config: Hash<Symbol, any> | Symbol,
+                      ?version: String | Symbol) -> void
   def self.tests: -> Hash<String, any>
 end
 

--- a/sig/runners/testing.rbi
+++ b/sig/runners/testing.rbi
@@ -33,7 +33,6 @@ class Runners::Testing::Smoke
                       ?ci_config: Hash<Symbol, any> | Symbol,
                       ?version: String | Symbol) -> void
   def self.tests: -> Hash<String, any>
-  def self.strip_message!: (any) -> void
 end
 
 Runners::Testing::Smoke::PROJECT_PATH: String

--- a/sig/runners/testing.rbi
+++ b/sig/runners/testing.rbi
@@ -33,6 +33,7 @@ class Runners::Testing::Smoke
                       ?ci_config: Hash<Symbol, any> | Symbol,
                       ?version: String | Symbol) -> void
   def self.tests: -> Hash<String, any>
+  def self.strip_message!: (any) -> void
 end
 
 Runners::Testing::Smoke::PROJECT_PATH: String

--- a/test/smokes/brakeman/expectations.rb
+++ b/test/smokes/brakeman/expectations.rb
@@ -148,13 +148,13 @@ s.add_test(
   analyzer: { name: "Brakeman", version: "4.3.1" },
   warnings: [
     {
-      message: <<~MESSAGE,
-        Sider tried to install `brakeman 4.4.0` according to your `Gemfile.lock`, but it installs `4.3.1` instead.
-        Because `4.4.0` does not satisfy the Sider constraints [\">= 4.0.0\", \"< 4.4.0\"].
+      message: <<~MESSAGE.strip,
+Sider tried to install `brakeman 4.4.0` according to your `Gemfile.lock`, but it installs `4.3.1` instead.
+Because `4.4.0` does not satisfy the Sider constraints [\">= 4.0.0\", \"< 4.4.0\"].
 
-        If you want to use a different version of `brakeman`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
-        See https://help.sider.review/getting-started/custom-configuration#gems-option
-      MESSAGE
+If you want to use a different version of `brakeman`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
+See https://help.sider.review/getting-started/custom-configuration#gems-option
+MESSAGE
       file: nil
     }
   ]

--- a/test/smokes/brakeman/expectations.rb
+++ b/test/smokes/brakeman/expectations.rb
@@ -1,180 +1,160 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "Gemfile.lock",
-        location: { start_line: 81 },
-        id: "Cross-Site Scripting-102",
-        message:
-          "Rails 4.2.7 content_tag does not escape double quotes in attribute values (CVE-2016-6316). Upgrade to 4.2.7.1",
-        links: %w[https://groups.google.com/d/msg/ruby-security-ann/8B2iV2tPRSE/JkjCJkSoCgAJ],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "Gemfile.lock",
-        location: { start_line: 66 },
-        id: "Cross-Site Scripting-106",
-        message: "Loofah 2.0.3 is vulnerable (CVE-2018-8048). Upgrade to 2.1.2",
-        links: %w[https://github.com/flavorjones/loofah/issues/144],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "Gemfile.lock",
-        location: { start_line: 98 },
-        id: "Cross-Site Scripting-107",
-        message: "rails-html-sanitizer 1.0.3 is vulnerable (CVE-2018-3741). Upgrade to 1.0.4",
-        links: %w[https://groups.google.com/d/msg/rubyonrails-security/tP7W3kLc5u4/uDy2Br7xBgAJ],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "Gemfile.lock",
-        location: { start_line: 81 },
-        id: "SQL Injection-103",
-        message: "Rails 4.2.7 contains a SQL injection vulnerability (CVE-2016-6317). Upgrade to 4.2.7.1",
-        links: %w[https://groups.google.com/d/msg/ruby-security-ann/WccgKSKiPZA/9DrsDVSoCgAJ],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Brakeman", version: "4.3.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "Gemfile.lock",
+      location: { start_line: 81 },
+      id: "Cross-Site Scripting-102",
+      message:
+        "Rails 4.2.7 content_tag does not escape double quotes in attribute values (CVE-2016-6316). Upgrade to 4.2.7.1",
+      links: %w[https://groups.google.com/d/msg/ruby-security-ann/8B2iV2tPRSE/JkjCJkSoCgAJ],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "Gemfile.lock",
+      location: { start_line: 66 },
+      id: "Cross-Site Scripting-106",
+      message: "Loofah 2.0.3 is vulnerable (CVE-2018-8048). Upgrade to 2.1.2",
+      links: %w[https://github.com/flavorjones/loofah/issues/144],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "Gemfile.lock",
+      location: { start_line: 98 },
+      id: "Cross-Site Scripting-107",
+      message: "rails-html-sanitizer 1.0.3 is vulnerable (CVE-2018-3741). Upgrade to 1.0.4",
+      links: %w[https://groups.google.com/d/msg/rubyonrails-security/tP7W3kLc5u4/uDy2Br7xBgAJ],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "Gemfile.lock",
+      location: { start_line: 81 },
+      id: "SQL Injection-103",
+      message: "Rails 4.2.7 contains a SQL injection vulnerability (CVE-2016-6317). Upgrade to 4.2.7.1",
+      links: %w[https://groups.google.com/d/msg/ruby-security-ann/WccgKSKiPZA/9DrsDVSoCgAJ],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Brakeman", version: "4.3.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "subdir",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "rails_app/Gemfile.lock",
-        location: { start_line: 81 },
-        id: "Cross-Site Scripting-102",
-        message:
-          "Rails 4.2.7 content_tag does not escape double quotes in attribute values (CVE-2016-6316). Upgrade to 4.2.7.1",
-        links: %w[https://groups.google.com/d/msg/ruby-security-ann/8B2iV2tPRSE/JkjCJkSoCgAJ],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "rails_app/Gemfile.lock",
-        location: { start_line: 66 },
-        id: "Cross-Site Scripting-106",
-        message: "Loofah 2.0.3 is vulnerable (CVE-2018-8048). Upgrade to 2.1.2",
-        links: %w[https://github.com/flavorjones/loofah/issues/144],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "rails_app/Gemfile.lock",
-        location: { start_line: 98 },
-        id: "Cross-Site Scripting-107",
-        message: "rails-html-sanitizer 1.0.3 is vulnerable (CVE-2018-3741). Upgrade to 1.0.4",
-        links: %w[https://groups.google.com/d/msg/rubyonrails-security/tP7W3kLc5u4/uDy2Br7xBgAJ],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "rails_app/Gemfile.lock",
-        location: { start_line: 81 },
-        id: "SQL Injection-103",
-        message: "Rails 4.2.7 contains a SQL injection vulnerability (CVE-2016-6317). Upgrade to 4.2.7.1",
-        links: %w[https://groups.google.com/d/msg/ruby-security-ann/WccgKSKiPZA/9DrsDVSoCgAJ],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Brakeman", version: "4.3.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "rails_app/Gemfile.lock",
+      location: { start_line: 81 },
+      id: "Cross-Site Scripting-102",
+      message:
+        "Rails 4.2.7 content_tag does not escape double quotes in attribute values (CVE-2016-6316). Upgrade to 4.2.7.1",
+      links: %w[https://groups.google.com/d/msg/ruby-security-ann/8B2iV2tPRSE/JkjCJkSoCgAJ],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "rails_app/Gemfile.lock",
+      location: { start_line: 66 },
+      id: "Cross-Site Scripting-106",
+      message: "Loofah 2.0.3 is vulnerable (CVE-2018-8048). Upgrade to 2.1.2",
+      links: %w[https://github.com/flavorjones/loofah/issues/144],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "rails_app/Gemfile.lock",
+      location: { start_line: 98 },
+      id: "Cross-Site Scripting-107",
+      message: "rails-html-sanitizer 1.0.3 is vulnerable (CVE-2018-3741). Upgrade to 1.0.4",
+      links: %w[https://groups.google.com/d/msg/rubyonrails-security/tP7W3kLc5u4/uDy2Br7xBgAJ],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "rails_app/Gemfile.lock",
+      location: { start_line: 81 },
+      id: "SQL Injection-103",
+      message: "Rails 4.2.7 contains a SQL injection vulnerability (CVE-2016-6317). Upgrade to 4.2.7.1",
+      links: %w[https://groups.google.com/d/msg/ruby-security-ann/WccgKSKiPZA/9DrsDVSoCgAJ],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Brakeman", version: "4.3.1" }
 )
 
-Smoke.add_test(
-  "not_rails",
-  { guid: "test-guid", timestamp: :_, type: "failure", message: :_, analyzer: { name: "Brakeman", version: "4.3.1" } }
-)
+s.add_test("not_rails", type: "failure", message: :_, analyzer: { name: "Brakeman", version: "4.3.1" })
 
-Smoke.add_test(
+s.add_test(
   "lowest_deps",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "Gemfile.lock",
-        location: { start_line: 63 },
-        id: "Cross-Site Scripting-102",
-        message:
-          "Rails 4.2.7 content_tag does not escape double quotes in attribute values (CVE-2016-6316). Upgrade to 4.2.7.1",
-        links: %w[https://groups.google.com/d/msg/ruby-security-ann/8B2iV2tPRSE/JkjCJkSoCgAJ],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "Gemfile.lock",
-        location: { start_line: 63 },
-        id: "SQL Injection-103",
-        message: "Rails 4.2.7 contains a SQL injection vulnerability (CVE-2016-6317). Upgrade to 4.2.7.1",
-        links: %w[https://groups.google.com/d/msg/ruby-security-ann/WccgKSKiPZA/9DrsDVSoCgAJ],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Brakeman", version: "4.0.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "Gemfile.lock",
+      location: { start_line: 63 },
+      id: "Cross-Site Scripting-102",
+      message:
+        "Rails 4.2.7 content_tag does not escape double quotes in attribute values (CVE-2016-6316). Upgrade to 4.2.7.1",
+      links: %w[https://groups.google.com/d/msg/ruby-security-ann/8B2iV2tPRSE/JkjCJkSoCgAJ],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "Gemfile.lock",
+      location: { start_line: 63 },
+      id: "SQL Injection-103",
+      message: "Rails 4.2.7 contains a SQL injection vulnerability (CVE-2016-6317). Upgrade to 4.2.7.1",
+      links: %w[https://groups.google.com/d/msg/ruby-security-ann/WccgKSKiPZA/9DrsDVSoCgAJ],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Brakeman", version: "4.0.0" }
 )
 
 # Brakeman v4.4.0 and later is distributed under a non-OSS license.
 # See https://brakemanscanner.org/blog/2019/01/17/brakeman-4-dot-4-dot-0-released
-Smoke.add_test(
+s.add_test(
   "new_licensed",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "Gemfile.lock",
-        location: { start_line: 63 },
-        id: "Cross-Site Scripting-102",
-        message:
-          "Rails 4.2.7 content_tag does not escape double quotes in attribute values (CVE-2016-6316). Upgrade to 4.2.7.1",
-        links: %w[https://groups.google.com/d/msg/ruby-security-ann/8B2iV2tPRSE/JkjCJkSoCgAJ],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "Gemfile.lock",
-        location: { start_line: 63 },
-        id: "SQL Injection-103",
-        message: "Rails 4.2.7 contains a SQL injection vulnerability (CVE-2016-6317). Upgrade to 4.2.7.1",
-        links: %w[https://groups.google.com/d/msg/ruby-security-ann/WccgKSKiPZA/9DrsDVSoCgAJ],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Brakeman", version: "4.3.1" }
-  },
+  type: "success",
+  issues: [
+    {
+      path: "Gemfile.lock",
+      location: { start_line: 63 },
+      id: "Cross-Site Scripting-102",
+      message:
+        "Rails 4.2.7 content_tag does not escape double quotes in attribute values (CVE-2016-6316). Upgrade to 4.2.7.1",
+      links: %w[https://groups.google.com/d/msg/ruby-security-ann/8B2iV2tPRSE/JkjCJkSoCgAJ],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "Gemfile.lock",
+      location: { start_line: 63 },
+      id: "SQL Injection-103",
+      message: "Rails 4.2.7 contains a SQL injection vulnerability (CVE-2016-6317). Upgrade to 4.2.7.1",
+      links: %w[https://groups.google.com/d/msg/ruby-security-ann/WccgKSKiPZA/9DrsDVSoCgAJ],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Brakeman", version: "4.3.1" },
   warnings: [
     {
-      message: <<~MESSAGE
+      message: <<~MESSAGE,
         Sider tried to install `brakeman 4.4.0` according to your `Gemfile.lock`, but it installs `4.3.1` instead.
         Because `4.4.0` does not satisfy the Sider constraints [\">= 4.0.0\", \"< 4.4.0\"].
 
         If you want to use a different version of `brakeman`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
         See https://help.sider.review/getting-started/custom-configuration#gems-option
       MESSAGE
-        .strip,
       file: nil
     }
   ]

--- a/test/smokes/checkstyle/expectations.rb
+++ b/test/smokes/checkstyle/expectations.rb
@@ -1,180 +1,155 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "Checkstyle", version: "8.30" },
-    issues: [
-      {
-        message: "The name of the outer type and the file do not match.",
-        links: %w[https://checkstyle.org/config_misc.html#OuterTypeFilename],
-        id: "com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck#b81ef5",
-        path: "src/Hello.java",
-        location: { start_line: 3 },
-        object: { severity: "warning" },
-        git_blame_info: nil
-      },
-      {
-        message: "'method def' child has incorrect indentation level 8, expected level should be 4.",
-        links: %w[https://checkstyle.org/config_misc.html#Indentation],
-        id: "com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck#2aa7da",
-        path: "src/Hello.java",
-        location: { start_line: 6 },
-        object: { severity: "warning" },
-        git_blame_info: nil
-      },
-      {
-        message: "'method def modifier' has incorrect indentation level 4, expected level should be 2.",
-        links: %w[https://checkstyle.org/config_misc.html#Indentation],
-        id: "com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck#d0bdde",
-        path: "src/Hello.java",
-        location: { start_line: 5 },
-        object: { severity: "warning" },
-        git_blame_info: nil
-      },
-      {
-        message: "'method def rcurly' has incorrect indentation level 4, expected level should be 2.",
-        links: %w[https://checkstyle.org/config_misc.html#Indentation],
-        id: "com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck#e7930a",
-        path: "src/Hello.java",
-        location: { start_line: 7 },
-        object: { severity: "warning" },
-        git_blame_info: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "Checkstyle", version: "8.30" },
+  issues: [
+    {
+      message: "The name of the outer type and the file do not match.",
+      links: %w[https://checkstyle.org/config_misc.html#OuterTypeFilename],
+      id: "com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck#b81ef5",
+      path: "src/Hello.java",
+      location: { start_line: 3 },
+      object: { severity: "warning" },
+      git_blame_info: nil
+    },
+    {
+      message: "'method def' child has incorrect indentation level 8, expected level should be 4.",
+      links: %w[https://checkstyle.org/config_misc.html#Indentation],
+      id: "com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck#2aa7da",
+      path: "src/Hello.java",
+      location: { start_line: 6 },
+      object: { severity: "warning" },
+      git_blame_info: nil
+    },
+    {
+      message: "'method def modifier' has incorrect indentation level 4, expected level should be 2.",
+      links: %w[https://checkstyle.org/config_misc.html#Indentation],
+      id: "com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck#d0bdde",
+      path: "src/Hello.java",
+      location: { start_line: 5 },
+      object: { severity: "warning" },
+      git_blame_info: nil
+    },
+    {
+      message: "'method def rcurly' has incorrect indentation level 4, expected level should be 2.",
+      links: %w[https://checkstyle.org/config_misc.html#Indentation],
+      id: "com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck#e7930a",
+      path: "src/Hello.java",
+      location: { start_line: 7 },
+      object: { severity: "warning" },
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "config",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "Checkstyle", version: "8.30" },
-    issues: [
-      {
-        message: "Parameter args should be final.",
-        links: %w[https://checkstyle.org/config_misc.html#FinalParameters],
-        id: "com.puppycrawl.tools.checkstyle.checks.FinalParametersCheck#0bbcea",
-        path: "src/Main.java",
-        location: { start_line: 5 },
-        object: { severity: "error" },
-        git_blame_info: nil
-      },
-      {
-        message: "Utility classes should not have a public or default constructor.",
-        links: %w[https://checkstyle.org/config_design.html#HideUtilityClassConstructor],
-        id: "com.puppycrawl.tools.checkstyle.checks.design.HideUtilityClassConstructorCheck#97f5fb",
-        path: "src/Main.java",
-        location: { start_line: 3 },
-        object: { severity: "error" },
-        git_blame_info: nil
-      },
-      {
-        message: "Missing package-info.java file.",
-        links: %w[https://checkstyle.org/config_javadoc.html#JavadocPackage],
-        id: "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck#1cbcec",
-        path: "src/Main.java",
-        location: { start_line: 1 },
-        object: { severity: "error" },
-        git_blame_info: nil
-      },
-      {
-        message: "Missing a Javadoc comment.",
-        links: %w[https://checkstyle.org/config_javadoc.html#MissingJavadocMethod],
-        id: "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck#0cbebf",
-        path: "src/Main.java",
-        location: { start_line: 5 },
-        object: { severity: "error" },
-        git_blame_info: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "Checkstyle", version: "8.30" },
+  issues: [
+    {
+      message: "Parameter args should be final.",
+      links: %w[https://checkstyle.org/config_misc.html#FinalParameters],
+      id: "com.puppycrawl.tools.checkstyle.checks.FinalParametersCheck#0bbcea",
+      path: "src/Main.java",
+      location: { start_line: 5 },
+      object: { severity: "error" },
+      git_blame_info: nil
+    },
+    {
+      message: "Utility classes should not have a public or default constructor.",
+      links: %w[https://checkstyle.org/config_design.html#HideUtilityClassConstructor],
+      id: "com.puppycrawl.tools.checkstyle.checks.design.HideUtilityClassConstructorCheck#97f5fb",
+      path: "src/Main.java",
+      location: { start_line: 3 },
+      object: { severity: "error" },
+      git_blame_info: nil
+    },
+    {
+      message: "Missing package-info.java file.",
+      links: %w[https://checkstyle.org/config_javadoc.html#JavadocPackage],
+      id: "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck#1cbcec",
+      path: "src/Main.java",
+      location: { start_line: 1 },
+      object: { severity: "error" },
+      git_blame_info: nil
+    },
+    {
+      message: "Missing a Javadoc comment.",
+      links: %w[https://checkstyle.org/config_javadoc.html#MissingJavadocMethod],
+      id: "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck#0cbebf",
+      path: "src/Main.java",
+      location: { start_line: 5 },
+      object: { severity: "error" },
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "failure",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "Could not find config XML file 'custom.xml'.",
-    analyzer: { name: "Checkstyle", version: "8.30" }
-  }
+  type: "failure",
+  message: "Could not find config XML file 'custom.xml'.",
+  analyzer: { name: "Checkstyle", version: "8.30" }
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sideci_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message:
-      "The value of the attribute `$.linter.checkstyle.exclude` in your `sideci.yml` is invalid. Please fix and retry.",
-    analyzer: nil
-  }
+  type: "failure",
+  message:
+    "The value of the attribute `$.linter.checkstyle.exclude` in your `sideci.yml` is invalid. Please fix and retry.",
+  analyzer: :_
 )
 
-Smoke.add_test(
+s.add_test(
   "properties",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Line is longer than 50 characters (found 67).",
-        links: %w[https://checkstyle.org/config_sizes.html#LineLength],
-        id: "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck#446163",
-        path: "src/Main.java",
-        location: { start_line: 3 },
-        object: { severity: "error" },
-        git_blame_info: nil
-      },
-      {
-        message: "Line is longer than 50 characters (found 63).",
-        links: %w[https://checkstyle.org/config_sizes.html#LineLength],
-        id: "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck#6a9962",
-        path: "myruleset.xml",
-        location: { start_line: 4 },
-        object: { severity: "error" },
-        git_blame_info: nil
-      },
-      {
-        message: "Line is longer than 50 characters (found 54).",
-        links: %w[https://checkstyle.org/config_sizes.html#LineLength],
-        id: "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck#8de3eb",
-        path: "myruleset.xml",
-        location: { start_line: 8 },
-        object: { severity: "error" },
-        git_blame_info: nil
-      },
-      {
-        message: "Line is longer than 50 characters (found 57).",
-        links: %w[https://checkstyle.org/config_sizes.html#LineLength],
-        id: "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck#a134cc",
-        path: "myruleset.xml",
-        location: { start_line: 3 },
-        object: { severity: "error" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Checkstyle", version: "8.30" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Line is longer than 50 characters (found 67).",
+      links: %w[https://checkstyle.org/config_sizes.html#LineLength],
+      id: "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck#446163",
+      path: "src/Main.java",
+      location: { start_line: 3 },
+      object: { severity: "error" },
+      git_blame_info: nil
+    },
+    {
+      message: "Line is longer than 50 characters (found 63).",
+      links: %w[https://checkstyle.org/config_sizes.html#LineLength],
+      id: "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck#6a9962",
+      path: "myruleset.xml",
+      location: { start_line: 4 },
+      object: { severity: "error" },
+      git_blame_info: nil
+    },
+    {
+      message: "Line is longer than 50 characters (found 54).",
+      links: %w[https://checkstyle.org/config_sizes.html#LineLength],
+      id: "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck#8de3eb",
+      path: "myruleset.xml",
+      location: { start_line: 8 },
+      object: { severity: "error" },
+      git_blame_info: nil
+    },
+    {
+      message: "Line is longer than 50 characters (found 57).",
+      links: %w[https://checkstyle.org/config_sizes.html#LineLength],
+      id: "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck#a134cc",
+      path: "myruleset.xml",
+      location: { start_line: 3 },
+      object: { severity: "error" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Checkstyle", version: "8.30" }
 )
 
-Smoke.add_test(
+s.add_test(
   "syntax_error",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message:
-      "com.puppycrawl.tools.checkstyle.api.CheckstyleException: Exception was thrown while processing ./Foo.java",
-    analyzer: { name: "Checkstyle", version: "8.30" }
-  }
+  type: "failure",
+  message: "com.puppycrawl.tools.checkstyle.api.CheckstyleException: Exception was thrown while processing ./Foo.java",
+  analyzer: { name: "Checkstyle", version: "8.30" }
 )

--- a/test/smokes/code_sniffer/expectations.rb
+++ b/test/smokes/code_sniffer/expectations.rb
@@ -1,53 +1,46 @@
 require_relative "phpcs3/expectations.rb"
 
-Smoke.add_test(
+s = Runners::Testing::Smoke
+
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "app.php",
-        location: { start_line: 18 },
-        id: "PSR2.Files.ClosingTag.NotAllowed",
-        message: "A closing tag is not permitted at the end of a PHP file",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: true },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "app.php",
+      location: { start_line: 18 },
+      id: "PSR2.Files.ClosingTag.NotAllowed",
+      message: "A closing tag is not permitted at the end of a PHP file",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: true },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
 )
 
-Smoke.add_test(
+s.add_test(
   "specified_dir",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "app/app.php",
-        location: { start_line: 6 },
-        id: "PSR2.Files.ClosingTag.NotAllowed",
-        message: "A closing tag is not permitted at the end of a PHP file",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: true },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
-  },
+  type: "success",
+  issues: [
+    {
+      path: "app/app.php",
+      location: { start_line: 6 },
+      id: "PSR2.Files.ClosingTag.NotAllowed",
+      message: "A closing tag is not permitted at the end of a PHP file",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: true },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" },
   warnings: [
     {
-      message: <<~MSG
+      message: <<~MSG,
         DEPRECATION WARNING!!!
         The `$.linter.code_sniffer.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
         Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/php/codesniffer ).
       MSG
-        .strip,
       file: "sideci.yml"
     }
   ]
@@ -55,59 +48,32 @@ Smoke.add_test(
 
 # Regression test for large output
 # See https://github.com/sideci/runner_code_sniffer/pull/27
-Smoke.add_test(
-  "sideci_php_sandbox",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: :_,
-    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
-  }
-)
+s.add_test("sideci_php_sandbox", type: "success", issues: :_, analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" })
 
-Smoke.add_test(
-  "with_php_version",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: :_,
-    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
-  }
-)
+s.add_test("with_php_version", type: "success", issues: :_, analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" })
 
-Smoke.add_test(
+s.add_test(
   "broken_sideci_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    analyzer: nil,
-    message:
-      "The attribute `$.linter.code_sniffer.extension` in your `sideci.yml` is unsupported. Please fix and retry."
-  }
+  type: "failure",
+  analyzer: :_,
+  message: "The attribute `$.linter.code_sniffer.extension` in your `sideci.yml` is unsupported. Please fix and retry."
 )
 
-Smoke.add_test(
+s.add_test(
   "version_2",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "app.php",
-        location: { start_line: 18 },
-        id: "PSR2.Files.ClosingTag.NotAllowed",
-        message: "A closing tag is not permitted at the end of a PHP file",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: true },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
-  },
+  type: "success",
+  issues: [
+    {
+      path: "app.php",
+      location: { start_line: 18 },
+      id: "PSR2.Files.ClosingTag.NotAllowed",
+      message: "A closing tag is not permitted at the end of a PHP file",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: true },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" },
   warnings: [
     {
       message: /The `\$\.linter\.code_sniffer\.version` option\(s\) in your `sider\.yml` are deprecated/,
@@ -116,53 +82,45 @@ Smoke.add_test(
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "autodetect_cakephp",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "app/test.php",
-        location: { start_line: 2 },
-        id: "CakePHP.Commenting.FunctionComment.Missing",
-        message: "Missing doc comment for function foo()",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: false },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "app/test.php",
+      location: { start_line: 2 },
+      id: "CakePHP.Commenting.FunctionComment.Missing",
+      message: "Missing doc comment for function foo()",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: false },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
 )
 
-Smoke.add_test(
+s.add_test(
   "autodetect_symfony",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "src/test.php",
-        location: { start_line: 2 },
-        id: "Squiz.Functions.GlobalFunction.Found",
-        message: "Consider putting global function \"foo\" in a static class",
-        links: [],
-        object: { type: "WARNING", severity: 5, fixable: false },
-        git_blame_info: nil
-      },
-      {
-        path: "src/test.php",
-        location: { start_line: 2 },
-        id: "Symfony.Commenting.FunctionComment.Missing",
-        message: "Missing doc comment for function foo()",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: false },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "src/test.php",
+      location: { start_line: 2 },
+      id: "Squiz.Functions.GlobalFunction.Found",
+      message: "Consider putting global function \"foo\" in a static class",
+      links: [],
+      object: { type: "WARNING", severity: 5, fixable: false },
+      git_blame_info: nil
+    },
+    {
+      path: "src/test.php",
+      location: { start_line: 2 },
+      id: "Symfony.Commenting.FunctionComment.Missing",
+      message: "Missing doc comment for function foo()",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: false },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
 )

--- a/test/smokes/code_sniffer/expectations.rb
+++ b/test/smokes/code_sniffer/expectations.rb
@@ -36,11 +36,11 @@ s.add_test(
   analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" },
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The `$.linter.code_sniffer.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/php/codesniffer ).
-      MSG
+     message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The `$.linter.code_sniffer.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/php/codesniffer ).
+MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/code_sniffer/phpcs3/expectations.rb
+++ b/test/smokes/code_sniffer/phpcs3/expectations.rb
@@ -1,220 +1,190 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "phpcs3/success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "app.php",
-        location: { start_line: 6 },
-        id: "PSR2.Files.ClosingTag.NotAllowed",
-        message: "A closing tag is not permitted at the end of a PHP file",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: true },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "app.php",
+      location: { start_line: 6 },
+      id: "PSR2.Files.ClosingTag.NotAllowed",
+      message: "A closing tag is not permitted at the end of a PHP file",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: true },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
 )
 
-Smoke.add_test(
+s.add_test(
   "phpcs3/specified_dir",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "app/app.php",
-        location: { start_line: 6 },
-        id: "PSR2.Files.ClosingTag.NotAllowed",
-        message: "A closing tag is not permitted at the end of a PHP file",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: true },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "app/app.php",
+      location: { start_line: 6 },
+      id: "PSR2.Files.ClosingTag.NotAllowed",
+      message: "A closing tag is not permitted at the end of a PHP file",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: true },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
 )
 
-Smoke.add_test(
+s.add_test(
   "phpcs3/custom_argument",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "app.php",
-        location: { start_line: 2 },
-        id: "PEAR.Commenting.FileComment.Missing",
-        message: "Missing file doc comment",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: false },
-        git_blame_info: nil
-      },
-      {
-        path: "app.php",
-        location: { start_line: 8 },
-        id: "Zend.Files.ClosingTag.NotAllowed",
-        message: "A closing tag is not permitted at the end of a PHP file",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: true },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "app.php",
+      location: { start_line: 2 },
+      id: "PEAR.Commenting.FileComment.Missing",
+      message: "Missing file doc comment",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: false },
+      git_blame_info: nil
+    },
+    {
+      path: "app.php",
+      location: { start_line: 8 },
+      id: "Zend.Files.ClosingTag.NotAllowed",
+      message: "A closing tag is not permitted at the end of a PHP file",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: true },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
 )
 
-Smoke.add_test(
+s.add_test(
   "phpcs3/cakephp",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "app.php",
-        location: { start_line: 2 },
-        id: "CakePHP.Commenting.DocBlockAlignment.DocBlockMisaligned",
-        message: "Doc block not aligned with code; expected indentation of 0 but found 4",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: true },
-        git_blame_info: nil
-      },
-      {
-        path: "app.php",
-        location: { start_line: 6 },
-        id: "CakePHP.Commenting.DocBlockAlignment.DocBlockMisaligned",
-        message: "Doc block not aligned with code; expected indentation of 0 but found 4",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: true },
-        git_blame_info: nil
-      },
-      {
-        path: "app.php",
-        location: { start_line: 13 },
-        id: "CakePHP.Commenting.DocBlockAlignment.DocBlockMisaligned",
-        message: "Doc block not aligned with code; expected indentation of 4 but found 8",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: true },
-        git_blame_info: nil
-      },
-      {
-        path: "app.php",
-        location: { start_line: 19 },
-        id: "CakePHP.Commenting.DocBlockAlignment.DocBlockMisaligned",
-        message: "Doc block not aligned with code; expected indentation of 4 but found 0",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: true },
-        git_blame_info: nil
-      },
-      {
-        path: "app.php",
-        location: { start_line: 5 },
-        id: "PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter",
-        message: "There must be one blank line after the namespace declaration",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: true },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "app.php",
+      location: { start_line: 2 },
+      id: "CakePHP.Commenting.DocBlockAlignment.DocBlockMisaligned",
+      message: "Doc block not aligned with code; expected indentation of 0 but found 4",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: true },
+      git_blame_info: nil
+    },
+    {
+      path: "app.php",
+      location: { start_line: 6 },
+      id: "CakePHP.Commenting.DocBlockAlignment.DocBlockMisaligned",
+      message: "Doc block not aligned with code; expected indentation of 0 but found 4",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: true },
+      git_blame_info: nil
+    },
+    {
+      path: "app.php",
+      location: { start_line: 13 },
+      id: "CakePHP.Commenting.DocBlockAlignment.DocBlockMisaligned",
+      message: "Doc block not aligned with code; expected indentation of 4 but found 8",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: true },
+      git_blame_info: nil
+    },
+    {
+      path: "app.php",
+      location: { start_line: 19 },
+      id: "CakePHP.Commenting.DocBlockAlignment.DocBlockMisaligned",
+      message: "Doc block not aligned with code; expected indentation of 4 but found 0",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: true },
+      git_blame_info: nil
+    },
+    {
+      path: "app.php",
+      location: { start_line: 5 },
+      id: "PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter",
+      message: "There must be one blank line after the namespace declaration",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: true },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
 )
 
-Smoke.add_test(
+s.add_test(
   "phpcs3/wordpress",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "app.php",
-        location: { start_line: 1 },
-        id: "Squiz.Commenting.FileComment.Missing",
-        message: "Missing file doc comment",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: false },
-        git_blame_info: nil
-      },
-      {
-        path: "app.php",
-        location: { start_line: 1 },
-        id: "WordPress.Security.SafeRedirect.wp_redirect_wp_redirect",
-        message:
-          "wp_redirect() found. Using wp_safe_redirect(), along with the allowed_redirect_hosts filter if needed, can help avoid any chances of malicious redirects within code. It is also important to remember to call exit() after a redirect so that no other unwanted code is executed.",
-        links: [],
-        object: { type: "WARNING", severity: 5, fixable: false },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "app.php",
+      location: { start_line: 1 },
+      id: "Squiz.Commenting.FileComment.Missing",
+      message: "Missing file doc comment",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: false },
+      git_blame_info: nil
+    },
+    {
+      path: "app.php",
+      location: { start_line: 1 },
+      id: "WordPress.Security.SafeRedirect.wp_redirect_wp_redirect",
+      message:
+        "wp_redirect() found. Using wp_safe_redirect(), along with the allowed_redirect_hosts filter if needed, can help avoid any chances of malicious redirects within code. It is also important to remember to call exit() after a redirect so that no other unwanted code is executed.",
+      links: [],
+      object: { type: "WARNING", severity: 5, fixable: false },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
 )
 
-Smoke.add_test(
+s.add_test(
   "phpcs3/symfony",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "app.php",
-        location: { start_line: 5 },
-        id: "Squiz.Functions.GlobalFunction.Found",
-        message: "Consider putting global function \"test\" in a static class",
-        links: [],
-        object: { type: "WARNING", severity: 5, fixable: false },
-        git_blame_info: nil
-      },
-      {
-        path: "app.php",
-        location: { start_line: 14 },
-        id: "Squiz.Functions.GlobalFunction.Found",
-        message: "Consider putting global function \"test\" in a static class",
-        links: [],
-        object: { type: "WARNING", severity: 5, fixable: false },
-        git_blame_info: nil
-      },
-      {
-        path: "app.php",
-        location: { start_line: 21 },
-        id: "Squiz.Functions.GlobalFunction.Found",
-        message: "Consider putting global function \"testWithCallBack\" in a static class",
-        links: [],
-        object: { type: "WARNING", severity: 5, fixable: false },
-        git_blame_info: nil
-      },
-      {
-        path: "app.php",
-        location: { start_line: 4 },
-        id: "Symfony.Commenting.FunctionComment.MissingReturn",
-        message: "Missing @return tag in function comment",
-        links: [],
-        object: { type: "ERROR", severity: 5, fixable: false },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "app.php",
+      location: { start_line: 5 },
+      id: "Squiz.Functions.GlobalFunction.Found",
+      message: "Consider putting global function \"test\" in a static class",
+      links: [],
+      object: { type: "WARNING", severity: 5, fixable: false },
+      git_blame_info: nil
+    },
+    {
+      path: "app.php",
+      location: { start_line: 14 },
+      id: "Squiz.Functions.GlobalFunction.Found",
+      message: "Consider putting global function \"test\" in a static class",
+      links: [],
+      object: { type: "WARNING", severity: 5, fixable: false },
+      git_blame_info: nil
+    },
+    {
+      path: "app.php",
+      location: { start_line: 21 },
+      id: "Squiz.Functions.GlobalFunction.Found",
+      message: "Consider putting global function \"testWithCallBack\" in a static class",
+      links: [],
+      object: { type: "WARNING", severity: 5, fixable: false },
+      git_blame_info: nil
+    },
+    {
+      path: "app.php",
+      location: { start_line: 4 },
+      id: "Symfony.Commenting.FunctionComment.MissingReturn",
+      message: "Missing @return tag in function comment",
+      links: [],
+      object: { type: "ERROR", severity: 5, fixable: false },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
 )
 
-Smoke.add_test(
+s.add_test(
   "phpcs3/with_php_version",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: :_,
-    analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
-  }
+  type: "success", issues: :_, analyzer: { name: "PHP_CodeSniffer", version: "3.5.4" }
 )

--- a/test/smokes/coffeelint/expectations.rb
+++ b/test/smokes/coffeelint/expectations.rb
@@ -47,11 +47,11 @@ s.add_test(
   analyzer: { name: "CoffeeLint", version: "1.16.0" },
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The `$.linter.coffeelint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/coffeelint ).
-      MSG
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The `$.linter.coffeelint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/coffeelint ).
+MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/coffeelint/expectations.rb
+++ b/test/smokes/coffeelint/expectations.rb
@@ -1,216 +1,188 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
 # Smoke test allows testing by input and output of the analysis.
 # Following example, create "success" directory and put files, configurations, etc in this directory.
 #
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Class name should be UpperCamelCased class name: foo",
-        links: [],
-        id: "camel_case_classes",
-        path: "test.coffee",
-        location: { start_line: 3 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "Line exceeds maximum allowed length Length is 84, max is 80",
-        links: [],
-        id: "max_line_length",
-        path: "test.coffee",
-        location: { start_line: 1 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "Line ends with trailing whitespace",
-        links: [],
-        id: "no_trailing_whitespace",
-        path: "test.coffee",
-        location: { start_line: 2 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "CoffeeLint", version: "1.16.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Class name should be UpperCamelCased class name: foo",
+      links: [],
+      id: "camel_case_classes",
+      path: "test.coffee",
+      location: { start_line: 3 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "Line exceeds maximum allowed length Length is 84, max is 80",
+      links: [],
+      id: "max_line_length",
+      path: "test.coffee",
+      location: { start_line: 1 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "Line ends with trailing whitespace",
+      links: [],
+      id: "no_trailing_whitespace",
+      path: "test.coffee",
+      location: { start_line: 2 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "CoffeeLint", version: "1.16.0" }
 )
 
-Smoke.add_test(
-  "with_config",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "CoffeeLint", version: "1.16.0" } }
-)
+s.add_test("with_config", type: "success", issues: [], analyzer: { name: "CoffeeLint", version: "1.16.0" })
 
-Smoke.add_test(
+s.add_test(
   "with_config_deprecated",
-  {
-    guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "CoffeeLint", version: "1.16.0" }
-  },
+  type: "success",
+  issues: [],
+  analyzer: { name: "CoffeeLint", version: "1.16.0" },
   warnings: [
     {
-      message: <<~MSG
+      message: <<~MSG,
         DEPRECATION WARNING!!!
         The `$.linter.coffeelint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
         Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/coffeelint ).
       MSG
-        .strip,
       file: "sideci.yml"
     }
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "syntax_error",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Class name should be UpperCamelCased class name: foo",
-        links: [],
-        id: "camel_case_classes",
-        path: "test.coffee",
-        location: { start_line: 3 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "[stdin]:1:7: error: unexpected <\n" + "foo = <%= something %>\n" + "      ^",
-        links: [],
-        id: "coffeescript_error",
-        path: "er.coffee",
-        location: { start_line: 1 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "Line exceeds maximum allowed length Length is 84, max is 80",
-        links: [],
-        id: "max_line_length",
-        path: "test.coffee",
-        location: { start_line: 1 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "Line ends with trailing whitespace",
-        links: [],
-        id: "no_trailing_whitespace",
-        path: "test.coffee",
-        location: { start_line: 2 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "CoffeeLint", version: "1.16.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Class name should be UpperCamelCased class name: foo",
+      links: [],
+      id: "camel_case_classes",
+      path: "test.coffee",
+      location: { start_line: 3 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "[stdin]:1:7: error: unexpected <\n" + "foo = <%= something %>\n" + "      ^",
+      links: [],
+      id: "coffeescript_error",
+      path: "er.coffee",
+      location: { start_line: 1 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "Line exceeds maximum allowed length Length is 84, max is 80",
+      links: [],
+      id: "max_line_length",
+      path: "test.coffee",
+      location: { start_line: 1 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "Line ends with trailing whitespace",
+      links: [],
+      id: "no_trailing_whitespace",
+      path: "test.coffee",
+      location: { start_line: 2 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "CoffeeLint", version: "1.16.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "v2",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Class name should be UpperCamelCased class name: foo",
-        links: [],
-        id: "camel_case_classes",
-        path: "test.coffee",
-        location: { start_line: 3 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "Line exceeds maximum allowed length Length is 84, max is 80",
-        links: [],
-        id: "max_line_length",
-        path: "test.coffee",
-        location: { start_line: 1 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "Line ends with trailing whitespace",
-        links: [],
-        id: "no_trailing_whitespace",
-        path: "test.coffee",
-        location: { start_line: 2 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "CoffeeLint", version: "2.0.6" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Class name should be UpperCamelCased class name: foo",
+      links: [],
+      id: "camel_case_classes",
+      path: "test.coffee",
+      location: { start_line: 3 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "Line exceeds maximum allowed length Length is 84, max is 80",
+      links: [],
+      id: "max_line_length",
+      path: "test.coffee",
+      location: { start_line: 1 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "Line ends with trailing whitespace",
+      links: [],
+      id: "no_trailing_whitespace",
+      path: "test.coffee",
+      location: { start_line: 2 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "CoffeeLint", version: "2.0.6" }
 )
 
-Smoke.add_test(
+s.add_test(
   "only_package_json",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "camel_case_classes",
-        message: "Class name should be UpperCamelCased class name: foo",
-        links: [],
-        path: "test.coffee",
-        location: { start_line: 1 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "CoffeeLint", version: "2.0.3" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "camel_case_classes",
+      message: "Class name should be UpperCamelCased class name: foo",
+      links: [],
+      path: "test.coffee",
+      location: { start_line: 1 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "CoffeeLint", version: "2.0.3" }
 )
 
-Smoke.add_test(
+s.add_test(
   "package_lock_json",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "camel_case_classes",
-        message: "Class name should be UpperCamelCased class name: foo",
-        links: [],
-        path: "test.coffee",
-        location: { start_line: 1 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "CoffeeLint", version: "1.16.2" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "camel_case_classes",
+      message: "Class name should be UpperCamelCased class name: foo",
+      links: [],
+      path: "test.coffee",
+      location: { start_line: 1 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "CoffeeLint", version: "1.16.2" }
 )
 
-Smoke.add_test(
+s.add_test(
   "yarn_lock",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "camel_case_classes",
-        message: "Class name should be UpperCamelCased class name: foo",
-        links: [],
-        path: "test.coffee",
-        location: { start_line: 1 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "CoffeeLint", version: "2.0.5" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "camel_case_classes",
+      message: "Class name should be UpperCamelCased class name: foo",
+      links: [],
+      path: "test.coffee",
+      location: { start_line: 1 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "CoffeeLint", version: "2.0.5" }
 )

--- a/test/smokes/cppcheck/expectations.rb
+++ b/test/smokes/cppcheck/expectations.rb
@@ -1,9 +1,7 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "default",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -214,16 +212,16 @@ Smoke.add_test(
   analyzer: { name: "Cppcheck", version: "1.90" }
 )
 
-Smoke.add_test(
+s.add_test(
   "no_target",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Cppcheck", version: :_ } },
-  { warnings: [{ message: "No linting files.", file: nil }] }
+  type: "success",
+  issues: [],
+  analyzer: { name: "Cppcheck", version: :_ },
+  warnings: [{ message: "No linting files.", file: nil }]
 )
 
-Smoke.add_test(
+s.add_test(
   "single_target",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -241,10 +239,8 @@ Smoke.add_test(
   analyzer: { name: "Cppcheck", version: "1.90" }
 )
 
-Smoke.add_test(
+s.add_test(
   "multiple_target",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -273,10 +269,8 @@ Smoke.add_test(
   analyzer: { name: "Cppcheck", version: "1.90" }
 )
 
-Smoke.add_test(
+s.add_test(
   "single_ignore",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -294,10 +288,8 @@ Smoke.add_test(
   analyzer: { name: "Cppcheck", version: "1.90" }
 )
 
-Smoke.add_test(
+s.add_test(
   "multiple_ignore",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -313,10 +305,8 @@ Smoke.add_test(
   analyzer: { name: "Cppcheck", version: "1.90" }
 )
 
-Smoke.add_test(
+s.add_test(
   "enable",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -350,10 +340,8 @@ Smoke.add_test(
   analyzer: { name: "Cppcheck", version: "1.90" }
 )
 
-Smoke.add_test(
+s.add_test(
   "std",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -376,10 +364,8 @@ Smoke.add_test(
   analyzer: { name: "Cppcheck", version: "1.90" }
 )
 
-Smoke.add_test(
+s.add_test(
   "project",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -395,10 +381,8 @@ Smoke.add_test(
   analyzer: { name: "Cppcheck", version: "1.90" }
 )
 
-Smoke.add_test(
+s.add_test(
   "language",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -425,11 +409,7 @@ Smoke.add_test(
   analyzer: { name: "Cppcheck", version: "1.90" }
 )
 
-Smoke.add_test(
+s.add_test(
   "unexpected_error",
-  guid: "test-guid",
-  timestamp: :_,
-  type: "failure",
-  message: "cppcheck: Unknown language 'foo' enforced.",
-  analyzer: { name: "Cppcheck", version: :_ }
+  type: "failure", message: "cppcheck: Unknown language 'foo' enforced.", analyzer: { name: "Cppcheck", version: :_ }
 )

--- a/test/smokes/cpplint/expectations.rb
+++ b/test/smokes/cpplint/expectations.rb
@@ -1,197 +1,158 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "default",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "legal/copyright",
-        path: "src/test.cpp",
-        location: nil,
-        message: "No copyright message found.  You should have a line: \"Copyright [year] <Copyright Owner>\"",
-        links: [],
-        object: { confidence: "5" },
-        git_blame_info: nil
-      },
-      {
-        id: "whitespace/braces",
-        path: "foo.cc",
-        location: { start_line: 3 },
-        message: "{ should almost always be at the end of the previous line",
-        links: [],
-        object: { confidence: "4" },
-        git_blame_info: nil
-      },
-      {
-        id: "whitespace/tab",
-        path: "foo.cc",
-        location: { start_line: 4 },
-        message: "Tab found; better to use spaces",
-        links: [],
-        object: { confidence: "1" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "cpplint", version: "1.4.5" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "legal/copyright",
+      path: "src/test.cpp",
+      location: nil,
+      message: "No copyright message found.  You should have a line: \"Copyright [year] <Copyright Owner>\"",
+      links: [],
+      object: { confidence: "5" },
+      git_blame_info: nil
+    },
+    {
+      id: "whitespace/braces",
+      path: "foo.cc",
+      location: { start_line: 3 },
+      message: "{ should almost always be at the end of the previous line",
+      links: [],
+      object: { confidence: "4" },
+      git_blame_info: nil
+    },
+    {
+      id: "whitespace/tab",
+      path: "foo.cc",
+      location: { start_line: 4 },
+      message: "Tab found; better to use spaces",
+      links: [],
+      object: { confidence: "1" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "cpplint", version: "1.4.5" }
 )
 
-Smoke.add_test(
-  "official_samples",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: :_, analyzer: { name: "cpplint", version: "1.4.5" } }
-)
+s.add_test("official_samples", type: "success", issues: :_, analyzer: { name: "cpplint", version: "1.4.5" })
 
-Smoke.add_test(
-  "option_exclude",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "cpplint", version: "1.4.5" } }
-)
+s.add_test("option_exclude", type: "success", issues: [], analyzer: { name: "cpplint", version: "1.4.5" })
 
-Smoke.add_test(
-  "option_exclude_multi",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "cpplint", version: "1.4.5" } }
-)
+s.add_test("option_exclude_multi", type: "success", issues: [], analyzer: { name: "cpplint", version: "1.4.5" })
 
-Smoke.add_test(
-  "option_extensions",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "cpplint", version: "1.4.5" } }
-)
+s.add_test("option_extensions", type: "success", issues: [], analyzer: { name: "cpplint", version: "1.4.5" })
 
-Smoke.add_test(
+s.add_test(
   "option_filter",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "whitespace/braces",
-        path: "test.cpp",
-        location: { start_line: 2 },
-        message: "{ should almost always be at the end of the previous line",
-        links: [],
-        object: { confidence: "4" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "cpplint", version: "1.4.5" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "whitespace/braces",
+      path: "test.cpp",
+      location: { start_line: 2 },
+      message: "{ should almost always be at the end of the previous line",
+      links: [],
+      object: { confidence: "4" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "cpplint", version: "1.4.5" }
 )
 
-Smoke.add_test(
-  "option_headers",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "cpplint", version: "1.4.5" } }
-)
+s.add_test("option_headers", type: "success", issues: [], analyzer: { name: "cpplint", version: "1.4.5" })
 
-Smoke.add_test(
+s.add_test(
   "option_linelength",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "whitespace/line_length",
-        path: "test.cpp",
-        location: nil,
-        message: "Lines should be <= 50 characters long",
-        links: [],
-        object: { confidence: "2" },
-        git_blame_info: nil
-      },
-      {
-        id: "whitespace/line_length",
-        path: "test.cpp",
-        location: { start_line: 2 },
-        message: "Lines should be <= 50 characters long",
-        links: [],
-        object: { confidence: "2" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "cpplint", version: "1.4.5" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "whitespace/line_length",
+      path: "test.cpp",
+      location: nil,
+      message: "Lines should be <= 50 characters long",
+      links: [],
+      object: { confidence: "2" },
+      git_blame_info: nil
+    },
+    {
+      id: "whitespace/line_length",
+      path: "test.cpp",
+      location: { start_line: 2 },
+      message: "Lines should be <= 50 characters long",
+      links: [],
+      object: { confidence: "2" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "cpplint", version: "1.4.5" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_target",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "whitespace/braces",
-        path: "src/foo.cpp",
-        location: { start_line: 2 },
-        message: "Missing space before {",
-        links: [],
-        object: { confidence: "5" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "cpplint", version: "1.4.5" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "whitespace/braces",
+      path: "src/foo.cpp",
+      location: { start_line: 2 },
+      message: "Missing space before {",
+      links: [],
+      object: { confidence: "5" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "cpplint", version: "1.4.5" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_target_multi",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "whitespace/braces",
-        path: "lib/bar.cc",
-        location: { start_line: 2 },
-        message: "Missing space before {",
-        links: [],
-        object: { confidence: "5" },
-        git_blame_info: nil
-      },
-      {
-        id: "whitespace/braces",
-        path: "src/foo.cpp",
-        location: { start_line: 2 },
-        message: "Missing space before {",
-        links: [],
-        object: { confidence: "5" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "cpplint", version: "1.4.5" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "whitespace/braces",
+      path: "lib/bar.cc",
+      location: { start_line: 2 },
+      message: "Missing space before {",
+      links: [],
+      object: { confidence: "5" },
+      git_blame_info: nil
+    },
+    {
+      id: "whitespace/braces",
+      path: "src/foo.cpp",
+      location: { start_line: 2 },
+      message: "Missing space before {",
+      links: [],
+      object: { confidence: "5" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "cpplint", version: "1.4.5" }
 )
 
-Smoke.add_test(
+s.add_test(
   "no_line_number",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "build/header_guard",
-        path: "foo.h",
-        location: nil,
-        message: /No #ifndef header guard found, suggested CPP variable is:/,
-        links: [],
-        object: { confidence: "5" },
-        git_blame_info: nil
-      },
-      {
-        id: "build/include",
-        path: "foo.cc",
-        location: nil,
-        message: /(.+)foo\.cc should include its header file (.+)foo\.h/,
-        links: [],
-        object: { confidence: "5" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "cpplint", version: "1.4.5" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "build/header_guard",
+      path: "foo.h",
+      location: nil,
+      message: /No #ifndef header guard found, suggested CPP variable is:/,
+      links: [],
+      object: { confidence: "5" },
+      git_blame_info: nil
+    },
+    {
+      id: "build/include",
+      path: "foo.cc",
+      location: nil,
+      message: /(.+)foo\.cc should include its header file (.+)foo\.h/,
+      links: [],
+      object: { confidence: "5" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "cpplint", version: "1.4.5" }
 )

--- a/test/smokes/detekt/expectations.rb
+++ b/test/smokes/detekt/expectations.rb
@@ -3,7 +3,7 @@ s = Runners::Testing::Smoke
 s.add_test(
   "with_broken_sider_yml",
   type: "failure",
-  analyzer: nil,
+  analyzer: :_,
   message: "The attribute `$.linter.detekt.cli` in your `sider.yml` is unsupported. Please fix and retry."
 )
 

--- a/test/smokes/detekt/expectations.rb
+++ b/test/smokes/detekt/expectations.rb
@@ -1,205 +1,173 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "with_broken_sider_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    analyzer: nil,
-    message: "The attribute `$.linter.detekt.cli` in your `sider.yml` is unsupported. Please fix and retry."
-  }
+  type: "failure",
+  analyzer: nil,
+  message: "The attribute `$.linter.detekt.cli` in your `sider.yml` is unsupported. Please fix and retry."
 )
 
-Smoke.add_test(
+s.add_test(
   "with_invalid_detekt_config",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    analyzer: { name: "detekt", version: "1.7.0" },
-    message: "Your detekt configuration is invalid"
-  }
+  type: "failure", analyzer: { name: "detekt", version: "1.7.0" }, message: "Your detekt configuration is invalid"
 )
 
-Smoke.add_test(
+s.add_test(
   "with_invalid_sider_option",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "error",
-    class: "RuntimeError",
-    backtrace: :_,
-    inspect: %r{.*\'non\/exists\/dir\/\' does not exist.*}
-  }
+  type: "error", class: "RuntimeError", backtrace: :_, inspect: %r{.*\'non\/exists\/dir\/\' does not exist.*}
 )
 
-Smoke.add_test(
+s.add_test(
   "with_options",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "detekt", version: "1.7.0" },
-    issues: [
-      {
-        id: "detekt.EmptyClassBlock",
-        path: "src/FilteredClass.kt",
-        location: { start_line: 2 },
-        message: "The class or object FilteredClass is empty.",
-        links: [],
-        object: { severity: "info" },
-        git_blame_info: nil
-      },
-      {
-        id: "detekt.ForEachOnRange",
-        path: "src/ComplexClass.kt",
-        location: { start_line: 44 },
-        message: "Using the forEach method on ranges has a heavy performance cost. Prefer using simple for loops.",
-        links: [],
-        object: { severity: "warning" },
-        git_blame_info: nil
-      },
-      {
-        id: "detekt.FunctionOnlyReturningConstant",
-        path: "src/App.kt",
-        location: { start_line: 8 },
-        message: "get is returning a constant. Prefer declaring a constant instead.",
-        links: [],
-        object: { severity: "warning" },
-        git_blame_info: nil
-      },
-      {
-        id: "detekt.NestedBlockDepth",
-        path: "src/ComplexClass.kt",
-        location: { start_line: 9 },
-        message: "Function complex is nested too deeply.",
-        links: [],
-        object: { severity: "warning" },
-        git_blame_info: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "detekt", version: "1.7.0" },
+  issues: [
+    {
+      id: "detekt.EmptyClassBlock",
+      path: "src/FilteredClass.kt",
+      location: { start_line: 2 },
+      message: "The class or object FilteredClass is empty.",
+      links: [],
+      object: { severity: "info" },
+      git_blame_info: nil
+    },
+    {
+      id: "detekt.ForEachOnRange",
+      path: "src/ComplexClass.kt",
+      location: { start_line: 44 },
+      message: "Using the forEach method on ranges has a heavy performance cost. Prefer using simple for loops.",
+      links: [],
+      object: { severity: "warning" },
+      git_blame_info: nil
+    },
+    {
+      id: "detekt.FunctionOnlyReturningConstant",
+      path: "src/App.kt",
+      location: { start_line: 8 },
+      message: "get is returning a constant. Prefer declaring a constant instead.",
+      links: [],
+      object: { severity: "warning" },
+      git_blame_info: nil
+    },
+    {
+      id: "detekt.NestedBlockDepth",
+      path: "src/ComplexClass.kt",
+      location: { start_line: 9 },
+      message: "Function complex is nested too deeply.",
+      links: [],
+      object: { severity: "warning" },
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "without_options",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "detekt", version: "1.7.0" },
-    issues: [
-      {
-        id: "detekt.EmptyClassBlock",
-        path: "src/FilteredClass.kt",
-        location: { start_line: 2 },
-        message: "The class or object FilteredClass is empty.",
-        links: [],
-        object: { severity: "info" },
-        git_blame_info: nil
-      },
-      {
-        id: "detekt.ForEachOnRange",
-        path: "src/ComplexClass.kt",
-        location: { start_line: 44 },
-        message: "Using the forEach method on ranges has a heavy performance cost. Prefer using simple for loops.",
-        links: [],
-        object: { severity: "warning" },
-        git_blame_info: nil
-      },
-      {
-        id: "detekt.FunctionOnlyReturningConstant",
-        path: "src/App.kt",
-        location: { start_line: 8 },
-        message: "get is returning a constant. Prefer declaring a constant instead.",
-        links: [],
-        object: { severity: "warning" },
-        git_blame_info: nil
-      },
-      {
-        id: "detekt.MagicNumber",
-        path: "src/ComplexClass.kt",
-        location: { start_line: 44 },
-        message: "This expression contains a magic number. Consider defining it to a well named constant.",
-        links: [],
-        object: { severity: "warning" },
-        git_blame_info: nil
-      },
-      {
-        id: "detekt.MagicNumber",
-        path: "src/ComplexClass.kt",
-        location: { start_line: 48 },
-        message: "This expression contains a magic number. Consider defining it to a well named constant.",
-        links: [],
-        object: { severity: "warning" },
-        git_blame_info: nil
-      },
-      {
-        id: "detekt.NestedBlockDepth",
-        path: "src/ComplexClass.kt",
-        location: { start_line: 9 },
-        message: "Function complex is nested too deeply.",
-        links: [],
-        object: { severity: "warning" },
-        git_blame_info: nil
-      },
-      {
-        id: "detekt.TooGenericExceptionCaught",
-        path: "src/ComplexClass.kt",
-        location: { start_line: 19 },
-        message:
-          "Caught exception is too generic. Prefer catching specific exceptions to the case that is currently handled.",
-        links: [],
-        object: { severity: "error" },
-        git_blame_info: nil
-      },
-      {
-        id: "detekt.TooGenericExceptionCaught",
-        path: "src/ComplexClass.kt",
-        location: { start_line: 22 },
-        message:
-          "Caught exception is too generic. Prefer catching specific exceptions to the case that is currently handled.",
-        links: [],
-        object: { severity: "error" },
-        git_blame_info: nil
-      },
-      {
-        id: "detekt.TooGenericExceptionCaught",
-        path: "src/ComplexClass.kt",
-        location: { start_line: 34 },
-        message:
-          "Caught exception is too generic. Prefer catching specific exceptions to the case that is currently handled.",
-        links: [],
-        object: { severity: "error" },
-        git_blame_info: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "detekt", version: "1.7.0" },
+  issues: [
+    {
+      id: "detekt.EmptyClassBlock",
+      path: "src/FilteredClass.kt",
+      location: { start_line: 2 },
+      message: "The class or object FilteredClass is empty.",
+      links: [],
+      object: { severity: "info" },
+      git_blame_info: nil
+    },
+    {
+      id: "detekt.ForEachOnRange",
+      path: "src/ComplexClass.kt",
+      location: { start_line: 44 },
+      message: "Using the forEach method on ranges has a heavy performance cost. Prefer using simple for loops.",
+      links: [],
+      object: { severity: "warning" },
+      git_blame_info: nil
+    },
+    {
+      id: "detekt.FunctionOnlyReturningConstant",
+      path: "src/App.kt",
+      location: { start_line: 8 },
+      message: "get is returning a constant. Prefer declaring a constant instead.",
+      links: [],
+      object: { severity: "warning" },
+      git_blame_info: nil
+    },
+    {
+      id: "detekt.MagicNumber",
+      path: "src/ComplexClass.kt",
+      location: { start_line: 44 },
+      message: "This expression contains a magic number. Consider defining it to a well named constant.",
+      links: [],
+      object: { severity: "warning" },
+      git_blame_info: nil
+    },
+    {
+      id: "detekt.MagicNumber",
+      path: "src/ComplexClass.kt",
+      location: { start_line: 48 },
+      message: "This expression contains a magic number. Consider defining it to a well named constant.",
+      links: [],
+      object: { severity: "warning" },
+      git_blame_info: nil
+    },
+    {
+      id: "detekt.NestedBlockDepth",
+      path: "src/ComplexClass.kt",
+      location: { start_line: 9 },
+      message: "Function complex is nested too deeply.",
+      links: [],
+      object: { severity: "warning" },
+      git_blame_info: nil
+    },
+    {
+      id: "detekt.TooGenericExceptionCaught",
+      path: "src/ComplexClass.kt",
+      location: { start_line: 19 },
+      message:
+        "Caught exception is too generic. Prefer catching specific exceptions to the case that is currently handled.",
+      links: [],
+      object: { severity: "error" },
+      git_blame_info: nil
+    },
+    {
+      id: "detekt.TooGenericExceptionCaught",
+      path: "src/ComplexClass.kt",
+      location: { start_line: 22 },
+      message:
+        "Caught exception is too generic. Prefer catching specific exceptions to the case that is currently handled.",
+      links: [],
+      object: { severity: "error" },
+      git_blame_info: nil
+    },
+    {
+      id: "detekt.TooGenericExceptionCaught",
+      path: "src/ComplexClass.kt",
+      location: { start_line: 34 },
+      message:
+        "Caught exception is too generic. Prefer catching specific exceptions to the case that is currently handled.",
+      links: [],
+      object: { severity: "error" },
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "with_option_includes",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "detekt", version: "1.7.0" },
-    issues: [
-      {
-        id: "detekt.EmptyClassBlock",
-        path: "src/main/App.kt",
-        location: { start_line: 1 },
-        message: "The class or object App is empty.",
-        links: [],
-        object: { severity: "info" },
-        git_blame_info: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "detekt", version: "1.7.0" },
+  issues: [
+    {
+      id: "detekt.EmptyClassBlock",
+      path: "src/main/App.kt",
+      location: { start_line: 1 },
+      message: "The class or object App is empty.",
+      links: [],
+      object: { severity: "info" },
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
-  "no_files",
-  { guid: "test-guid", timestamp: :_, type: "success", analyzer: { name: "detekt", version: "1.7.0" }, issues: [] }
-)
+s.add_test("no_files", type: "success", analyzer: { name: "detekt", version: "1.7.0" }, issues: [])

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -46,10 +46,10 @@ MESSAGE
 s.add_test(
   "pinned_old_eslint",
   type: "failure",
-  message: <<~MSG
+  message: <<~MSG,
     Your `eslint` settings could not satisfy the required constraints. Please check your `package.json` again.
     If you want to analyze via the Sider default settings, please configure your `sideci.yml`. For details, see the documentation.
-  MSG,
+  MSG
   analyzer: :_
 )
 

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -30,25 +30,16 @@ s.add_test(
 s.add_test(
   "only_eslintrc",
   type: "failure",
-  message:
-    Regexp.new(
-      Regexp.quote(<<-MESSAGE)
-Oops! Something went wrong! :(
-
-ESLint: 6.8.0.
-
-ESLint couldn't find the plugin "eslint-plugin-filenames".
-MESSAGE
-    ),
+  message: /ESLint couldn't find the plugin "eslint-plugin-filenames"/,
   analyzer: { name: "ESLint", version: "6.8.0" }
 )
 
 s.add_test(
   "pinned_old_eslint",
   type: "failure",
-  message: <<~MSG,
-    Your `eslint` settings could not satisfy the required constraints. Please check your `package.json` again.
-    If you want to analyze via the Sider default settings, please configure your `sideci.yml`. For details, see the documentation.
+  message: <<~MSG.strip,
+Your `eslint` settings could not satisfy the required constraints. Please check your `package.json` again.
+If you want to analyze via the Sider default settings, please configure your `sideci.yml`. For details, see the documentation.
   MSG
   analyzer: :_
 )
@@ -140,11 +131,11 @@ s.add_test(
   analyzer: { name: "ESLint", version: "6.8.0" },
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The `$.linter.eslint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/eslint ).
-      MSG
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The `$.linter.eslint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/eslint ).
+MSG
       file: "sideci.yml"
     }
   ]
@@ -286,16 +277,16 @@ s.add_test(
   type: "success",
   issues: [
     {
-      message: <<~MESSAGE,
-        Parsing error: Unexpected token, expected ";"
+      message: <<~MESSAGE.strip,
+Parsing error: Unexpected token, expected ";"
 
-          1 | function bar() {
-        > 2 |   var x = foo:
-            |              ^
-          3 |   for (;;) {
-          4 |     break x;
-          5 |   }
-      MESSAGE
+  1 | function bar() {
+> 2 |   var x = foo:
+    |              ^
+  3 |   for (;;) {
+  4 |     break x;
+  5 |   }
+MESSAGE
       links: [],
       id: "d91b54561db04524f183f5f8dee752dcf1d4fcb0",
       path: "index.js",

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -1,435 +1,364 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "no_config",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "index.js",
-        location: { start_line: 1, start_column: 1, end_line: 2, end_column: 2 },
-        id: "for-direction",
-        message: "The update clause in this loop moves the variable in the wrong direction.",
-        links: %w[https://eslint.org/docs/rules/for-direction],
-        object: { severity: "error", category: "Possible Errors", recommended: true },
-        git_blame_info: nil
-      },
-      {
-        path: "index.js",
-        location: { start_line: 1, start_column: 30, end_line: 2, end_column: 2 },
-        id: "no-empty",
-        message: "Empty block statement.",
-        links: %w[https://eslint.org/docs/rules/no-empty],
-        object: { severity: "error", category: "Possible Errors", recommended: true },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ESLint", version: "6.8.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "index.js",
+      location: { start_line: 1, start_column: 1, end_line: 2, end_column: 2 },
+      id: "for-direction",
+      message: "The update clause in this loop moves the variable in the wrong direction.",
+      links: %w[https://eslint.org/docs/rules/for-direction],
+      object: { severity: "error", category: "Possible Errors", recommended: true },
+      git_blame_info: nil
+    },
+    {
+      path: "index.js",
+      location: { start_line: 1, start_column: 30, end_line: 2, end_column: 2 },
+      id: "no-empty",
+      message: "Empty block statement.",
+      links: %w[https://eslint.org/docs/rules/no-empty],
+      object: { severity: "error", category: "Possible Errors", recommended: true },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ESLint", version: "6.8.0" }
 )
 
 # This test case's .eslintrc includes ESLint plugin, thus Sider fails because of the plugin unavailable.
-Smoke.add_test(
+s.add_test(
   "only_eslintrc",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message:
-      Regexp.new(
-        Regexp.quote(<<~MESSAGE)
-          Oops! Something went wrong! :(
+  type: "failure",
+  message:
+    Regexp.new(
+      Regexp.quote(<<-MESSAGE)
+Oops! Something went wrong! :(
 
-          ESLint: 6.8.0.
+ESLint: 6.8.0.
 
-          ESLint couldn't find the plugin "eslint-plugin-filenames".
-  MESSAGE
-      ),
-    analyzer: { name: "ESLint", version: "6.8.0" }
-  }
+ESLint couldn't find the plugin "eslint-plugin-filenames".
+MESSAGE
+    ),
+  analyzer: { name: "ESLint", version: "6.8.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "pinned_old_eslint",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: <<~MSG
-      Your `eslint` settings could not satisfy the required constraints. Please check your `package.json` again.
-      If you want to analyze via the Sider default settings, please configure your `sideci.yml`. For details, see the documentation.
-    MSG
-      .strip,
-    analyzer: nil
-  }
+  type: "failure",
+  message: <<~MSG
+    Your `eslint` settings could not satisfy the required constraints. Please check your `package.json` again.
+    If you want to analyze via the Sider default settings, please configure your `sideci.yml`. For details, see the documentation.
+  MSG,
+  analyzer: :_
 )
 
-Smoke.add_test(
-  "no_files",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "ESLint", version: "6.8.0" } }
-)
+s.add_test("no_files", type: "success", issues: [], analyzer: { name: "ESLint", version: "6.8.0" })
 
-Smoke.add_test(
+s.add_test(
   "pinned_eslint5",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Expected indentation of 8 space characters but found 6.",
-        links: [],
-        id: "react/jsx-indent",
-        path: "src/App.jsx",
-        location: { start_line: 6, start_column: 7, end_line: 6, end_column: 11 },
-        object: { severity: "error", category: nil, recommended: nil },
-        git_blame_info: nil
-      },
-      {
-        message: "Missing JSX expression container around literal string",
-        links: [],
-        id: "react/jsx-no-literals",
-        path: "src/App.jsx",
-        location: { start_line: 6, start_column: 11, end_line: 6, end_column: 23 },
-        object: { severity: "error", category: nil, recommended: nil },
-        git_blame_info: nil
-      },
-      {
-        message: "`Hello world.` must be placed on a new line",
-        links: [],
-        id: "react/jsx-one-expression-per-line",
-        path: "src/App.jsx",
-        location: { start_line: 6, start_column: 11, end_line: 6, end_column: 23 },
-        object: { severity: "error", category: nil, recommended: nil },
-        git_blame_info: nil
-      },
-      {
-        message: "Component should be written as a pure function",
-        links: [],
-        id: "react/prefer-stateless-function",
-        path: "src/App.jsx",
-        location: { start_line: 3, start_column: 16, end_line: 9, end_column: 2 },
-        object: { severity: "error", category: nil, recommended: nil },
-        git_blame_info: nil
-      },
-      {
-        message: "Component is not optimized. Please add a shouldComponentUpdate method.",
-        links: [],
-        id: "react/require-optimization",
-        path: "src/App.jsx",
-        location: { start_line: 3, start_column: 16, end_line: 9, end_column: 2 },
-        object: { severity: "error", category: nil, recommended: nil },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ESLint", version: "5.1.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Expected indentation of 8 space characters but found 6.",
+      links: [],
+      id: "react/jsx-indent",
+      path: "src/App.jsx",
+      location: { start_line: 6, start_column: 7, end_line: 6, end_column: 11 },
+      object: { severity: "error", category: nil, recommended: nil },
+      git_blame_info: nil
+    },
+    {
+      message: "Missing JSX expression container around literal string",
+      links: [],
+      id: "react/jsx-no-literals",
+      path: "src/App.jsx",
+      location: { start_line: 6, start_column: 11, end_line: 6, end_column: 23 },
+      object: { severity: "error", category: nil, recommended: nil },
+      git_blame_info: nil
+    },
+    {
+      message: "`Hello world.` must be placed on a new line",
+      links: [],
+      id: "react/jsx-one-expression-per-line",
+      path: "src/App.jsx",
+      location: { start_line: 6, start_column: 11, end_line: 6, end_column: 23 },
+      object: { severity: "error", category: nil, recommended: nil },
+      git_blame_info: nil
+    },
+    {
+      message: "Component should be written as a pure function",
+      links: [],
+      id: "react/prefer-stateless-function",
+      path: "src/App.jsx",
+      location: { start_line: 3, start_column: 16, end_line: 9, end_column: 2 },
+      object: { severity: "error", category: nil, recommended: nil },
+      git_blame_info: nil
+    },
+    {
+      message: "Component is not optimized. Please add a shouldComponentUpdate method.",
+      links: [],
+      id: "react/require-optimization",
+      path: "src/App.jsx",
+      location: { start_line: 3, start_column: 16, end_line: 9, end_column: 2 },
+      object: { severity: "error", category: nil, recommended: nil },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ESLint", version: "5.1.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_config",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: /Error: ESLint configuration in .eslintrc.yml is invalid:/,
-    analyzer: { name: "ESLint", version: :_ }
-  }
+  type: "failure",
+  message: /Error: ESLint configuration in .eslintrc.yml is invalid:/,
+  analyzer: { name: "ESLint", version: :_ }
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sideci_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message:
-      "The value of the attribute `$.linter.eslint.npm_install` in your `sideci.yml` is invalid. Please fix and retry.",
-    analyzer: nil
-  }
+  type: "failure",
+  message:
+    "The value of the attribute `$.linter.eslint.npm_install` in your `sideci.yml` is invalid. Please fix and retry.",
+  analyzer: :_
 )
 
-Smoke.add_test(
+s.add_test(
   "quiet",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Missing semicolon.",
-        links: %w[https://eslint.org/docs/rules/semi],
-        id: "semi",
-        path: "test.js",
-        location: { start_line: 1, start_column: 83, end_line: 2, end_column: 1 },
-        object: { severity: "error", category: "Stylistic Issues", recommended: false },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ESLint", version: "6.8.0" }
-  },
-  {
-    warnings: [
-      {
-        message: <<~MSG
-          DEPRECATION WARNING!!!
-          The `$.linter.eslint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-          Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/eslint ).
-        MSG
-          .strip,
-        file: "sideci.yml"
-      }
-    ]
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Missing semicolon.",
+      links: %w[https://eslint.org/docs/rules/semi],
+      id: "semi",
+      path: "test.js",
+      location: { start_line: 1, start_column: 83, end_line: 2, end_column: 1 },
+      object: { severity: "error", category: "Stylistic Issues", recommended: false },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ESLint", version: "6.8.0" },
+  warnings: [
+    {
+      message: <<~MSG,
+        DEPRECATION WARNING!!!
+        The `$.linter.eslint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/eslint ).
+      MSG
+      file: "sideci.yml"
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "array_ignore_pattern",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "This line has a length of 82. Maximum allowed is 10.",
-        links: %w[https://eslint.org/docs/rules/max-len],
-        id: "max-len",
-        path: "app.js",
-        location: { start_line: 1 },
-        object: { severity: "warn", category: "Stylistic Issues", recommended: false },
-        git_blame_info: nil
-      },
-      {
-        message: "Missing semicolon.",
-        links: %w[https://eslint.org/docs/rules/semi],
-        id: "semi",
-        path: "app.js",
-        location: { start_line: 1, start_column: 83, end_line: 2, end_column: 1 },
-        object: { severity: "error", category: "Stylistic Issues", recommended: false },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ESLint", version: "6.8.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "This line has a length of 82. Maximum allowed is 10.",
+      links: %w[https://eslint.org/docs/rules/max-len],
+      id: "max-len",
+      path: "app.js",
+      location: { start_line: 1 },
+      object: { severity: "warn", category: "Stylistic Issues", recommended: false },
+      git_blame_info: nil
+    },
+    {
+      message: "Missing semicolon.",
+      links: %w[https://eslint.org/docs/rules/semi],
+      id: "semi",
+      path: "app.js",
+      location: { start_line: 1, start_column: 83, end_line: 2, end_column: 1 },
+      object: { severity: "error", category: "Stylistic Issues", recommended: false },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ESLint", version: "6.8.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "sider_config",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Parsing error: The keyword 'import' is reserved",
-        links: [],
-        id: "0299e5a2c549669334ef4905ed3a636d9ae07723",
-        path: "src/App.jsx",
-        location: { start_line: 1 },
-        object: { severity: "error", category: nil, recommended: nil },
-        git_blame_info: nil
-      },
-      {
-        message: "Parsing error: The keyword 'import' is reserved",
-        links: [],
-        id: "0299e5a2c549669334ef4905ed3a636d9ae07723",
-        path: "src/application.jsx",
-        location: { start_line: 1 },
-        object: { severity: "error", category: nil, recommended: nil },
-        git_blame_info: nil
-      },
-      {
-        message: "'foo' is not defined.",
-        links: %w[https://eslint.org/docs/rules/no-undef],
-        id: "no-undef",
-        path: "src/index.js",
-        location: { start_line: 1, start_column: 9, end_line: 1, end_column: 12 },
-        object: { severity: "error", category: "Variables", recommended: true },
-        git_blame_info: nil
-      },
-      {
-        message: "'x' is assigned a value but never used.",
-        links: %w[https://eslint.org/docs/rules/no-unused-vars],
-        id: "no-unused-vars",
-        path: "src/index.js",
-        location: { start_line: 1, start_column: 5, end_line: 1, end_column: 6 },
-        object: { severity: "error", category: "Variables", recommended: true },
-        git_blame_info: nil
-      },
-      {
-        message: "'bar' is defined but never used.",
-        links: %w[https://eslint.org/docs/rules/no-unused-vars],
-        id: "no-unused-vars",
-        path: "src/index.js",
-        location: { start_line: 2, start_column: 10, end_line: 2, end_column: 13 },
-        object: { severity: "error", category: "Variables", recommended: true },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ESLint", version: "5.16.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Parsing error: The keyword 'import' is reserved",
+      links: [],
+      id: "0299e5a2c549669334ef4905ed3a636d9ae07723",
+      path: "src/App.jsx",
+      location: { start_line: 1 },
+      object: { severity: "error", category: nil, recommended: nil },
+      git_blame_info: nil
+    },
+    {
+      message: "Parsing error: The keyword 'import' is reserved",
+      links: [],
+      id: "0299e5a2c549669334ef4905ed3a636d9ae07723",
+      path: "src/application.jsx",
+      location: { start_line: 1 },
+      object: { severity: "error", category: nil, recommended: nil },
+      git_blame_info: nil
+    },
+    {
+      message: "'foo' is not defined.",
+      links: %w[https://eslint.org/docs/rules/no-undef],
+      id: "no-undef",
+      path: "src/index.js",
+      location: { start_line: 1, start_column: 9, end_line: 1, end_column: 12 },
+      object: { severity: "error", category: "Variables", recommended: true },
+      git_blame_info: nil
+    },
+    {
+      message: "'x' is assigned a value but never used.",
+      links: %w[https://eslint.org/docs/rules/no-unused-vars],
+      id: "no-unused-vars",
+      path: "src/index.js",
+      location: { start_line: 1, start_column: 5, end_line: 1, end_column: 6 },
+      object: { severity: "error", category: "Variables", recommended: true },
+      git_blame_info: nil
+    },
+    {
+      message: "'bar' is defined but never used.",
+      links: %w[https://eslint.org/docs/rules/no-unused-vars],
+      id: "no-unused-vars",
+      path: "src/index.js",
+      location: { start_line: 2, start_column: 10, end_line: 2, end_column: 13 },
+      object: { severity: "error", category: "Variables", recommended: true },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ESLint", version: "5.16.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "no_ignore",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Parsing error: The keyword 'import' is reserved",
-        links: [],
-        id: "0299e5a2c549669334ef4905ed3a636d9ae07723",
-        path: "src/App.jsx",
-        location: { start_line: 1 },
-        object: { severity: "error", category: nil, recommended: nil },
-        git_blame_info: nil
-      },
-      {
-        message: "Parsing error: The keyword 'import' is reserved",
-        links: [],
-        id: "0299e5a2c549669334ef4905ed3a636d9ae07723",
-        path: "src/index.jsx",
-        location: { start_line: 1 },
-        object: { severity: "error", category: nil, recommended: nil },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ESLint", version: "5.16.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Parsing error: The keyword 'import' is reserved",
+      links: [],
+      id: "0299e5a2c549669334ef4905ed3a636d9ae07723",
+      path: "src/App.jsx",
+      location: { start_line: 1 },
+      object: { severity: "error", category: nil, recommended: nil },
+      git_blame_info: nil
+    },
+    {
+      message: "Parsing error: The keyword 'import' is reserved",
+      links: [],
+      id: "0299e5a2c549669334ef4905ed3a636d9ae07723",
+      path: "src/index.jsx",
+      location: { start_line: 1 },
+      object: { severity: "error", category: nil, recommended: nil },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ESLint", version: "5.16.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "additional_options",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Parsing error: The keyword 'import' is reserved",
-        links: [],
-        id: "0299e5a2c549669334ef4905ed3a636d9ae07723",
-        path: "src/App.jsx",
-        location: { start_line: 1 },
-        object: { severity: "error", category: nil, recommended: nil },
-        git_blame_info: nil
-      },
-      {
-        message: "Parsing error: The keyword 'import' is reserved",
-        links: [],
-        id: "0299e5a2c549669334ef4905ed3a636d9ae07723",
-        path: "src/application.jsx",
-        location: { start_line: 1 },
-        object: { severity: "error", category: nil, recommended: nil },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ESLint", version: "5.16.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Parsing error: The keyword 'import' is reserved",
+      links: [],
+      id: "0299e5a2c549669334ef4905ed3a636d9ae07723",
+      path: "src/App.jsx",
+      location: { start_line: 1 },
+      object: { severity: "error", category: nil, recommended: nil },
+      git_blame_info: nil
+    },
+    {
+      message: "Parsing error: The keyword 'import' is reserved",
+      links: [],
+      id: "0299e5a2c549669334ef4905ed3a636d9ae07723",
+      path: "src/application.jsx",
+      location: { start_line: 1 },
+      object: { severity: "error", category: nil, recommended: nil },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ESLint", version: "5.16.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "prefer_npm_install_true_to_eslintrc",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: <<~MESSAGE
-          Parsing error: Unexpected token, expected ";"
+  type: "success",
+  issues: [
+    {
+      message: <<~MESSAGE,
+        Parsing error: Unexpected token, expected ";"
 
-            1 | function bar() {
-          > 2 |   var x = foo:
-              |              ^
-            3 |   for (;;) {
-            4 |     break x;
-            5 |   }
+          1 | function bar() {
+        > 2 |   var x = foo:
+            |              ^
+          3 |   for (;;) {
+          4 |     break x;
+          5 |   }
       MESSAGE
-          .rstrip,
-        links: [],
-        id: "d91b54561db04524f183f5f8dee752dcf1d4fcb0",
-        path: "index.js",
-        location: { start_line: 2 },
-        object: { severity: "error", category: nil, recommended: nil },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ESLint", version: "5.16.0" }
-  }
+      links: [],
+      id: "d91b54561db04524f183f5f8dee752dcf1d4fcb0",
+      path: "index.js",
+      location: { start_line: 2 },
+      object: { severity: "error", category: nil, recommended: nil },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ESLint", version: "5.16.0" }
 )
 
-Smoke.add_test(
-  "default_version_is_used",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "ESLint", version: "6.8.0" } }
-)
+s.add_test("default_version_is_used", type: "success", issues: [], analyzer: { name: "ESLint", version: "6.8.0" })
 
-Smoke.add_test(
+s.add_test(
   "mismatched_package_version",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "`yarn install` failed. Please confirm `yarn.lock` is consistent with `package.json`.",
-    analyzer: nil
-  }
+  type: "failure",
+  message: "`yarn install` failed. Please confirm `yarn.lock` is consistent with `package.json`.",
+  analyzer: :_
 )
 
-Smoke.add_test(
+s.add_test(
   "eslintrc_js",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "eqeqeq",
-        message: "Expected '===' and instead saw '=='.",
-        links: %w[https://eslint.org/docs/rules/eqeqeq],
-        path: "index.js",
-        location: { start_line: 1, start_column: 7, end_line: 1, end_column: 9 },
-        object: { severity: "error", category: "Best Practices", recommended: false },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ESLint", version: "6.8.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "eqeqeq",
+      message: "Expected '===' and instead saw '=='.",
+      links: %w[https://eslint.org/docs/rules/eqeqeq],
+      path: "index.js",
+      location: { start_line: 1, start_column: 7, end_line: 1, end_column: 9 },
+      object: { severity: "error", category: "Best Practices", recommended: false },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ESLint", version: "6.8.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "typescript",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "@typescript-eslint/no-unused-vars",
-        message: "'x' is assigned a value but never used.",
-        links: %w[
-          https://github.com/typescript-eslint/typescript-eslint/blob/v1.13.0/packages/eslint-plugin/docs/rules/no-unused-vars.md
-        ],
-        path: "index.ts",
-        location: { start_line: 1, start_column: 7, end_line: 1, end_column: 8 },
-        object: { severity: "warn", category: "Variables", recommended: "warn" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ESLint", version: "6.5.1" }
-  },
-  {
-    warnings: [
-      { message: /The required dependency `eslint` may not have been correctly installed/, file: "package.json" }
-    ]
-  }
+  type: "success",
+  issues: [
+    {
+      id: "@typescript-eslint/no-unused-vars",
+      message: "'x' is assigned a value but never used.",
+      links: %w[
+        https://github.com/typescript-eslint/typescript-eslint/blob/v1.13.0/packages/eslint-plugin/docs/rules/no-unused-vars.md
+      ],
+      path: "index.ts",
+      location: { start_line: 1, start_column: 7, end_line: 1, end_column: 8 },
+      object: { severity: "warn", category: "Variables", recommended: "warn" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ESLint", version: "6.5.1" },
+  warnings: [
+    { message: /The required dependency `eslint` may not have been correctly installed/, file: "package.json" }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "duplicate_lock_files",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "ESLint", version: "5.16.0" } },
-  { warnings: [{ message: /Two lock files `package-lock.json` and `yarn.lock` are found/, file: "yarn.lock" }] }
+  type: "success",
+  issues: [],
+  analyzer: { name: "ESLint", version: "5.16.0" },
+  warnings: [{ message: /Two lock files `package-lock.json` and `yarn.lock` are found/, file: "yarn.lock" }]
 )

--- a/test/smokes/flake8/expectations.rb
+++ b/test/smokes/flake8/expectations.rb
@@ -1,9 +1,7 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "sandbox_django",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -82,10 +80,8 @@ Smoke.add_test(
   analyzer: { name: "Flake8", version: "3.7.9" }
 )
 
-Smoke.add_test(
+s.add_test(
   "user_config_enabled",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -110,10 +106,8 @@ Smoke.add_test(
   analyzer: { name: "Flake8", version: "3.7.9" }
 )
 
-Smoke.add_test(
+s.add_test(
   "no_user_config_enabled",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [],
   analyzer: {
@@ -123,10 +117,8 @@ Smoke.add_test(
   }
 )
 
-Smoke.add_test(
+s.add_test(
   "with_plugins",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -142,10 +134,8 @@ Smoke.add_test(
   analyzer: { name: "Flake8", version: "3.7.9" }
 )
 
-Smoke.add_test(
+s.add_test(
   "with_output_options",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -188,31 +178,28 @@ Smoke.add_test(
   analyzer: { name: "Flake8", version: "3.7.9" }
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sideci_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message:
-      "The value of the attribute `$.linter.flake8.plugins` in your `sideci.yml` is invalid. Please fix and retry.",
-    analyzer: nil
-  }
+  type: "failure",
+  message:
+    "The value of the attribute `$.linter.flake8.plugins` in your `sideci.yml` is invalid. Please fix and retry.",
+  analyzer: :_
 )
 
-Smoke.add_test(
+s.add_test(
   "python2",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Flake8", version: "3.7.9" } },
-  { warnings: [{ message: "Python 2 is deprecated. Consider migrating to Python 3.", file: nil }] }
+  type: "success",
+  issues: [],
+  analyzer: { name: "Flake8", version: "3.7.9" },
+  warnings: [{ message: "Python 2 is deprecated. Consider migrating to Python 3.", file: nil }]
 )
 
-Smoke.add_test(
-  "dot_python_version",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Flake8", version: "3.7.9" } }
-)
+s.add_test("dot_python_version", type: "success", issues: [], analyzer: { name: "Flake8", version: "3.7.9" })
 
-Smoke.add_test(
+s.add_test(
   "dot_python_version_2",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Flake8", version: "3.7.9" } },
-  { warnings: [{ message: "Python 2 is deprecated. Consider migrating to Python 3.", file: nil }] }
+  type: "success",
+  issues: [],
+  analyzer: { name: "Flake8", version: "3.7.9" },
+  warnings: [{ message: "Python 2 is deprecated. Consider migrating to Python 3.", file: nil }]
 )

--- a/test/smokes/fxcop/expectations.rb
+++ b/test/smokes/fxcop/expectations.rb
@@ -1,201 +1,157 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
 # a normal case
-Smoke.add_test(
-  'success',
-  {
-    guid: 'test-guid',
-    timestamp: :_,
-    type: 'success',
-    issues: [
-      {
-        path: 'Program.cs',
-        location: { start_line: 9, start_column: 31, end_line:9, end_column:45 },
-        id: 'CA1303',
-        message: "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
-        object: {
-          severity: 'warning'
-        },
-        git_blame_info: nil,
-        links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters"]
-      },
-      {
-        path: 'Program.cs',
-        location: { start_line: 7, start_column: 35, end_line:7, end_column:39 },
-        id: 'CA1801',
-        message: 'Parameter args of method Main is never used. Remove the parameter or use it in the method body.',
-        object: {
-          severity: 'warning'
-        },
-        git_blame_info: nil,
-        links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters"]
-      }
-    ],
-    analyzer: { name: 'FxCop', version: '2.9.8' }
-  }
+s.add_test(
+  "success",
+  type: "success",
+  issues: [
+    {
+      path: "Program.cs",
+      location: { start_line: 9, start_column: 31, end_line: 9, end_column: 45 },
+      id: "CA1303",
+      message:
+        "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
+      object: { severity: "warning" },
+      git_blame_info: nil,
+      links: %w[
+        https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters
+      ]
+    },
+    {
+      path: "Program.cs",
+      location: { start_line: 7, start_column: 35, end_line: 7, end_column: 39 },
+      id: "CA1801",
+      message: "Parameter args of method Main is never used. Remove the parameter or use it in the method body.",
+      object: { severity: "warning" },
+      git_blame_info: nil,
+      links: %w[https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters]
+    }
+  ],
+  analyzer: { name: "FxCop", version: "2.9.8" }
 )
 
 # a normal case (the target repository already enable fxcop)
-Smoke.add_test(
-  'already_enable_fxcop',
-  {
-    guid: 'test-guid',
-    timestamp: :_,
-    type: 'success',
-    issues: [
-      {
-        path: 'Program.cs',
-        location: { start_line: 9, start_column: 31, end_line:9, end_column:45 },
-        id: 'CA1303',
-        message: "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
-        object: {
-          severity: 'warning'
-        },
-        git_blame_info: nil,
-        links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters"]
-      },
-      {
-        path: 'Program.cs',
-        location: { start_line: 7, start_column: 35, end_line:7, end_column:39 },
-        id: 'CA1801',
-        message: 'Parameter args of method Main is never used. Remove the parameter or use it in the method body.',
-        object: {
-          severity: 'warning'
-        },
-        git_blame_info: nil,
-        links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters"]
-      }
-    ],
-    analyzer: { name: 'FxCop', version: '2.9.8' }
-  }
+s.add_test(
+  "already_enable_fxcop",
+  type: "success",
+  issues: [
+    {
+      path: "Program.cs",
+      location: { start_line: 9, start_column: 31, end_line: 9, end_column: 45 },
+      id: "CA1303",
+      message:
+        "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
+      object: { severity: "warning" },
+      git_blame_info: nil,
+      links: %w[
+        https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters
+      ]
+    },
+    {
+      path: "Program.cs",
+      location: { start_line: 7, start_column: 35, end_line: 7, end_column: 39 },
+      id: "CA1801",
+      message: "Parameter args of method Main is never used. Remove the parameter or use it in the method body.",
+      object: { severity: "warning" },
+      git_blame_info: nil,
+      links: %w[https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters]
+    }
+  ],
+  analyzer: { name: "FxCop", version: "2.9.8" }
 )
 
 # a normal case (the target repository already enable old fxcop)
-Smoke.add_test(
-  'already_enable_oldversion_fxcop',
-  {
-    guid: 'test-guid',
-    timestamp: :_,
-    type: 'success',
-    issues: [
-      {
-        path: 'Program.cs',
-        location: { start_line: 9, start_column: 31, end_line:9, end_column:45 },
-        id: 'CA1303',
-        message: "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
-        object: {
-          severity: 'warning'
-        },
-        git_blame_info: nil,
-        links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters"]
-      },
-      {
-        path: 'Program.cs',
-        location: { start_line: 7, start_column: 35, end_line:7, end_column:39 },
-        id: 'CA1801',
-        message: 'Parameter args of method Main is never used. Remove the parameter or use it in the method body.',
-        object: {
-          severity: 'warning'
-        },
-        git_blame_info: nil,
-        links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters"]
-      }
-    ],
-    analyzer: { name: 'FxCop', version: '2.9.8' }
-  }
+s.add_test(
+  "already_enable_oldversion_fxcop",
+  type: "success",
+  issues: [
+    {
+      path: "Program.cs",
+      location: { start_line: 9, start_column: 31, end_line: 9, end_column: 45 },
+      id: "CA1303",
+      message:
+        "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
+      object: { severity: "warning" },
+      git_blame_info: nil,
+      links: %w[
+        https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters
+      ]
+    },
+    {
+      path: "Program.cs",
+      location: { start_line: 7, start_column: 35, end_line: 7, end_column: 39 },
+      id: "CA1801",
+      message: "Parameter args of method Main is never used. Remove the parameter or use it in the method body.",
+      object: { severity: "warning" },
+      git_blame_info: nil,
+      links: %w[https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters]
+    }
+  ],
+  analyzer: { name: "FxCop", version: "2.9.8" }
 )
 
 # a project have .csproj file in non analysis root
-Smoke.add_test(
-  'success_csproj_in_non_root_dir',
-  {
-    guid: 'test-guid',
-    timestamp: :_,
-    type: 'success',
-    issues: [
-      {
-        path: 'src/Program.cs',
-        location: { start_line: 9, start_column: 31, end_line:9, end_column:45 },
-        id: 'CA1303',
-        message: "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
-        object: {
-          severity: 'warning'
-        },
-        git_blame_info: nil,
-        links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters"]
-      },
-      {
-        path: 'src/Program.cs',
-        location: { start_line: 7, start_column: 35, end_line:7, end_column:39 },
-        id: 'CA1801',
-        message: 'Parameter args of method Main is never used. Remove the parameter or use it in the method body.',
-        object: {
-          severity: 'warning'
-        },
-        git_blame_info: nil,
-        links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters"]
-      }
-    ],
-    analyzer: { name: 'FxCop', version: '2.9.8' }
-  }
+s.add_test(
+  "success_csproj_in_non_root_dir",
+  type: "success",
+  issues: [
+    {
+      path: "src/Program.cs",
+      location: { start_line: 9, start_column: 31, end_line: 9, end_column: 45 },
+      id: "CA1303",
+      message:
+        "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
+      object: { severity: "warning" },
+      git_blame_info: nil,
+      links: %w[
+        https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters
+      ]
+    },
+    {
+      path: "src/Program.cs",
+      location: { start_line: 7, start_column: 35, end_line: 7, end_column: 39 },
+      id: "CA1801",
+      message: "Parameter args of method Main is never used. Remove the parameter or use it in the method body.",
+      object: { severity: "warning" },
+      git_blame_info: nil,
+      links: %w[https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters]
+    }
+  ],
+  analyzer: { name: "FxCop", version: "2.9.8" }
 )
-
 
 # a project don't have .NET Core Project file (csproj)
-Smoke.add_test(
-  'no_csproj',
-  {
-    guid: 'test-guid',
-    timestamp: :_,
-    type: 'failure',
-    message: :_,
-    analyzer: :_,
-  }
-)
+s.add_test("no_csproj", type: "failure", message: :_, analyzer: :_)
 
 # a project have invalid .NET Core Project file (csproj)
-Smoke.add_test(
-  'invalid_csproj',
-  {
-    guid: 'test-guid',
-    timestamp: :_,
-    type: 'failure',
-    message: :_,
-    analyzer: :_,
-  }
-)
+s.add_test("invalid_csproj", type: "failure", message: :_, analyzer: :_)
 
 # a project have .csproj file in non analysis root
-Smoke.add_test(
-  'success',
-  {
-    guid: 'test-guid',
-    timestamp: :_,
-    type: 'success',
-    issues: [
-      {
-        path: 'Program.cs',
-        location: { start_line: 9, start_column: 31, end_line:9, end_column:45 },
-        id: 'CA1303',
-        message: "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
-        object: {
-          severity: 'warning'
-        },
-        git_blame_info: nil,
-        links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters"]
-      },
-      {
-        path: 'Program.cs',
-        location: { start_line: 7, start_column: 35, end_line:7, end_column:39 },
-        id: 'CA1801',
-        message: 'Parameter args of method Main is never used. Remove the parameter or use it in the method body.',
-        object: {
-          severity: 'warning'
-        },
-        git_blame_info: nil,
-        links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters"]
-      }
-    ],
-    analyzer: { name: 'FxCop', version: '2.9.8' }
-  }
+s.add_test(
+  "success",
+  type: "success",
+  issues: [
+    {
+      path: "Program.cs",
+      location: { start_line: 9, start_column: 31, end_line: 9, end_column: 45 },
+      id: "CA1303",
+      message:
+        "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
+      object: { severity: "warning" },
+      git_blame_info: nil,
+      links: %w[
+        https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters
+      ]
+    },
+    {
+      path: "Program.cs",
+      location: { start_line: 7, start_column: 35, end_line: 7, end_column: 39 },
+      id: "CA1801",
+      message: "Parameter args of method Main is never used. Remove the parameter or use it in the method body.",
+      object: { severity: "warning" },
+      git_blame_info: nil,
+      links: %w[https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters]
+    }
+  ],
+  analyzer: { name: "FxCop", version: "2.9.8" }
 )

--- a/test/smokes/fxcop/expectations.rb
+++ b/test/smokes/fxcop/expectations.rb
@@ -2,156 +2,172 @@ s = Runners::Testing::Smoke
 
 # a normal case
 s.add_test(
-  "success",
-  type: "success",
+  'success',
+  type: 'success',
   issues: [
     {
-      path: "Program.cs",
-      location: { start_line: 9, start_column: 31, end_line: 9, end_column: 45 },
-      id: "CA1303",
-      message:
-        "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
-      object: { severity: "warning" },
+      path: 'Program.cs',
+      location: { start_line: 9, start_column: 31, end_line:9, end_column:45 },
+      id: 'CA1303',
+      message: "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
+      object: {
+        severity: 'warning'
+      },
       git_blame_info: nil,
-      links: %w[
-        https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters
-      ]
+      links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters"]
     },
     {
-      path: "Program.cs",
-      location: { start_line: 7, start_column: 35, end_line: 7, end_column: 39 },
-      id: "CA1801",
-      message: "Parameter args of method Main is never used. Remove the parameter or use it in the method body.",
-      object: { severity: "warning" },
+      path: 'Program.cs',
+      location: { start_line: 7, start_column: 35, end_line:7, end_column:39 },
+      id: 'CA1801',
+      message: 'Parameter args of method Main is never used. Remove the parameter or use it in the method body.',
+      object: {
+        severity: 'warning'
+      },
       git_blame_info: nil,
-      links: %w[https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters]
+      links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters"]
     }
   ],
-  analyzer: { name: "FxCop", version: "2.9.8" }
+  analyzer: { name: 'FxCop', version: '2.9.8' }
 )
 
 # a normal case (the target repository already enable fxcop)
 s.add_test(
-  "already_enable_fxcop",
-  type: "success",
+  'already_enable_fxcop',
+  type: 'success',
   issues: [
     {
-      path: "Program.cs",
-      location: { start_line: 9, start_column: 31, end_line: 9, end_column: 45 },
-      id: "CA1303",
-      message:
-        "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
-      object: { severity: "warning" },
+      path: 'Program.cs',
+      location: { start_line: 9, start_column: 31, end_line:9, end_column:45 },
+      id: 'CA1303',
+      message: "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
+      object: {
+        severity: 'warning'
+      },
       git_blame_info: nil,
-      links: %w[
-        https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters
-      ]
+      links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters"]
     },
     {
-      path: "Program.cs",
-      location: { start_line: 7, start_column: 35, end_line: 7, end_column: 39 },
-      id: "CA1801",
-      message: "Parameter args of method Main is never used. Remove the parameter or use it in the method body.",
-      object: { severity: "warning" },
+      path: 'Program.cs',
+      location: { start_line: 7, start_column: 35, end_line:7, end_column:39 },
+      id: 'CA1801',
+      message: 'Parameter args of method Main is never used. Remove the parameter or use it in the method body.',
+      object: {
+        severity: 'warning'
+      },
       git_blame_info: nil,
-      links: %w[https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters]
+      links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters"]
     }
   ],
-  analyzer: { name: "FxCop", version: "2.9.8" }
+  analyzer: { name: 'FxCop', version: '2.9.8' }
 )
 
 # a normal case (the target repository already enable old fxcop)
 s.add_test(
-  "already_enable_oldversion_fxcop",
-  type: "success",
+  'already_enable_oldversion_fxcop',
+  type: 'success',
   issues: [
     {
-      path: "Program.cs",
-      location: { start_line: 9, start_column: 31, end_line: 9, end_column: 45 },
-      id: "CA1303",
-      message:
-        "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
-      object: { severity: "warning" },
+      path: 'Program.cs',
+      location: { start_line: 9, start_column: 31, end_line:9, end_column:45 },
+      id: 'CA1303',
+      message: "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
+      object: {
+        severity: 'warning'
+      },
       git_blame_info: nil,
-      links: %w[
-        https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters
-      ]
+      links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters"]
     },
     {
-      path: "Program.cs",
-      location: { start_line: 7, start_column: 35, end_line: 7, end_column: 39 },
-      id: "CA1801",
-      message: "Parameter args of method Main is never used. Remove the parameter or use it in the method body.",
-      object: { severity: "warning" },
+      path: 'Program.cs',
+      location: { start_line: 7, start_column: 35, end_line:7, end_column:39 },
+      id: 'CA1801',
+      message: 'Parameter args of method Main is never used. Remove the parameter or use it in the method body.',
+      object: {
+        severity: 'warning'
+      },
       git_blame_info: nil,
-      links: %w[https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters]
+      links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters"]
     }
   ],
-  analyzer: { name: "FxCop", version: "2.9.8" }
+  analyzer: { name: 'FxCop', version: '2.9.8' }
 )
 
 # a project have .csproj file in non analysis root
 s.add_test(
-  "success_csproj_in_non_root_dir",
-  type: "success",
+  'success_csproj_in_non_root_dir',
+  type: 'success',
   issues: [
     {
-      path: "src/Program.cs",
-      location: { start_line: 9, start_column: 31, end_line: 9, end_column: 45 },
-      id: "CA1303",
-      message:
-        "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
-      object: { severity: "warning" },
+      path: 'src/Program.cs',
+      location: { start_line: 9, start_column: 31, end_line:9, end_column:45 },
+      id: 'CA1303',
+      message: "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
+      object: {
+        severity: 'warning'
+      },
       git_blame_info: nil,
-      links: %w[
-        https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters
-      ]
+      links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters"]
     },
     {
-      path: "src/Program.cs",
-      location: { start_line: 7, start_column: 35, end_line: 7, end_column: 39 },
-      id: "CA1801",
-      message: "Parameter args of method Main is never used. Remove the parameter or use it in the method body.",
-      object: { severity: "warning" },
+      path: 'src/Program.cs',
+      location: { start_line: 7, start_column: 35, end_line:7, end_column:39 },
+      id: 'CA1801',
+      message: 'Parameter args of method Main is never used. Remove the parameter or use it in the method body.',
+      object: {
+        severity: 'warning'
+      },
       git_blame_info: nil,
-      links: %w[https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters]
+      links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters"]
     }
   ],
-  analyzer: { name: "FxCop", version: "2.9.8" }
+  analyzer: { name: 'FxCop', version: '2.9.8' }
 )
+
 
 # a project don't have .NET Core Project file (csproj)
-s.add_test("no_csproj", type: "failure", message: :_, analyzer: :_)
+s.add_test(
+  'no_csproj',
+  type: 'failure',
+  message: :_,
+  analyzer: :_,
+)
 
 # a project have invalid .NET Core Project file (csproj)
-s.add_test("invalid_csproj", type: "failure", message: :_, analyzer: :_)
+s.add_test(
+  'invalid_csproj',
+  type: 'failure',
+  message: :_,
+  analyzer: :_,
+)
 
 # a project have .csproj file in non analysis root
 s.add_test(
-  "success",
-  type: "success",
+  'success',
+  type: 'success',
   issues: [
     {
-      path: "Program.cs",
-      location: { start_line: 9, start_column: 31, end_line: 9, end_column: 45 },
-      id: "CA1303",
-      message:
-        "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
-      object: { severity: "warning" },
+      path: 'Program.cs',
+      location: { start_line: 9, start_column: 31, end_line:9, end_column:45 },
+      id: 'CA1303',
+      message: "Method 'void Program.Main(string[] args)' passes a literal string as parameter 'value' of a call to 'void Console.WriteLine(string value)'. Retrieve the following string(s) from a resource table instead: \"Hello World!\".",
+      object: {
+        severity: 'warning'
+      },
       git_blame_info: nil,
-      links: %w[
-        https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters
-      ]
+      links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1303-do-not-pass-literals-as-localized-parameters"]
     },
     {
-      path: "Program.cs",
-      location: { start_line: 7, start_column: 35, end_line: 7, end_column: 39 },
-      id: "CA1801",
-      message: "Parameter args of method Main is never used. Remove the parameter or use it in the method body.",
-      object: { severity: "warning" },
+      path: 'Program.cs',
+      location: { start_line: 7, start_column: 35, end_line:7, end_column:39 },
+      id: 'CA1801',
+      message: 'Parameter args of method Main is never used. Remove the parameter or use it in the method body.',
+      object: {
+        severity: 'warning'
+      },
       git_blame_info: nil,
-      links: %w[https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters]
+      links: ["https://docs.microsoft.com/visualstudio/code-quality/ca1801-review-unused-parameters"]
     }
   ],
-  analyzer: { name: "FxCop", version: "2.9.8" }
+  analyzer: { name: 'FxCop', version: '2.9.8' }
 )

--- a/test/smokes/go_vet/expectations.rb
+++ b/test/smokes/go_vet/expectations.rb
@@ -1,32 +1,27 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "main.go",
-        location: { start_line: 7 },
-        id: "bc596b8e1c54fbda9055c3f53940b5df39d6c11f",
-        message: "Printf call has arguments but no formatting directives",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "go vet", version: "3.0.0" }
-  },
+  type: "success",
+  issues: [
+    {
+      path: "main.go",
+      location: { start_line: 7 },
+      id: "bc596b8e1c54fbda9055c3f53940b5df39d6c11f",
+      message: "Printf call has arguments but no formatting directives",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "go vet", version: "3.0.0" },
   warnings: [
     {
-      message: <<~MSG
+      message: <<~MSG,
         DEPRECATION WARNING!!!
         The support for go vet is deprecated. Sider will drop these versions on April 30, 2020.
         Please consider using an alternative tool GolangCI-Lint. See https://help.sider.review/tools/go/govet
       MSG
-        .strip,
       file: "sider.yml"
     }
   ]

--- a/test/smokes/go_vet/expectations.rb
+++ b/test/smokes/go_vet/expectations.rb
@@ -17,11 +17,11 @@ s.add_test(
   analyzer: { name: "go vet", version: "3.0.0" },
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The support for go vet is deprecated. Sider will drop these versions on April 30, 2020.
-        Please consider using an alternative tool GolangCI-Lint. See https://help.sider.review/tools/go/govet
-      MSG
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The support for go vet is deprecated. Sider will drop these versions on April 30, 2020.
+Please consider using an alternative tool GolangCI-Lint. See https://help.sider.review/tools/go/govet
+MSG
       file: "sider.yml"
     }
   ]

--- a/test/smokes/golangci_lint/expectations.rb
+++ b/test/smokes/golangci_lint/expectations.rb
@@ -1,438 +1,322 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "target",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "dir1/sample.go",
-        location: { start_line: 9 },
-        id: "errcheck",
-        message: "Error return value of `validate` is not checked",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "dir2/src/sample.go",
-        location: { start_line: 9 },
-        id: "errcheck",
-        message: "Error return value of `validate` is not checked",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "dir1/sample.go",
+      location: { start_line: 9 },
+      id: "errcheck",
+      message: "Error return value of `validate` is not checked",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "dir2/src/sample.go",
+      location: { start_line: 9 },
+      id: "errcheck",
+      message: "Error return value of `validate` is not checked",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "sample.go",
-        location: { start_line: 11 },
-        id: "bodyclose",
-        message: "response body must be closed",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "sample.go",
+      location: { start_line: 11 },
+      id: "bodyclose",
+      message: "response body must be closed",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
-  "no_error",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
-)
+s.add_test("no_error", type: "success", issues: [], analyzer: { name: "GolangCI-Lint", version: "1.24.0" })
 
-Smoke.add_test(
+s.add_test(
   "failure",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    # Error message will change randomly
-    message: %r{\/tmp\/.+\/sample.go:4:3: undeclared name: fmt|Running Error},
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "failure",
+  # Error message will change randomly
+  message: %r{\/tmp\/.+\/sample.go:4:3: undeclared name: fmt|Running Error},
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "no_go_file",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  },
-  { warnings: [{ message: "No Go files to analyze", file: nil }] }
+  type: "success",
+  issues: [],
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" },
+  warnings: [{ message: "No Go files to analyze", file: nil }]
 )
 
-Smoke.add_test(
+s.add_test(
   "config_sample",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "sample.go",
-        location: { start_line: 17 },
-        id: "lll",
-        message: "line is 188 characters",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "sample.go",
-        location: { start_line: 11 },
-        id: "structcheck",
-        message: "`birthDay` is unused",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "sample.go",
+      location: { start_line: 17 },
+      id: "lll",
+      message: "line is 188 characters",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "sample.go",
+      location: { start_line: 11 },
+      id: "structcheck",
+      message: "`birthDay` is unused",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "disable_option",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "sample.go",
-        location: { start_line: 8 },
-        id: "varcheck",
-        message: "`unused` is unused",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "sample.go",
+      location: { start_line: 8 },
+      id: "varcheck",
+      message: "`unused` is unused",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "enable_option",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "sample.go",
-        location: { start_line: 8 },
-        id: "misspell",
-        message: "`Amercia` is a misspelling of `America`",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "sample.go",
+      location: { start_line: 8 },
+      id: "misspell",
+      message: "`Amercia` is a misspelling of `America`",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "disable-all_option",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "sample.go",
-        location: { start_line: 8 },
-        id: "unused",
-        message: "var `unused` is unused",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "sample.go",
+      location: { start_line: 8 },
+      id: "unused",
+      message: "var `unused` is unused",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "disable_default_linter_in_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "Can't be disabled and enabled at one moment",
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "failure",
+  message: "Can't be disabled and enabled at one moment",
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "disable_only",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "Must enable at least one linter",
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "failure", message: "Must enable at least one linter", analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "enable_disable_same_linter",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "Can't be disabled and enabled at one moment",
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "failure",
+  message: "Can't be disabled and enabled at one moment",
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "duplicate_disable",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "Can't combine options --disable-all and --disable",
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "failure",
+  message: "Can't combine options --disable-all and --disable",
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "uniq-by-line",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "sample.go",
-        location: { start_line: 20 },
-        id: "gocritic:appendCombine",
-        message: "appendCombine: can combine chain of 2 appends into one",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "sample.go",
-        location: { start_line: 17 },
-        id: "gocritic:commentFormatting",
-        message: "commentFormatting: put a space between `//` and comment text",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "sample.go",
-        location: { start_line: 13 },
-        id: "gosec:G401",
-        message: "G401: Use of weak cryptographic primitive",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "sample.go",
-        location: { start_line: 4 },
-        id: "gosec:G505",
-        message: "G505: Blacklisted import `crypto/sha1`: weak cryptographic primitive",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "sample.go",
-        location: { start_line: 10 },
-        id: "gosimple:S1002",
-        message: "S1002: should omit comparison to bool constant, can be simplified to `x`",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "sample.go",
-        location: { start_line: 10 },
-        id: "staticcheck:SA9003",
-        message: "SA9003: empty branch",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "sample.go",
-        location: { start_line: 18 },
-        id: "stylecheck:ST1003",
-        message: "ST1003: should not use underscores in Go names; func redundant_append should be redundantAppend",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "sample.go",
+      location: { start_line: 20 },
+      id: "gocritic:appendCombine",
+      message: "appendCombine: can combine chain of 2 appends into one",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "sample.go",
+      location: { start_line: 17 },
+      id: "gocritic:commentFormatting",
+      message: "commentFormatting: put a space between `//` and comment text",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "sample.go",
+      location: { start_line: 13 },
+      id: "gosec:G401",
+      message: "G401: Use of weak cryptographic primitive",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "sample.go",
+      location: { start_line: 4 },
+      id: "gosec:G505",
+      message: "G505: Blacklisted import `crypto/sha1`: weak cryptographic primitive",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "sample.go",
+      location: { start_line: 10 },
+      id: "gosimple:S1002",
+      message: "S1002: should omit comparison to bool constant, can be simplified to `x`",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "sample.go",
+      location: { start_line: 10 },
+      id: "staticcheck:SA9003",
+      message: "SA9003: empty branch",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "sample.go",
+      location: { start_line: 18 },
+      id: "stylecheck:ST1003",
+      message: "ST1003: should not use underscores in Go names; func redundant_append should be redundantAppend",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
-  "tests",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
-)
+s.add_test("tests", type: "success", issues: [], analyzer: { name: "GolangCI-Lint", version: "1.24.0" })
 
-Smoke.add_test(
+s.add_test(
   "no-lint",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "sample.go",
-        location: { start_line: 8 },
-        id: "varcheck",
-        message: "`unused` is unused",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "sample.go",
+      location: { start_line: 8 },
+      id: "varcheck",
+      message: "`unused` is unused",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "presets",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "sample.go",
-        location: { start_line: 4 },
-        id: "gofmt",
-        message: "File is not `gofmt`-ed with `-s`",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "sample.go",
+      location: { start_line: 4 },
+      id: "gofmt",
+      message: "File is not `gofmt`-ed with `-s`",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "presets_validate",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "Only next presets exist: (bugs|complexity|format|performance|style|unused)",
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "failure",
+  message: "Only next presets exist: (bugs|complexity|format|performance|style|unused)",
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "no_such_linter",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "No such linter",
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "failure", message: "No such linter", analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
-  "no-config",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
-)
+s.add_test("no-config", type: "success", issues: [], analyzer: { name: "GolangCI-Lint", version: "1.24.0" })
 
-Smoke.add_test(
+s.add_test(
   "skip-dirs-use-default",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "vendor/third_party.go",
-        location: { start_line: 9 },
-        id: "errcheck",
-        message: "Error return value of `validate` is not checked",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "vendor/third_party.go",
+      location: { start_line: 9 },
+      id: "errcheck",
+      message: "Error return value of `validate` is not checked",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )
 
-Smoke.add_test(
-  "skip-files",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
-)
+s.add_test("skip-files", type: "success", issues: [], analyzer: { name: "GolangCI-Lint", version: "1.24.0" })
 
-Smoke.add_test(
+s.add_test(
   "skip-dirs",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "src/libs/sample.go",
-        location: { start_line: 9 },
-        id: "errcheck",
-        message: "Error return value of `validate` is not checked",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "src/libs/sample.go",
+      location: { start_line: 9 },
+      id: "errcheck",
+      message: "Error return value of `validate` is not checked",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "GolangCI-Lint", version: "1.24.0" }
 )

--- a/test/smokes/golint/expectations.rb
+++ b/test/smokes/golint/expectations.rb
@@ -17,11 +17,11 @@ s.add_test(
   analyzer: { name: "Golint", version: "3.0.0" },
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The support for Golint is deprecated. Sider will drop these versions on April 30, 2020.
-        Please consider using an alternative tool GolangCI-Lint. See https://help.sider.review/tools/go/golint
-      MSG
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The support for Golint is deprecated. Sider will drop these versions on April 30, 2020.
+Please consider using an alternative tool GolangCI-Lint. See https://help.sider.review/tools/go/golint
+MSG
       file: "sider.yml"
     }
   ]

--- a/test/smokes/golint/expectations.rb
+++ b/test/smokes/golint/expectations.rb
@@ -1,32 +1,27 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "main.go",
-        location: { start_line: 6 },
-        id: "edf57ab64b4d061a5cefa2b2ee80ea5de31c58d2",
-        message: "don't use underscores in Go names; var awesome_text should be awesomeText",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Golint", version: "3.0.0" }
-  },
+  type: "success",
+  issues: [
+    {
+      path: "main.go",
+      location: { start_line: 6 },
+      id: "edf57ab64b4d061a5cefa2b2ee80ea5de31c58d2",
+      message: "don't use underscores in Go names; var awesome_text should be awesomeText",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Golint", version: "3.0.0" },
   warnings: [
     {
-      message: <<~MSG
+      message: <<~MSG,
         DEPRECATION WARNING!!!
         The support for Golint is deprecated. Sider will drop these versions on April 30, 2020.
         Please consider using an alternative tool GolangCI-Lint. See https://help.sider.review/tools/go/golint
       MSG
-        .strip,
       file: "sider.yml"
     }
   ]

--- a/test/smokes/gometalinter/expectations.rb
+++ b/test/smokes/gometalinter/expectations.rb
@@ -1,143 +1,117 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [],
-    analyzer: { name: "Go Meta Linter", version: "2.0.11" }
-  },
+  type: "success",
+  issues: [],
+  analyzer: { name: "Go Meta Linter", version: "2.0.11" },
   warnings: [
     {
-      message: <<~MSG
+      message: <<~MSG,
         DEPRECATION WARNING!!!
         The support for Go Meta Linter is deprecated. Sider will drop these versions on April 30, 2020.
         Please consider using an alternative tool GolangCI-Lint. See https://github.com/alecthomas/gometalinter/issues/590
       MSG
-        .strip,
       file: "sider.yml"
     }
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "require_install",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "main.go",
-        location: { start_line: 12 },
-        id: "bc596b8e1c54fbda9055c3f53940b5df39d6c11f",
-        message: "[vet] Printf call has arguments but no formatting directives",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Go Meta Linter", version: "2.0.11" }
-  },
+  type: "success",
+  issues: [
+    {
+      path: "main.go",
+      location: { start_line: 12 },
+      id: "bc596b8e1c54fbda9055c3f53940b5df39d6c11f",
+      message: "[vet] Printf call has arguments but no formatting directives",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Go Meta Linter", version: "2.0.11" },
   warnings: [{ message: /The support for Go Meta Linter is deprecated/, file: "sideci.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "specify_config",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "[golint] const Id should be ID",
-        links: [],
-        id: "36ef88e1b6c2a396d1032b473a93606e91fda03b",
-        path: "main.go",
-        location: { start_line: 9 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "[golint] comment on exported const Id should be of the form \"Id ...\"",
-        links: [],
-        id: "5058a11cfd937cc5547f20ededd3629ff875a2ca",
-        path: "main.go",
-        location: { start_line: 8 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "[golint] comment on exported function NoDocFunc should be of the form \"NoDocFunc ...\"",
-        links: [],
-        id: "54b8e33e5e4f35fef5654c7280e6e3b24be91de0",
-        path: "main.go",
-        location: { start_line: 19 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message:
-          Regexp.new(Regexp.escape("[gotype] could not import os/exec (type-checking package \"os/exec\" failed")),
-        links: [],
-        id: "6a64372708d696ef4a6634706e74b3d9b69a813c",
-        path: "main.go",
-        location: { start_line: 5 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: Regexp.new(Regexp.escape("[gotype] could not import fmt (type-checking package \"fmt\" failed")),
-        links: [],
-        id: "873e123509f57e9ea64859ad99cf4aa3688949cb",
-        path: "main.go",
-        location: { start_line: 4 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Go Meta Linter", version: "2.0.11" }
-  },
+  type: "success",
+  issues: [
+    {
+      message: "[golint] const Id should be ID",
+      links: [],
+      id: "36ef88e1b6c2a396d1032b473a93606e91fda03b",
+      path: "main.go",
+      location: { start_line: 9 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "[golint] comment on exported const Id should be of the form \"Id ...\"",
+      links: [],
+      id: "5058a11cfd937cc5547f20ededd3629ff875a2ca",
+      path: "main.go",
+      location: { start_line: 8 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "[golint] comment on exported function NoDocFunc should be of the form \"NoDocFunc ...\"",
+      links: [],
+      id: "54b8e33e5e4f35fef5654c7280e6e3b24be91de0",
+      path: "main.go",
+      location: { start_line: 19 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: Regexp.new(Regexp.escape("[gotype] could not import os/exec (type-checking package \"os/exec\" failed")),
+      links: [],
+      id: "6a64372708d696ef4a6634706e74b3d9b69a813c",
+      path: "main.go",
+      location: { start_line: 5 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: Regexp.new(Regexp.escape("[gotype] could not import fmt (type-checking package \"fmt\" failed")),
+      links: [],
+      id: "873e123509f57e9ea64859ad99cf4aa3688949cb",
+      path: "main.go",
+      location: { start_line: 4 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Go Meta Linter", version: "2.0.11" },
   warnings: [{ message: /The support for Go Meta Linter is deprecated/, file: "sideci.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "install_path",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [],
-    analyzer: { name: "Go Meta Linter", version: "2.0.11" }
-  },
+  type: "success",
+  issues: [],
+  analyzer: { name: "Go Meta Linter", version: "2.0.11" },
   warnings: [
     { message: /The support for Go Meta Linter is deprecated/, file: "sideci.yml" },
     { message: "`install_path` option is deprecated. Use `import_path` instead.", file: "sideci.yml" }
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "import_path",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [],
-    analyzer: { name: "Go Meta Linter", version: "2.0.11" }
-  },
+  type: "success",
+  issues: [],
+  analyzer: { name: "Go Meta Linter", version: "2.0.11" },
   warnings: [{ message: /The support for Go Meta Linter is deprecated/, file: "sideci.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "import_path_and_install_path",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [],
-    analyzer: { name: "Go Meta Linter", version: "2.0.11" }
-  },
+  type: "success",
+  issues: [],
+  analyzer: { name: "Go Meta Linter", version: "2.0.11" },
   warnings: [{ message: /The support for Go Meta Linter is deprecated/, file: "sideci.yml" }]
 )

--- a/test/smokes/gometalinter/expectations.rb
+++ b/test/smokes/gometalinter/expectations.rb
@@ -7,11 +7,11 @@ s.add_test(
   analyzer: { name: "Go Meta Linter", version: "2.0.11" },
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The support for Go Meta Linter is deprecated. Sider will drop these versions on April 30, 2020.
-        Please consider using an alternative tool GolangCI-Lint. See https://github.com/alecthomas/gometalinter/issues/590
-      MSG
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The support for Go Meta Linter is deprecated. Sider will drop these versions on April 30, 2020.
+Please consider using an alternative tool GolangCI-Lint. See https://github.com/alecthomas/gometalinter/issues/590
+MSG
       file: "sider.yml"
     }
   ]

--- a/test/smokes/goodcheck/expectations.rb
+++ b/test/smokes/goodcheck/expectations.rb
@@ -41,13 +41,13 @@ s.add_test(
   analyzer: { name: "Goodcheck", version: "2.5.1" },
   warnings: [
     {
-      message: <<~MESSAGE,
-        Sider cannot find the required configuration file `goodcheck.yml`.
-        Please set up Goodcheck by following the instructions, or you can disable it in the repository settings.
+      message: <<~MESSAGE.strip,
+Sider cannot find the required configuration file `goodcheck.yml`.
+Please set up Goodcheck by following the instructions, or you can disable it in the repository settings.
 
-        - https://github.com/sider/goodcheck
-        - https://help.sider.review/tools/others/goodcheck
-      MESSAGE
+- https://github.com/sider/goodcheck
+- https://help.sider.review/tools/others/goodcheck
+MESSAGE
       file: nil
     }
   ]

--- a/test/smokes/goodcheck/expectations.rb
+++ b/test/smokes/goodcheck/expectations.rb
@@ -1,91 +1,78 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "com.goodcheck.hello",
-        path: "app/foo.rb",
-        location: { start_line: 1, start_column: 21, end_line: 1, end_column: 24 },
-        message: "foo is not a good name...",
-        links: [],
-        object: { id: "com.goodcheck.hello", message: "foo is not a good name...", justifications: [] },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Goodcheck", version: "2.5.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "com.goodcheck.hello",
+      path: "app/foo.rb",
+      location: { start_line: 1, start_column: 21, end_line: 1, end_column: 24 },
+      message: "foo is not a good name...",
+      links: [],
+      object: { id: "com.goodcheck.hello", message: "foo is not a good name...", justifications: [] },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Goodcheck", version: "2.5.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "with_ci_config",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        object: { id: "com.sample", message: "Foo", justifications: [] },
-        git_blame_info: nil,
-        message: "Foo",
-        links: [],
-        id: "com.sample",
-        path: "app/foo.rb",
-        location: { start_line: 1, start_column: 0, end_line: 1, end_column: 3 }
-      }
-    ],
-    analyzer: { name: "Goodcheck", version: "2.5.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      object: { id: "com.sample", message: "Foo", justifications: [] },
+      git_blame_info: nil,
+      message: "Foo",
+      links: [],
+      id: "com.sample",
+      path: "app/foo.rb",
+      location: { start_line: 1, start_column: 0, end_line: 1, end_column: 3 }
+    }
+  ],
+  analyzer: { name: "Goodcheck", version: "2.5.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "no_config_file",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Goodcheck", version: "2.5.1" } },
+  type: "success",
+  issues: [],
+  analyzer: { name: "Goodcheck", version: "2.5.1" },
   warnings: [
     {
-      message: <<~MESSAGE
+      message: <<~MESSAGE,
         Sider cannot find the required configuration file `goodcheck.yml`.
         Please set up Goodcheck by following the instructions, or you can disable it in the repository settings.
 
         - https://github.com/sider/goodcheck
         - https://help.sider.review/tools/others/goodcheck
       MESSAGE
-        .strip,
       file: nil
     }
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "invalid_config_file",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "Invalid config: TypeError at $.rules[0]: expected=rule, value=\"id:foo\"",
-    analyzer: { name: "Goodcheck", version: "2.5.1" }
-  }
+  type: "failure",
+  message: "Invalid config: TypeError at $.rules[0]: expected=rule, value=\"id:foo\"",
+  analyzer: { name: "Goodcheck", version: "2.5.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "with_invalid_ci_config",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message:
-      "The value of the attribute `$.linter.goodcheck.config` in your `sideci.yml` is invalid. Please fix and retry.",
-    analyzer: nil
-  }
+  type: "failure",
+  message:
+    "The value of the attribute `$.linter.goodcheck.config` in your `sideci.yml` is invalid. Please fix and retry.",
+  analyzer: :_
 )
 
-Smoke.add_test(
+s.add_test(
   "warning_config_file",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Goodcheck", version: "2.5.1" } },
+  type: "success",
+  issues: [],
+  analyzer: { name: "Goodcheck", version: "2.5.1" },
   warnings: [
     {
       message:
@@ -95,79 +82,69 @@ Smoke.add_test(
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "deprecated-options",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Goodcheck", version: "2.5.1" } },
+  type: "success",
+  issues: [],
+  analyzer: { name: "Goodcheck", version: "2.5.1" },
   warnings: [{ message: "👻 `case_insensitive` option is deprecated. Use `case_sensitive` option instead.", file: nil }]
 )
 
-Smoke.add_test(
+s.add_test(
   "lowest_deps",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "com.goodcheck.hello",
-        path: "app/foo.rb",
-        location: { start_line: 1, start_column: 21, end_line: 1, end_column: 24 },
-        message: "foo is not a good name...",
-        links: [],
-        object: { id: "com.goodcheck.hello", message: "foo is not a good name...", justifications: [] },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Goodcheck", version: "1.0.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "com.goodcheck.hello",
+      path: "app/foo.rb",
+      location: { start_line: 1, start_column: 21, end_line: 1, end_column: 24 },
+      message: "foo is not a good name...",
+      links: [],
+      object: { id: "com.goodcheck.hello", message: "foo is not a good name...", justifications: [] },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Goodcheck", version: "1.0.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "detect_there_is_no_content",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        object: { id: "smoke", message: "Specify frozen_string_literal magic comment.", justifications: [] },
-        git_blame_info: nil,
-        message: "Specify frozen_string_literal magic comment.",
-        links: [],
-        id: "smoke",
-        path: "lib/duck.rb",
-        location: nil
-      }
-    ],
-    analyzer: { name: "Goodcheck", version: "2.5.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      object: { id: "smoke", message: "Specify frozen_string_literal magic comment.", justifications: [] },
+      git_blame_info: nil,
+      message: "Specify frozen_string_literal magic comment.",
+      links: [],
+      id: "smoke",
+      path: "lib/duck.rb",
+      location: nil
+    }
+  ],
+  analyzer: { name: "Goodcheck", version: "2.5.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "rules_without_pattern",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        object: {
-          id: "com.goodcheck.without_pattern",
-          message: <<~MESSAGE
-            Check the following documentation when editing this file.
-              * https://example.com/path/to/note
-          MESSAGE
-            .strip,
-          justifications: []
-        },
-        git_blame_info: nil,
-        message: /Check the following documentation when editing this file/,
-        links: [],
+  type: "success",
+  issues: [
+    {
+      object: {
         id: "com.goodcheck.without_pattern",
-        path: "app/checks/example.rb",
-        location: nil
-      }
-    ],
-    analyzer: { name: "Goodcheck", version: "2.5.1" }
-  }
+        message:
+          "Check the following documentation when editing this file.\n" \
+            "  * https://example.com/path/to/note",
+        justifications: []
+      },
+      git_blame_info: nil,
+      message:
+        "Check the following documentation when editing this file.\n" \
+          "  * https://example.com/path/to/note",
+      links: [],
+      id: "com.goodcheck.without_pattern",
+      path: "app/checks/example.rb",
+      location: nil
+    }
+  ],
+  analyzer: { name: "Goodcheck", version: "2.5.1" }
 )

--- a/test/smokes/hadolint/expectations.rb
+++ b/test/smokes/hadolint/expectations.rb
@@ -1,9 +1,7 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "config_option",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -28,10 +26,8 @@ Smoke.add_test(
   analyzer: { name: "hadolint", version: "1.17.5" }
 )
 
-Smoke.add_test(
+s.add_test(
   "default",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -65,10 +61,8 @@ Smoke.add_test(
   analyzer: { name: "hadolint", version: "1.17.5" }
 )
 
-Smoke.add_test(
+s.add_test(
   "multi_dockerfile",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -102,65 +96,45 @@ Smoke.add_test(
   analyzer: { name: "hadolint", version: "1.17.5" }
 )
 
-Smoke.add_test(
-  "option_ignore",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "hadolint", version: "1.17.5" } }
-)
+s.add_test("option_ignore", type: "success", issues: [], analyzer: { name: "hadolint", version: "1.17.5" })
 
-Smoke.add_test(
-  "option_ignore_multi",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "hadolint", version: "1.17.5" } }
-)
+s.add_test("option_ignore_multi", type: "success", issues: [], analyzer: { name: "hadolint", version: "1.17.5" })
 
-Smoke.add_test(
+s.add_test(
   "no_dockerfile",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "No Docker files found",
-    analyzer: { name: "hadolint", version: "1.17.5" }
-  }
+  type: "failure", message: "No Docker files found", analyzer: { name: "hadolint", version: "1.17.5" }
 )
 
-Smoke.add_test(
+s.add_test(
   "trusted_registry",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "DL3026",
-        links: %w[https://github.com/hadolint/hadolint/wiki/DL3026],
-        path: "Dockerfile",
-        location: { start_line: 4 },
-        message: "Use only an allowed registry in the FROM image",
-        object: { severity: "error" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "hadolint", version: "1.17.5" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "DL3026",
+      links: %w[https://github.com/hadolint/hadolint/wiki/DL3026],
+      path: "Dockerfile",
+      location: { start_line: 4 },
+      message: "Use only an allowed registry in the FROM image",
+      object: { severity: "error" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "hadolint", version: "1.17.5" }
 )
 
-Smoke.add_test(
+s.add_test(
   "trusted_registry_multi",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "DL3026",
-        links: %w[https://github.com/hadolint/hadolint/wiki/DL3026],
-        path: "Dockerfile",
-        location: { start_line: 7 },
-        message: "Use only an allowed registry in the FROM image",
-        object: { severity: "error" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "hadolint", version: "1.17.5" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "DL3026",
+      links: %w[https://github.com/hadolint/hadolint/wiki/DL3026],
+      path: "Dockerfile",
+      location: { start_line: 7 },
+      message: "Use only an allowed registry in the FROM image",
+      object: { severity: "error" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "hadolint", version: "1.17.5" }
 )

--- a/test/smokes/haml_lint/expectations.rb
+++ b/test/smokes/haml_lint/expectations.rb
@@ -34,11 +34,11 @@ s.add_test(
   analyzer: { name: "HAML-Lint", version: "0.35.0" },
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The `$.linter.haml_lint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/haml-lint ).
-      MSG
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The `$.linter.haml_lint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/haml-lint ).
+MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/haml_lint/expectations.rb
+++ b/test/smokes/haml_lint/expectations.rb
@@ -158,7 +158,7 @@ s.add_test(
 
 s.add_test(
   "incompatible_rubocop",
-  guid: "test-guid", timestamp: :_, type: "failure", message: /Failed to install gems/, analyzer: nil
+  guid: "test-guid", timestamp: :_, type: "failure", message: /Failed to install gems/, analyzer: :_
 )
 
 # This test case, `incompatible_haml`, will be failed if updating HAML-Lint version,

--- a/test/smokes/haml_lint/expectations.rb
+++ b/test/smokes/haml_lint/expectations.rb
@@ -1,9 +1,7 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -19,44 +17,35 @@ Smoke.add_test(
   analyzer: { name: "HAML-Lint", version: "0.35.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "with-sideci.yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Avoid defining `class` in attributes hash for static class names",
-        links: %w[https://github.com/sds/haml-lint/blob/v0.35.0/lib/haml_lint/linter#classattributewithstaticvalue],
-        id: "ClassAttributeWithStaticValue",
-        path: "test.haml",
-        location: { start_line: 4 },
-        object: { severity: "warning" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "HAML-Lint", version: "0.35.0" }
-  },
-  {
-    warnings: [
-      {
-        message: <<~MSG
-    DEPRECATION WARNING!!!
-    The `$.linter.haml_lint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-    Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/haml-lint ).
-  MSG
-          .strip,
-        file: "sideci.yml"
-      }
-    ]
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Avoid defining `class` in attributes hash for static class names",
+      links: %w[https://github.com/sds/haml-lint/blob/v0.35.0/lib/haml_lint/linter#classattributewithstaticvalue],
+      id: "ClassAttributeWithStaticValue",
+      path: "test.haml",
+      location: { start_line: 4 },
+      object: { severity: "warning" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "HAML-Lint", version: "0.35.0" },
+  warnings: [
+    {
+      message: <<~MSG,
+        DEPRECATION WARNING!!!
+        The `$.linter.haml_lint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/haml-lint ).
+      MSG
+      file: "sideci.yml"
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "plain-rubocop",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -72,10 +61,8 @@ Smoke.add_test(
   analyzer: { name: "HAML-Lint", version: "0.35.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "with-inherit-gem",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -92,10 +79,8 @@ Smoke.add_test(
   analyzer: { name: "HAML-Lint", version: "0.34.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "optional_gems_are_installed_via_gemfile",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -120,52 +105,42 @@ Smoke.add_test(
   analyzer: { name: "HAML-Lint", version: "0.35.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "with_exclude_files",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "3 consecutive Ruby scripts can be merged into a single `:ruby` filter",
-        links: %w[https://github.com/sds/haml-lint/blob/v0.35.0/lib/haml_lint/linter#consecutivesilentscripts],
-        id: "ConsecutiveSilentScripts",
-        path: "hello.haml",
-        location: { start_line: 2 },
-        object: { severity: "warning" },
-        git_blame_info: nil
-      },
-      {
-        message: "Illegal nesting: content can't be both given on the same line as %span and nested within it.",
-        links: [],
-        id: "Syntax",
-        path: "test.haml",
-        location: { start_line: 3 },
-        object: { severity: "error" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "HAML-Lint", version: "0.35.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "3 consecutive Ruby scripts can be merged into a single `:ruby` filter",
+      links: %w[https://github.com/sds/haml-lint/blob/v0.35.0/lib/haml_lint/linter#consecutivesilentscripts],
+      id: "ConsecutiveSilentScripts",
+      path: "hello.haml",
+      location: { start_line: 2 },
+      object: { severity: "warning" },
+      git_blame_info: nil
+    },
+    {
+      message: "Illegal nesting: content can't be both given on the same line as %span and nested within it.",
+      links: [],
+      id: "Syntax",
+      path: "test.haml",
+      location: { start_line: 3 },
+      object: { severity: "error" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "HAML-Lint", version: "0.35.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sideci_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message:
-      "The value of the attribute `$.linter.haml_lint.config` in your `sideci.yml` is invalid. Please fix and retry.",
-    analyzer: nil
-  }
+  type: "failure",
+  message:
+    "The value of the attribute `$.linter.haml_lint.config` in your `sideci.yml` is invalid. Please fix and retry.",
+  analyzer: :_
 )
 
-Smoke.add_test(
+s.add_test(
   "lowest-deps",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -181,7 +156,7 @@ Smoke.add_test(
   analyzer: { name: "HAML-Lint", version: "0.26.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "incompatible_rubocop",
   guid: "test-guid", timestamp: :_, type: "failure", message: /Failed to install gems/, analyzer: nil
 )
@@ -189,7 +164,7 @@ Smoke.add_test(
 # This test case, `incompatible_haml`, will be failed if updating HAML-Lint version,
 # because HAML-Lint 4.1 beta support was dropped.
 # https://github.com/sds/haml-lint/releases/tag/v0.31.0
-Smoke.add_test(
+s.add_test(
   "incompatible_haml",
   guid: "test-guid",
   timestamp: :_,
@@ -210,56 +185,42 @@ Smoke.add_test(
 
 # HAML-Lint v0.33.0 has supported HAML 5.1, therefore this test case checks brand-new HAML version.
 # When HAML-Lint supports upper HAML version than 5.1, feel free to change pinned version such as `5.2`, `5.3`, ....
-Smoke.add_test(
+s.add_test(
   "pinned_haml_version",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Avoid defining `class` in attributes hash for static class names",
-        links: %w[https://github.com/sds/haml-lint/blob/v0.32.0/lib/haml_lint/linter#classattributewithstaticvalue],
-        id: "ClassAttributeWithStaticValue",
-        path: "test.haml",
-        location: { start_line: 4 },
-        object: { severity: "warning" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "HAML-Lint", version: "0.32.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Avoid defining `class` in attributes hash for static class names",
+      links: %w[https://github.com/sds/haml-lint/blob/v0.32.0/lib/haml_lint/linter#classattributewithstaticvalue],
+      id: "ClassAttributeWithStaticValue",
+      path: "test.haml",
+      location: { start_line: 4 },
+      object: { severity: "warning" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "HAML-Lint", version: "0.32.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "missing_rubocop_required_gems",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "HAML-Lint raises an unexpected error",
-    analyzer: { name: "HAML-Lint", version: "0.35.0" }
-  }
+  type: "failure", message: "HAML-Lint raises an unexpected error", analyzer: { name: "HAML-Lint", version: "0.35.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "missing_rubocop_required_gems_with_old_haml_lint",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Avoid defining `class` in attributes hash for static class names",
-        links: %w[https://github.com/sds/haml-lint/blob/v0.34.2/lib/haml_lint/linter#classattributewithstaticvalue],
-        id: "ClassAttributeWithStaticValue",
-        path: "test.haml",
-        location: { start_line: 1 },
-        object: { severity: "warning" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "HAML-Lint", version: "0.34.2" }
-  },
-  { warnings: [{ message: "cannot load such file -- rubocop-performance", file: nil }] }
+  type: "success",
+  issues: [
+    {
+      message: "Avoid defining `class` in attributes hash for static class names",
+      links: %w[https://github.com/sds/haml-lint/blob/v0.34.2/lib/haml_lint/linter#classattributewithstaticvalue],
+      id: "ClassAttributeWithStaticValue",
+      path: "test.haml",
+      location: { start_line: 1 },
+      object: { severity: "warning" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "HAML-Lint", version: "0.34.2" },
+  warnings: [{ message: "cannot load such file -- rubocop-performance", file: nil }]
 )

--- a/test/smokes/javasee/expectations.rb
+++ b/test/smokes/javasee/expectations.rb
@@ -1,88 +1,67 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "JavaSee", version: "0.1.3" },
-    issues: [
-      {
-        id: "hello",
-        path: "src/Hello.java",
-        location: { start_line: 6, start_column: 9, end_line: 6, end_column: 48 },
-        message: "Hello world\n",
-        links: [],
-        object: { id: "hello", message: "Hello world\n", justifications: [] },
-        git_blame_info: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "JavaSee", version: "0.1.3" },
+  issues: [
+    {
+      id: "hello",
+      path: "src/Hello.java",
+      location: { start_line: 6, start_column: 9, end_line: 6, end_column: 48 },
+      message: "Hello world\n",
+      links: [],
+      object: { id: "hello", message: "Hello world\n", justifications: [] },
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "config",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "JavaSee", version: :_ },
-    issues: [
-      {
-        id: "hello",
-        path: "src/Main.java",
-        location: { start_line: 6, start_column: 9, end_line: 6, end_column: 48 },
-        message: "Hello world\n",
-        links: [],
-        object: { id: "hello", message: "Hello world\n", justifications: [] },
-        git_blame_info: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "JavaSee", version: :_ },
+  issues: [
+    {
+      id: "hello",
+      path: "src/Main.java",
+      location: { start_line: 6, start_column: 9, end_line: 6, end_column: 48 },
+      message: "Hello world\n",
+      links: [],
+      object: { id: "hello", message: "Hello world\n", justifications: [] },
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "failure",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    analyzer: { name: "JavaSee", version: :_ },
-    message: /java.lang.ClassCastException: class java.lang.Integer cannot be cast/
-  }
+  type: "failure",
+  analyzer: { name: "JavaSee", version: :_ },
+  message: /java.lang.ClassCastException: class java.lang.Integer cannot be cast/
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sider_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    analyzer: nil,
-    message:
-      "The value of the attribute `$.linter.javasee.dir[2]` in your `sider.yml` is invalid. Please fix and retry."
-  }
+  type: "failure",
+  analyzer: :_,
+  message: "The value of the attribute `$.linter.javasee.dir[2]` in your `sider.yml` is invalid. Please fix and retry."
 )
 
-Smoke.add_test(
+s.add_test(
   "no_config_file",
-  { guid: "test-guid", timestamp: :_, type: "success", analyzer: { name: "JavaSee", version: :_ }, issues: [] },
-  {
-    warnings: [
-      {
-        message: <<~MSG
-          Configuration file javasee.yml does not look a file.
-          Specify configuration file by -config option.
-        MSG
-          .strip,
-        file: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "JavaSee", version: :_ },
+  issues: [],
+  warnings: [
+    {
+      message: <<~MSG,
+        Configuration file javasee.yml does not look a file.
+        Specify configuration file by -config option.
+      MSG
+      file: nil
+    }
+  ]
 )
 
-Smoke.add_test(
-  "no_linting_files",
-  { guid: "test-guid", timestamp: :_, type: "success", analyzer: { name: "JavaSee", version: :_ }, issues: [] }
-)
+s.add_test("no_linting_files", type: "success", analyzer: { name: "JavaSee", version: :_ }, issues: [])

--- a/test/smokes/javasee/expectations.rb
+++ b/test/smokes/javasee/expectations.rb
@@ -55,10 +55,9 @@ s.add_test(
   issues: [],
   warnings: [
     {
-      message: <<~MSG,
-        Configuration file javasee.yml does not look a file.
-        Specify configuration file by -config option.
-      MSG
+      message:
+        "Configuration file javasee.yml does not look a file.\n" \
+          "Specify configuration file by -config option.",
       file: nil
     }
   ]

--- a/test/smokes/jshint/expectations.rb
+++ b/test/smokes/jshint/expectations.rb
@@ -1,9 +1,7 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "sample1",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -19,10 +17,8 @@ Smoke.add_test(
   analyzer: { name: "JSHint", version: "2.11.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "es2015-code-without-config",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -56,10 +52,8 @@ Smoke.add_test(
   analyzer: { name: "JSHint", version: "2.11.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "dir",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -75,65 +69,51 @@ Smoke.add_test(
   analyzer: { name: "JSHint", version: "2.11.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sideci_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    analyzer: nil,
-    message:
-      "The value of the attribute `$.linter.jshint.config` in your `sideci.yml` is invalid. Please fix and retry."
-  }
+  type: "failure",
+  analyzer: :_,
+  message: "The value of the attribute `$.linter.jshint.config` in your `sideci.yml` is invalid. Please fix and retry."
 )
 
-Smoke.add_test(
+s.add_test(
   "with_options",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Bad invocation.",
-        links: [],
-        id: "jshint.W067",
-        path: "src/index.js",
-        location: { start_line: 3 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "JSHint", version: "2.11.0" }
-  },
-  {
-    warnings: [
-      {
-        message: <<~MSG
-    DEPRECATION WARNING!!!
-    The `$.linter.jshint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-    Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/jshint ).
-  MSG
-          .strip,
-        file: "sideci.yml"
-      }
-    ]
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Bad invocation.",
+      links: [],
+      id: "jshint.W067",
+      path: "src/index.js",
+      location: { start_line: 3 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "JSHint", version: "2.11.0" },
+  warnings: [
+    {
+      message: <<~MSG,
+        DEPRECATION WARNING!!!
+        The `$.linter.jshint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/jshint ).
+      MSG
+      file: "sideci.yml"
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_package_json",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "JSHint", version: "2.11.0" } },
-  { warnings: [{ message: /`package.json` is broken: \d+: unexpected token at/, file: "package.json" }] }
+  type: "success",
+  issues: [],
+  analyzer: { name: "JSHint", version: "2.11.0" },
+  warnings: [{ message: /`package.json` is broken: \d+: unexpected token at/, file: "package.json" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "invalid_output_xml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: 'The output XML is invalid: Illegal character "\\u0000" in raw string "Unexpected &apos;\\u0000&apos;."',
-    analyzer: { name: "JSHint", version: "2.11.0" }
-  }
+  type: "failure",
+  message: 'The output XML is invalid: Illegal character "\\u0000" in raw string "Unexpected &apos;\\u0000&apos;."',
+  analyzer: { name: "JSHint", version: "2.11.0" }
 )

--- a/test/smokes/jshint/expectations.rb
+++ b/test/smokes/jshint/expectations.rb
@@ -93,11 +93,11 @@ s.add_test(
   analyzer: { name: "JSHint", version: "2.11.0" },
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The `$.linter.jshint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/jshint ).
-      MSG
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The `$.linter.jshint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/jshint ).
+MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/ktlint/expectations.rb
+++ b/test/smokes/ktlint/expectations.rb
@@ -1,171 +1,147 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "cli",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "ktlint", version: "0.36.0" },
-    issues: [
-      {
-        id: "7c8346bd",
-        path: "src/Foo.kt",
-        location: { start_line: 1 },
-        message: "Not a valid Kotlin file (expecting a top level declaration) (cannot be auto-corrected)",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        id: "indent",
-        path: "src/App.kt",
-        location: { start_line: 8 },
-        message: "Unexpected indentation (2) (it should be 4) (cannot be auto-corrected)",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        id: "indent",
-        path: "src/App.kt",
-        location: { start_line: 9 },
-        message: "Unexpected indentation (12) (it should be 6) (cannot be auto-corrected)",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "ktlint", version: "0.36.0" },
+  issues: [
+    {
+      id: "7c8346bd",
+      path: "src/Foo.kt",
+      location: { start_line: 1 },
+      message: "Not a valid Kotlin file (expecting a top level declaration) (cannot be auto-corrected)",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      id: "indent",
+      path: "src/App.kt",
+      location: { start_line: 8 },
+      message: "Unexpected indentation (2) (it should be 4) (cannot be auto-corrected)",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      id: "indent",
+      path: "src/App.kt",
+      location: { start_line: 9 },
+      message: "Unexpected indentation (12) (it should be 6) (cannot be auto-corrected)",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "cli_with_options",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "ktlint", version: "0.36.0" },
-    issues: [
-      {
-        id: "experimental:package-name",
-        path: "src/App.kt",
-        location: { start_line: 1 },
-        message: "Package name must not contain underscore (cannot be auto-corrected)",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        id: "no-semi",
-        path: "src/App.kt",
-        location: { start_line: 6 },
-        message: "Unnecessary semicolon",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "ktlint", version: "0.36.0" },
+  issues: [
+    {
+      id: "experimental:package-name",
+      path: "src/App.kt",
+      location: { start_line: 1 },
+      message: "Package name must not contain underscore (cannot be auto-corrected)",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      id: "no-semi",
+      path: "src/App.kt",
+      location: { start_line: 6 },
+      message: "Unnecessary semicolon",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "gradle",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "ktlint", version: "0.34.0" },
-    issues: [
-      {
-        id: "0ebc0f91",
-        path: "src/main/kotlin/gradle/App.kt",
-        location: { start_line: 9 },
-        message: "Unexpected indentation (12) (it should be 6) (cannot be auto-corrected)",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        id: "5e2630c4",
-        path: "src/main/kotlin/gradle/App.kt",
-        location: { start_line: 8 },
-        message: "Unexpected indentation (2) (it should be 4) (cannot be auto-corrected)",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "ktlint", version: "0.34.0" },
+  issues: [
+    {
+      id: "0ebc0f91",
+      path: "src/main/kotlin/gradle/App.kt",
+      location: { start_line: 9 },
+      message: "Unexpected indentation (12) (it should be 6) (cannot be auto-corrected)",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      id: "5e2630c4",
+      path: "src/main/kotlin/gradle/App.kt",
+      location: { start_line: 8 },
+      message: "Unexpected indentation (2) (it should be 4) (cannot be auto-corrected)",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "gradle_ktlint-gradle-plugin",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "ktlint", version: "0.34.0" },
-    issues: [
-      {
-        id: "experimental:indent",
-        path: "src/main/kotlin/gradle/App.kt",
-        location: { start_line: 10 },
-        message: "Unexpected indentation (6) (should be 4)",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        id: "indent",
-        path: "src/main/kotlin/gradle/App.kt",
-        location: { start_line: 10 },
-        message: "Unexpected indentation (6) (it should be 8) (cannot be auto-corrected)",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "ktlint", version: "0.34.0" },
+  issues: [
+    {
+      id: "experimental:indent",
+      path: "src/main/kotlin/gradle/App.kt",
+      location: { start_line: 10 },
+      message: "Unexpected indentation (6) (should be 4)",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      id: "indent",
+      path: "src/main/kotlin/gradle/App.kt",
+      location: { start_line: 10 },
+      message: "Unexpected indentation (6) (it should be 8) (cannot be auto-corrected)",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "maven",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "ktlint", version: "0.34.0" },
-    issues: [
-      {
-        id: "indent",
-        path: "src/main/App.kt",
-        location: { start_line: 8 },
-        message: "Unexpected indentation (2) (it should be 4) (cannot be auto-corrected)",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        id: "indent",
-        path: "src/main/App.kt",
-        location: { start_line: 9 },
-        message: "Unexpected indentation (12) (it should be 6) (cannot be auto-corrected)",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "ktlint", version: "0.34.0" },
+  issues: [
+    {
+      id: "indent",
+      path: "src/main/App.kt",
+      location: { start_line: 8 },
+      message: "Unexpected indentation (2) (it should be 4) (cannot be auto-corrected)",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      id: "indent",
+      path: "src/main/App.kt",
+      location: { start_line: 9 },
+      message: "Unexpected indentation (12) (it should be 6) (cannot be auto-corrected)",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sider_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    analyzer: nil,
-    message: "The attribute `$.linter.ktlint.gradle` in your `sider.yml` is unsupported. Please fix and retry."
-  }
+  type: "failure",
+  analyzer: :_,
+  message: "The attribute `$.linter.ktlint.gradle` in your `sider.yml` is unsupported. Please fix and retry."
 )

--- a/test/smokes/languagetool/expectations.rb
+++ b/test/smokes/languagetool/expectations.rb
@@ -1,306 +1,260 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "EN_A_VS_AN",
-        path: "sample.txt",
-        location: { start_line: 3 },
-        message:
-          "Use \"a\" instead of 'an' if the following word doesn't start with a vowel sound, e.g. 'a sentence', 'a university'",
-        links: [],
-        object: {
-          sentence: "to see an few of the problems that LanguageTool can detecd.",
-          type: "misspelling",
-          category: "MISC",
-          replacements: %w[a]
-        },
-        git_blame_info: nil
+  type: "success",
+  issues: [
+    {
+      id: "EN_A_VS_AN",
+      path: "sample.txt",
+      location: { start_line: 3 },
+      message:
+        "Use \"a\" instead of 'an' if the following word doesn't start with a vowel sound, e.g. 'a sentence', 'a university'",
+      links: [],
+      object: {
+        sentence: "to see an few of the problems that LanguageTool can detecd.",
+        type: "misspelling",
+        category: "MISC",
+        replacements: %w[a]
       },
-      {
-        id: "MORFOLOGIK_RULE_EN_US",
-        path: "sample.txt",
-        location: { start_line: 3 },
-        message: "Possible spelling mistake found.",
-        links: [],
-        object: {
-          sentence: "to see an few of the problems that LanguageTool can detecd.",
-          type: "misspelling",
-          category: "TYPOS",
-          replacements: %w[detect]
-        },
-        git_blame_info: nil
+      git_blame_info: nil
+    },
+    {
+      id: "MORFOLOGIK_RULE_EN_US",
+      path: "sample.txt",
+      location: { start_line: 3 },
+      message: "Possible spelling mistake found.",
+      links: [],
+      object: {
+        sentence: "to see an few of the problems that LanguageTool can detecd.",
+        type: "misspelling",
+        category: "TYPOS",
+        replacements: %w[detect]
       },
-      {
-        id: "THE_SENT_END",
-        path: "dir/foo.txt",
-        location: { start_line: 1 },
-        message: "Did you forget something after 'a'?",
-        links: [],
-        object: { sentence: "This is a.", type: "grammar", category: "GRAMMAR", replacements: [] },
-        git_blame_info: nil
+      git_blame_info: nil
+    },
+    {
+      id: "THE_SENT_END",
+      path: "dir/foo.txt",
+      location: { start_line: 1 },
+      message: "Did you forget something after 'a'?",
+      links: [],
+      object: { sentence: "This is a.", type: "grammar", category: "GRAMMAR", replacements: [] },
+      git_blame_info: nil
+    },
+    {
+      id: "UPPERCASE_SENTENCE_START",
+      path: "sample.txt",
+      location: { start_line: 3 },
+      message: "This sentence does not start with an uppercase letter",
+      links: [],
+      object: {
+        sentence: "to see an few of the problems that LanguageTool can detecd.",
+        type: "typographical",
+        category: "CASING",
+        replacements: %w[To]
       },
-      {
-        id: "UPPERCASE_SENTENCE_START",
-        path: "sample.txt",
-        location: { start_line: 3 },
-        message: "This sentence does not start with an uppercase letter",
-        links: [],
-        object: {
-          sentence: "to see an few of the problems that LanguageTool can detecd.",
-          type: "typographical",
-          category: "CASING",
-          replacements: %w[To]
-        },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "LanguageTool", version: "4.9" }
-  }
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "LanguageTool", version: "4.9" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_language",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "DOUSI_KOTOGADEKIRU",
-        path: "sample.txt",
-        location: { start_line: 1 },
-        message: "省略が可能です。暮\"らせる\"",
-        links: [],
-        object: {
-          sentence: "これわ文章を入力して'CheckText'をクリックすると、誤記を探すことができる。",
-          type: "uncategorized",
-          category: "CAT1",
-          replacements: %w[らせる]
-        },
-        git_blame_info: nil
+  type: "success",
+  issues: [
+    {
+      id: "DOUSI_KOTOGADEKIRU",
+      path: "sample.txt",
+      location: { start_line: 1 },
+      message: "省略が可能です。暮\"らせる\"",
+      links: [],
+      object: {
+        sentence: "これわ文章を入力して'CheckText'をクリックすると、誤記を探すことができる。",
+        type: "uncategorized",
+        category: "CAT1",
+        replacements: %w[らせる]
       },
-      {
-        id: "KOREWA",
-        path: "sample.txt",
-        location: { start_line: 1 },
-        message: "文法ミスがあります。\"これは\"の間違いです。",
-        links: [],
-        object: {
-          sentence: "これわ文章を入力して'CheckText'をクリックすると、誤記を探すことができる。",
-          type: "uncategorized",
-          category: "CAT1",
-          replacements: %w[これは]
-        },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "LanguageTool", version: "4.9" }
-  }
+      git_blame_info: nil
+    },
+    {
+      id: "KOREWA",
+      path: "sample.txt",
+      location: { start_line: 1 },
+      message: "文法ミスがあります。\"これは\"の間違いです。",
+      links: [],
+      object: {
+        sentence: "これわ文章を入力して'CheckText'をクリックすると、誤記を探すことができる。",
+        type: "uncategorized",
+        category: "CAT1",
+        replacements: %w[これは]
+      },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "LanguageTool", version: "4.9" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_target",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "MORFOLOGIK_RULE_EN_US",
-        path: "dir/incorrect.txt",
-        location: { start_line: 1 },
-        message: "Possible spelling mistake found.",
-        links: [],
-        object: { sentence: "Thes is correct text.", type: "misspelling", category: "TYPOS", replacements: :_ },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "LanguageTool", version: "4.9" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "MORFOLOGIK_RULE_EN_US",
+      path: "dir/incorrect.txt",
+      location: { start_line: 1 },
+      message: "Possible spelling mistake found.",
+      links: [],
+      object: { sentence: "Thes is correct text.", type: "misspelling", category: "TYPOS", replacements: :_ },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "LanguageTool", version: "4.9" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_ext",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "EN_QUOTES",
-        path: "target.html",
-        location: { start_line: 3 },
-        message: "Use a smart closing quote here: \"”\".",
-        links: [],
-        object: {
-          sentence: "<p class=\"normal\">This is a sample <em>HTML</em> file.</p>",
-          type: "typographical",
-          category: "TYPOGRAPHY",
-          replacements: %w[”]
-        },
-        git_blame_info: nil
+  type: "success",
+  issues: [
+    {
+      id: "EN_QUOTES",
+      path: "target.html",
+      location: { start_line: 3 },
+      message: "Use a smart closing quote here: \"”\".",
+      links: [],
+      object: {
+        sentence: "<p class=\"normal\">This is a sample <em>HTML</em> file.</p>",
+        type: "typographical",
+        category: "TYPOGRAPHY",
+        replacements: %w[”]
       },
-      {
-        id: "EN_QUOTES",
-        path: "target.html",
-        location: { start_line: 3 },
-        message: "Use a smart closing quote here: \"”\".",
-        links: [],
-        object: {
-          sentence: "<p class=\"normal\">This is a sample <em>HTML</em> file.</p>",
-          type: "typographical",
-          category: "TYPOGRAPHY",
-          replacements: %w[”]
-        },
-        git_blame_info: nil
+      git_blame_info: nil
+    },
+    {
+      id: "EN_QUOTES",
+      path: "target.html",
+      location: { start_line: 3 },
+      message: "Use a smart closing quote here: \"”\".",
+      links: [],
+      object: {
+        sentence: "<p class=\"normal\">This is a sample <em>HTML</em> file.</p>",
+        type: "typographical",
+        category: "TYPOGRAPHY",
+        replacements: %w[”]
       },
-      {
-        id: "MORFOLOGIK_RULE_EN_US",
-        path: "target.md",
-        location: { start_line: 3 },
-        message: "Possible spelling mistake found.",
-        links: [],
-        object: {
-          sentence: "This is a sample [markdow](https://en.wikipedia.org/wiki/Markdown) file.",
-          type: "misspelling",
-          category: "TYPOS",
-          replacements: %w[markdown]
-        },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "LanguageTool", version: "4.9" }
-  }
+      git_blame_info: nil
+    },
+    {
+      id: "MORFOLOGIK_RULE_EN_US",
+      path: "target.md",
+      location: { start_line: 3 },
+      message: "Possible spelling mistake found.",
+      links: [],
+      object: {
+        sentence: "This is a sample [markdow](https://en.wikipedia.org/wiki/Markdown) file.",
+        type: "misspelling",
+        category: "TYPOS",
+        replacements: %w[markdown]
+      },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "LanguageTool", version: "4.9" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_exclude",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "UPPERCASE_SENTENCE_START",
-        path: "target.txt",
-        location: { start_line: 1 },
-        message: "This sentence does not start with an uppercase letter",
-        links: [],
-        object: { sentence: "this is a pen.", type: "typographical", category: "CASING", replacements: %w[This] },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "LanguageTool", version: "4.9" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "UPPERCASE_SENTENCE_START",
+      path: "target.txt",
+      location: { start_line: 1 },
+      message: "This sentence does not start with an uppercase letter",
+      links: [],
+      object: { sentence: "this is a pen.", type: "typographical", category: "CASING", replacements: %w[This] },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "LanguageTool", version: "4.9" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_encoding",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "KOREWA",
-        path: "sample.txt",
-        location: { start_line: 1 },
-        message: "文法ミスがあります。\"これは\"の間違いです。",
-        links: [],
-        object: { sentence: "これわペンです。", type: "uncategorized", category: "CAT1", replacements: %w[これは] },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "LanguageTool", version: "4.9" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "KOREWA",
+      path: "sample.txt",
+      location: { start_line: 1 },
+      message: "文法ミスがあります。\"これは\"の間違いです。",
+      links: [],
+      object: { sentence: "これわペンです。", type: "uncategorized", category: "CAT1", replacements: %w[これは] },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "LanguageTool", version: "4.9" }
 )
 
-Smoke.add_test(
-  "option_disable",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "LanguageTool", version: "4.9" } }
-)
+s.add_test("option_disable", type: "success", issues: [], analyzer: { name: "LanguageTool", version: "4.9" })
 
-Smoke.add_test(
+s.add_test(
   "option_enable",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "UPPERCASE_SENTENCE_START",
-        path: "sample.txt",
-        location: { start_line: 1 },
-        message: "This sentence does not start with an uppercase letter",
-        links: [],
-        object: { sentence: "this is a.", type: "typographical", category: "CASING", replacements: %w[This] },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "LanguageTool", version: "4.9" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "UPPERCASE_SENTENCE_START",
+      path: "sample.txt",
+      location: { start_line: 1 },
+      message: "This sentence does not start with an uppercase letter",
+      links: [],
+      object: { sentence: "this is a.", type: "typographical", category: "CASING", replacements: %w[This] },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "LanguageTool", version: "4.9" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_disablecategories",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "THE_SENT_END",
-        path: "sample.txt",
-        location: { start_line: 1 },
-        message: "Did you forget something after 'a'?",
-        links: [],
-        object: { sentence: "this is a.", type: "grammar", category: "GRAMMAR", replacements: [] },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "LanguageTool", version: "4.9" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "THE_SENT_END",
+      path: "sample.txt",
+      location: { start_line: 1 },
+      message: "Did you forget something after 'a'?",
+      links: [],
+      object: { sentence: "this is a.", type: "grammar", category: "GRAMMAR", replacements: [] },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "LanguageTool", version: "4.9" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_enablecategories",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "UPPERCASE_SENTENCE_START",
-        path: "sample.txt",
-        location: { start_line: 1 },
-        message: "This sentence does not start with an uppercase letter",
-        links: [],
-        object: { sentence: "this is a.", type: "typographical", category: "CASING", replacements: %w[This] },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "LanguageTool", version: "4.9" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "UPPERCASE_SENTENCE_START",
+      path: "sample.txt",
+      location: { start_line: 1 },
+      message: "This sentence does not start with an uppercase letter",
+      links: [],
+      object: { sentence: "this is a.", type: "typographical", category: "CASING", replacements: %w[This] },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "LanguageTool", version: "4.9" }
 )
 
-Smoke.add_test(
-  "no_files",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "LanguageTool", version: "4.9" } }
-)
+s.add_test("no_files", type: "success", issues: [], analyzer: { name: "LanguageTool", version: "4.9" })
 
-Smoke.add_test(
+s.add_test(
   "invalid_options",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "You cannot specify both disabled rules and enabledonly\nPlease check your `sider.yml`",
-    analyzer: { name: "LanguageTool", version: "4.9" }
-  }
+  type: "failure",
+  message: "You cannot specify both disabled rules and enabledonly\nPlease check your `sider.yml`",
+  analyzer: { name: "LanguageTool", version: "4.9" }
 )

--- a/test/smokes/misspell/expectations.rb
+++ b/test/smokes/misspell/expectations.rb
@@ -43,11 +43,11 @@ s.add_test(
   analyzer: { name: "Misspell", version: "0.3.4" },
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
-      MSG
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
+MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/misspell/expectations.rb
+++ b/test/smokes/misspell/expectations.rb
@@ -1,248 +1,221 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "\"infomation\" is a misspelling of \"information\"",
-        links: [],
-        id: "\"infomation\" is a misspelling of \"information\"",
-        path: "badspell.rb",
-        location: { start_line: 2, start_column: 2, end_line: 2, end_column: 12 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Misspell", version: "0.3.4" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "\"infomation\" is a misspelling of \"information\"",
+      links: [],
+      id: "\"infomation\" is a misspelling of \"information\"",
+      path: "badspell.rb",
+      location: { start_line: 2, start_column: 2, end_line: 2, end_column: 12 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Misspell", version: "0.3.4" }
 )
 
-Smoke.add_test(
+s.add_test(
   "locale",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "\"infomation\" is a misspelling of \"information\"",
-        links: [],
-        id: "\"infomation\" is a misspelling of \"information\"",
-        path: "badspell.rb",
-        location: { start_line: 4, start_column: 2, end_line: 4, end_column: 12 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "\"offense\" is a misspelling of \"offence\"",
-        links: [],
-        id: "\"offense\" is a misspelling of \"offence\"",
-        path: "badspell.rb",
-        location: { start_line: 3, start_column: 2, end_line: 3, end_column: 9 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Misspell", version: "0.3.4" }
-  },
-  {
-    warnings: [
-      {
-        message: <<~MSG
-    DEPRECATION WARNING!!!
-    The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-    Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
-  MSG
-          .strip,
-        file: "sideci.yml"
-      }
-    ]
-  }
+  type: "success",
+  issues: [
+    {
+      message: "\"infomation\" is a misspelling of \"information\"",
+      links: [],
+      id: "\"infomation\" is a misspelling of \"information\"",
+      path: "badspell.rb",
+      location: { start_line: 4, start_column: 2, end_line: 4, end_column: 12 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "\"offense\" is a misspelling of \"offence\"",
+      links: [],
+      id: "\"offense\" is a misspelling of \"offence\"",
+      path: "badspell.rb",
+      location: { start_line: 3, start_column: 2, end_line: 3, end_column: 9 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Misspell", version: "0.3.4" },
+  warnings: [
+    {
+      message: <<~MSG,
+        DEPRECATION WARNING!!!
+        The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
+      MSG
+      file: "sideci.yml"
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "ignore",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "\"recieve\" is a misspelling of \"receive\"",
-        links: [],
-        id: "\"recieve\" is a misspelling of \"receive\"",
-        path: "badspell.rb",
-        location: { start_line: 3, start_column: 2, end_line: 3, end_column: 9 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Misspell", version: "0.3.4" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "\"recieve\" is a misspelling of \"receive\"",
+      links: [],
+      id: "\"recieve\" is a misspelling of \"receive\"",
+      path: "badspell.rb",
+      location: { start_line: 3, start_column: 2, end_line: 3, end_column: 9 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Misspell", version: "0.3.4" }
 )
 
-Smoke.add_test(
+s.add_test(
   "analyze_specific_targets",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "\"acknowleges\" is a misspelling of \"acknowledges\"",
-        links: [],
-        id: "\"acknowleges\" is a misspelling of \"acknowledges\"",
-        path: "target_dir/bar.rb",
-        location: { start_line: 2, start_column: 2, end_line: 2, end_column: 13 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "\"comminucation\" is a misspelling of \"communications\"",
-        links: [],
-        id: "\"comminucation\" is a misspelling of \"communications\"",
-        path: "target_dir/foo.rb",
-        location: { start_line: 3, start_column: 2, end_line: 3, end_column: 15 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "\"comminucation\" is a misspelling of \"communications\"",
-        links: [],
-        id: "\"comminucation\" is a misspelling of \"communications\"",
-        path: "target_file.rb",
-        location: { start_line: 3, start_column: 2, end_line: 3, end_column: 15 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "\"infomation\" is a misspelling of \"information\"",
-        links: [],
-        id: "\"infomation\" is a misspelling of \"information\"",
-        path: "target_dir/bar.rb",
-        location: { start_line: 3, start_column: 2, end_line: 3, end_column: 12 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "\"recieve\" is a misspelling of \"receive\"",
-        links: [],
-        id: "\"recieve\" is a misspelling of \"receive\"",
-        path: "target_dir/foo.rb",
-        location: { start_line: 2, start_column: 2, end_line: 2, end_column: 9 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "\"recieve\" is a misspelling of \"receive\"",
-        links: [],
-        id: "\"recieve\" is a misspelling of \"receive\"",
-        path: "target_file.rb",
-        location: { start_line: 2, start_column: 2, end_line: 2, end_column: 9 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Misspell", version: "0.3.4" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "\"acknowleges\" is a misspelling of \"acknowledges\"",
+      links: [],
+      id: "\"acknowleges\" is a misspelling of \"acknowledges\"",
+      path: "target_dir/bar.rb",
+      location: { start_line: 2, start_column: 2, end_line: 2, end_column: 13 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "\"comminucation\" is a misspelling of \"communications\"",
+      links: [],
+      id: "\"comminucation\" is a misspelling of \"communications\"",
+      path: "target_dir/foo.rb",
+      location: { start_line: 3, start_column: 2, end_line: 3, end_column: 15 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "\"comminucation\" is a misspelling of \"communications\"",
+      links: [],
+      id: "\"comminucation\" is a misspelling of \"communications\"",
+      path: "target_file.rb",
+      location: { start_line: 3, start_column: 2, end_line: 3, end_column: 15 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "\"infomation\" is a misspelling of \"information\"",
+      links: [],
+      id: "\"infomation\" is a misspelling of \"information\"",
+      path: "target_dir/bar.rb",
+      location: { start_line: 3, start_column: 2, end_line: 3, end_column: 12 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "\"recieve\" is a misspelling of \"receive\"",
+      links: [],
+      id: "\"recieve\" is a misspelling of \"receive\"",
+      path: "target_dir/foo.rb",
+      location: { start_line: 2, start_column: 2, end_line: 2, end_column: 9 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "\"recieve\" is a misspelling of \"receive\"",
+      links: [],
+      id: "\"recieve\" is a misspelling of \"receive\"",
+      path: "target_file.rb",
+      location: { start_line: 2, start_column: 2, end_line: 2, end_column: 9 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Misspell", version: "0.3.4" }
 )
 
-Smoke.add_test(
+s.add_test(
   "exclude_targets",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "\"acknowleges\" is a misspelling of \"acknowledges\"",
-        links: [],
-        id: "\"acknowleges\" is a misspelling of \"acknowledges\"",
-        path: "target.rb",
-        location: { start_line: 2, start_column: 2, end_line: 2, end_column: 13 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "\"communiaction\" is a misspelling of \"communications\"",
-        links: [],
-        id: "\"communiaction\" is a misspelling of \"communications\"",
-        path: "partial_exclude_dir/target.html",
-        location: { start_line: 1, start_column: 5, end_line: 1, end_column: 18 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "\"internelized\" is a misspelling of \"internalized\"",
-        links: [],
-        id: "\"internelized\" is a misspelling of \"internalized\"",
-        path: "partial_exclude_dir/bar_dir/target.html",
-        location: { start_line: 1, start_column: 4, end_line: 1, end_column: 16 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "\"optimizacion\" is a misspelling of \"optimization\"",
-        links: [],
-        id: "\"optimizacion\" is a misspelling of \"optimization\"",
-        path: "partial_exclude_dir/bar_dir/target.js",
-        location: { start_line: 1, start_column: 9, end_line: 1, end_column: 21 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "\"profissional\" is a misspelling of \"professional\"",
-        links: [],
-        id: "\"profissional\" is a misspelling of \"professional\"",
-        path: "foo_dir/target.rb",
-        location: { start_line: 2, start_column: 2, end_line: 2, end_column: 14 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "\"requeriments\" is a misspelling of \"requirements\"",
-        links: [],
-        id: "\"requeriments\" is a misspelling of \"requirements\"",
-        path: "foo_dir/another_dir/target.html",
-        location: { start_line: 1, start_column: 4, end_line: 1, end_column: 16 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "\"scholarhsips\" is a misspelling of \"scholarships\"",
-        links: [],
-        id: "\"scholarhsips\" is a misspelling of \"scholarships\"",
-        path: "foo_dir/another_dir/target.rb",
-        location: { start_line: 2, start_column: 2, end_line: 2, end_column: 14 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "\"trasnmission\" is a misspelling of \"transmissions\"",
-        links: [],
-        id: "\"trasnmission\" is a misspelling of \"transmissions\"",
-        path: "partial_exclude_dir/foo_dir/target.py",
-        location: { start_line: 2, start_column: 4, end_line: 2, end_column: 16 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Misspell", version: "0.3.4" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "\"acknowleges\" is a misspelling of \"acknowledges\"",
+      links: [],
+      id: "\"acknowleges\" is a misspelling of \"acknowledges\"",
+      path: "target.rb",
+      location: { start_line: 2, start_column: 2, end_line: 2, end_column: 13 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "\"communiaction\" is a misspelling of \"communications\"",
+      links: [],
+      id: "\"communiaction\" is a misspelling of \"communications\"",
+      path: "partial_exclude_dir/target.html",
+      location: { start_line: 1, start_column: 5, end_line: 1, end_column: 18 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "\"internelized\" is a misspelling of \"internalized\"",
+      links: [],
+      id: "\"internelized\" is a misspelling of \"internalized\"",
+      path: "partial_exclude_dir/bar_dir/target.html",
+      location: { start_line: 1, start_column: 4, end_line: 1, end_column: 16 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "\"optimizacion\" is a misspelling of \"optimization\"",
+      links: [],
+      id: "\"optimizacion\" is a misspelling of \"optimization\"",
+      path: "partial_exclude_dir/bar_dir/target.js",
+      location: { start_line: 1, start_column: 9, end_line: 1, end_column: 21 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "\"profissional\" is a misspelling of \"professional\"",
+      links: [],
+      id: "\"profissional\" is a misspelling of \"professional\"",
+      path: "foo_dir/target.rb",
+      location: { start_line: 2, start_column: 2, end_line: 2, end_column: 14 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "\"requeriments\" is a misspelling of \"requirements\"",
+      links: [],
+      id: "\"requeriments\" is a misspelling of \"requirements\"",
+      path: "foo_dir/another_dir/target.html",
+      location: { start_line: 1, start_column: 4, end_line: 1, end_column: 16 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "\"scholarhsips\" is a misspelling of \"scholarships\"",
+      links: [],
+      id: "\"scholarhsips\" is a misspelling of \"scholarships\"",
+      path: "foo_dir/another_dir/target.rb",
+      location: { start_line: 2, start_column: 2, end_line: 2, end_column: 14 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "\"trasnmission\" is a misspelling of \"transmissions\"",
+      links: [],
+      id: "\"trasnmission\" is a misspelling of \"transmissions\"",
+      path: "partial_exclude_dir/foo_dir/target.py",
+      location: { start_line: 2, start_column: 4, end_line: 2, end_column: 16 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Misspell", version: "0.3.4" }
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sideci_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message:
-      "The value of the attribute `$.linter.misspell.locale` in your `sideci.yml` is invalid. Please fix and retry.",
-    analyzer: nil
-  }
+  type: "failure",
+  message:
+    "The value of the attribute `$.linter.misspell.locale` in your `sideci.yml` is invalid. Please fix and retry.",
+  analyzer: :_
 )

--- a/test/smokes/phinder/expectations.rb
+++ b/test/smokes/phinder/expectations.rb
@@ -1,197 +1,169 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "basic",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
+  type: "success",
+  issues: [
+    {
+      id: "sample.in_array_without_3rd_param",
+      path: "index.php",
+      location: { start_line: 2, start_column: 5, end_line: 2, end_column: 34 },
+      message: "Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.",
+      links: [],
+      object: {
         id: "sample.in_array_without_3rd_param",
-        path: "index.php",
-        location: { start_line: 2, start_column: 5, end_line: 2, end_column: 34 },
         message: "Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.",
-        links: [],
-        object: {
-          id: "sample.in_array_without_3rd_param",
-          message: "Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.",
-          justifications: []
-        },
-        git_blame_info: nil
+        justifications: []
       },
-      {
-        id: "sample.var_dump",
-        path: "index.php",
-        location: { start_line: 3, start_column: 5, end_line: 3, end_column: 21 },
-        message: "Do not use var_dump.",
-        links: [],
-        object: { id: "sample.var_dump", message: "Do not use var_dump.", justifications: ["Allowed when debugging"] },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Phinder", version: "0.9.2" }
-  }
+      git_blame_info: nil
+    },
+    {
+      id: "sample.var_dump",
+      path: "index.php",
+      location: { start_line: 3, start_column: 5, end_line: 3, end_column: 21 },
+      message: "Do not use var_dump.",
+      links: [],
+      object: { id: "sample.var_dump", message: "Do not use var_dump.", justifications: ["Allowed when debugging"] },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Phinder", version: "0.9.2" }
 )
 
-Smoke.add_test(
+s.add_test(
   "options",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
+  type: "success",
+  issues: [
+    {
+      id: "sample.in_array_without_3rd_param",
+      path: "src/index.php",
+      location: { start_line: 2, start_column: 5, end_line: 2, end_column: 33 },
+      message: "Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.",
+      links: [],
+      object: {
         id: "sample.in_array_without_3rd_param",
-        path: "src/index.php",
-        location: { start_line: 2, start_column: 5, end_line: 2, end_column: 33 },
         message: "Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.",
-        links: [],
-        object: {
-          id: "sample.in_array_without_3rd_param",
-          message: "Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.",
-          justifications: []
-        },
-        git_blame_info: nil
+        justifications: []
       },
-      {
-        id: "sample.var_dump",
-        path: "src/index.php",
-        location: { start_line: 3, start_column: 5, end_line: 3, end_column: 21 },
-        message: "Do not use var_dump.",
-        links: [],
-        object: { id: "sample.var_dump", message: "Do not use var_dump.", justifications: [] },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Phinder", version: "0.9.2" }
-  }
+      git_blame_info: nil
+    },
+    {
+      id: "sample.var_dump",
+      path: "src/index.php",
+      location: { start_line: 3, start_column: 5, end_line: 3, end_column: 21 },
+      message: "Do not use var_dump.",
+      links: [],
+      object: { id: "sample.var_dump", message: "Do not use var_dump.", justifications: [] },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Phinder", version: "0.9.2" }
 )
 
-Smoke.add_test(
+s.add_test(
   "test_failed",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
+  type: "success",
+  issues: [
+    {
+      id: "sample.in_array_without_3rd_param",
+      path: "index.php",
+      location: { start_line: 2, start_column: 5, end_line: 2, end_column: 33 },
+      message: "Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.",
+      links: [],
+      object: {
         id: "sample.in_array_without_3rd_param",
-        path: "index.php",
-        location: { start_line: 2, start_column: 5, end_line: 2, end_column: 33 },
         message: "Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.",
-        links: [],
-        object: {
-          id: "sample.in_array_without_3rd_param",
-          message: "Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.",
-          justifications: []
-        },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Phinder", version: "0.9.2" }
-  },
+        justifications: []
+      },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Phinder", version: "0.9.2" },
   warnings: [
     {
-      message: <<~MESSAGE
+      message: <<~MESSAGE,
         Phinder configuration validation failed.
         Check the following output by `phinder test` command.
 
         `in_array(2, $arr, false)` does not match the rule sample.in_array_without_3rd_param but should match that rule.
         `in_array(4, $arr)` matches the rule sample.in_array_without_3rd_param but should not match that rule.
       MESSAGE
-        .strip,
       file: "phinder.yml"
     }
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "analyzer_failed",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: <<~MESSAGE,
-      1 error occurred:
+  type: "failure",
+  message: <<~MESSAGE
+    1 error occurred:
 
-      InvalidRule: Invalid id value found in 1st rule in phinder.yml
-    MESSAGE
-    analyzer: { name: "Phinder", version: "0.9.2" }
-  }
+    InvalidRule: Invalid id value found in 1st rule in phinder.yml
+  MESSAGE,
+  analyzer: { name: "Phinder", version: "0.9.2" }
 )
 
-Smoke.add_test(
+s.add_test(
   "invalid_runner_config",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "The attribute `$.linter.phinder.format` in your `sideci.yml` is unsupported. Please fix and retry.",
-    analyzer: nil
-  }
+  type: "failure",
+  message: "The attribute `$.linter.phinder.format` in your `sideci.yml` is unsupported. Please fix and retry.",
+  analyzer: :_
 )
 
-Smoke.add_test(
+s.add_test(
   "ctp_file",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        object: {
-          id: "sample.in_array_without_3rd_param",
-          message: "Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.",
-          justifications: []
-        },
-        git_blame_info: nil,
-        message: "Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.",
-        links: [],
+  type: "success",
+  issues: [
+    {
+      object: {
         id: "sample.in_array_without_3rd_param",
-        path: "view.ctp",
-        location: { start_line: 3, start_column: 9, end_line: 3, end_column: 38 }
-      }
-    ],
-    analyzer: { name: "Phinder", version: "0.9.2" }
-  }
+        message: "Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.",
+        justifications: []
+      },
+      git_blame_info: nil,
+      message: "Specify 3rd parameter explicitly when calling in_array to avoid unexpected comparison results.",
+      links: [],
+      id: "sample.in_array_without_3rd_param",
+      path: "view.ctp",
+      location: { start_line: 3, start_column: 9, end_line: 3, end_column: 38 }
+    }
+  ],
+  analyzer: { name: "Phinder", version: "0.9.2" }
 )
 
-Smoke.add_test(
+s.add_test(
   "config_not_found",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Phinder", version: "0.9.2" } },
+  type: "success",
+  issues: [],
+  analyzer: { name: "Phinder", version: "0.9.2" },
   warnings: [
     {
-      message: <<~MESSAGE
+      message: <<~MESSAGE,
         Sider cannot find the required configuration file(s): `phinder.yml`.
         Please set up Phinder by following the instructions, or you can disable it in the repository settings.
 
         - https://github.com/sider/phinder
         - https://help.sider.review/tools/php/phinder
       MESSAGE
-        .strip,
       file: "phinder.yml"
     }
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "rule_option_as_config_file",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "no_var_dump",
-        path: "index.php",
-        location: { start_line: 2, start_column: 1, end_line: 2, end_column: 17 },
-        message: "Do not use `var_dump`",
-        links: [],
-        object: { id: "no_var_dump", message: "Do not use `var_dump`", justifications: [] },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Phinder", version: "0.9.2" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "no_var_dump",
+      path: "index.php",
+      location: { start_line: 2, start_column: 1, end_line: 2, end_column: 17 },
+      message: "Do not use `var_dump`",
+      links: [],
+      object: { id: "no_var_dump", message: "Do not use `var_dump`", justifications: [] },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Phinder", version: "0.9.2" }
 )

--- a/test/smokes/phinder/expectations.rb
+++ b/test/smokes/phinder/expectations.rb
@@ -96,11 +96,11 @@ s.add_test(
 s.add_test(
   "analyzer_failed",
   type: "failure",
-  message: <<~MESSAGE
+  message: <<~MESSAGE,
     1 error occurred:
 
     InvalidRule: Invalid id value found in 1st rule in phinder.yml
-  MESSAGE,
+  MESSAGE
   analyzer: { name: "Phinder", version: "0.9.2" }
 )
 

--- a/test/smokes/phinder/expectations.rb
+++ b/test/smokes/phinder/expectations.rb
@@ -81,13 +81,13 @@ s.add_test(
   analyzer: { name: "Phinder", version: "0.9.2" },
   warnings: [
     {
-      message: <<~MESSAGE,
-        Phinder configuration validation failed.
-        Check the following output by `phinder test` command.
+      message: <<~MESSAGE.strip,
+Phinder configuration validation failed.
+Check the following output by `phinder test` command.
 
-        `in_array(2, $arr, false)` does not match the rule sample.in_array_without_3rd_param but should match that rule.
-        `in_array(4, $arr)` matches the rule sample.in_array_without_3rd_param but should not match that rule.
-      MESSAGE
+`in_array(2, $arr, false)` does not match the rule sample.in_array_without_3rd_param but should match that rule.
+`in_array(4, $arr)` matches the rule sample.in_array_without_3rd_param but should not match that rule.
+MESSAGE
       file: "phinder.yml"
     }
   ]
@@ -97,10 +97,10 @@ s.add_test(
   "analyzer_failed",
   type: "failure",
   message: <<~MESSAGE,
-    1 error occurred:
+1 error occurred:
 
-    InvalidRule: Invalid id value found in 1st rule in phinder.yml
-  MESSAGE
+InvalidRule: Invalid id value found in 1st rule in phinder.yml
+MESSAGE
   analyzer: { name: "Phinder", version: "0.9.2" }
 )
 
@@ -139,13 +139,13 @@ s.add_test(
   analyzer: { name: "Phinder", version: "0.9.2" },
   warnings: [
     {
-      message: <<~MESSAGE,
-        Sider cannot find the required configuration file(s): `phinder.yml`.
-        Please set up Phinder by following the instructions, or you can disable it in the repository settings.
+      message: <<~MESSAGE.strip,
+Sider cannot find the required configuration file(s): `phinder.yml`.
+Please set up Phinder by following the instructions, or you can disable it in the repository settings.
 
-        - https://github.com/sider/phinder
-        - https://help.sider.review/tools/php/phinder
-      MESSAGE
+- https://github.com/sider/phinder
+- https://help.sider.review/tools/php/phinder
+MESSAGE
       file: "phinder.yml"
     }
   ]

--- a/test/smokes/phpmd/expectations.rb
+++ b/test/smokes/phpmd/expectations.rb
@@ -1,206 +1,160 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "app.php",
-        location: { start_line: 5, end_line: 5 },
-        id: "UnusedLocalVariable",
-        message: "Avoid unused local variables such as '$hoge'.",
-        links: %w[https://phpmd.org/rules/unusedcode.html#unusedlocalvariable],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHPMD", version: "2.8.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "app.php",
+      location: { start_line: 5, end_line: 5 },
+      id: "UnusedLocalVariable",
+      message: "Avoid unused local variables such as '$hoge'.",
+      links: %w[https://phpmd.org/rules/unusedcode.html#unusedlocalvariable],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHPMD", version: "2.8.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "invalid_rule",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "Invalid rule: \"invalid_rule\"",
-    analyzer: { name: "PHPMD", version: "2.8.1" }
-  }
+  type: "failure", message: "Invalid rule: \"invalid_rule\"", analyzer: { name: "PHPMD", version: "2.8.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "valid_options",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "app/index.php",
-        location: { start_line: 23, end_line: 23 },
-        id: "BooleanArgumentFlag",
-        message:
-          "The method bar has a boolean flag argument $flag, which is a certain sign of a Single Responsibility Principle violation.",
-        links: %w[https://phpmd.org/rules/cleancode.html#booleanargumentflag],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "app/index.php",
-        location: { start_line: 20, end_line: 20 },
-        id: "UnusedLocalVariable",
-        message: "Avoid unused local variables such as '$hoge'.",
-        links: %w[https://phpmd.org/rules/unusedcode.html#unusedlocalvariable],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "foo.phtml",
-        location: { start_line: 5, end_line: 5 },
-        id: "UnusedLocalVariable",
-        message: "Avoid unused local variables such as '$var'.",
-        links: %w[https://phpmd.org/rules/unusedcode.html#unusedlocalvariable],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHPMD", version: "2.8.1" }
-  },
-  {
-    warnings: [
-      {
-        message: <<~MSG
-          DEPRECATION WARNING!!!
-          The `$.linter.phpmd.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-          Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/php/phpmd ).
-        MSG
-          .strip,
-        file: "sideci.yml"
-      }
-    ]
-  }
+  type: "success",
+  issues: [
+    {
+      path: "app/index.php",
+      location: { start_line: 23, end_line: 23 },
+      id: "BooleanArgumentFlag",
+      message:
+        "The method bar has a boolean flag argument $flag, which is a certain sign of a Single Responsibility Principle violation.",
+      links: %w[https://phpmd.org/rules/cleancode.html#booleanargumentflag],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "app/index.php",
+      location: { start_line: 20, end_line: 20 },
+      id: "UnusedLocalVariable",
+      message: "Avoid unused local variables such as '$hoge'.",
+      links: %w[https://phpmd.org/rules/unusedcode.html#unusedlocalvariable],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "foo.phtml",
+      location: { start_line: 5, end_line: 5 },
+      id: "UnusedLocalVariable",
+      message: "Avoid unused local variables such as '$var'.",
+      links: %w[https://phpmd.org/rules/unusedcode.html#unusedlocalvariable],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHPMD", version: "2.8.1" },
+  warnings: [
+    {
+      message: <<~MSG,
+        DEPRECATION WARNING!!!
+        The `$.linter.phpmd.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/php/phpmd ).
+      MSG
+      file: "sideci.yml"
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "syntax_error",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: /Unexpected end of token stream in file:/,
-    analyzer: { name: "PHPMD", version: "2.8.1" }
-  }
+  type: "failure", message: /Unexpected end of token stream in file:/, analyzer: { name: "PHPMD", version: "2.8.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "php_7.1",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "SomeClass.php",
-        location: { start_line: 11, end_line: 11 },
-        id: "UnusedPrivateField",
-        message: "Avoid unused private fields such as '$unusedVariable'.",
-        links: %w[https://phpmd.org/rules/unusedcode.html#unusedprivatefield],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHPMD", version: "2.8.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "SomeClass.php",
+      location: { start_line: 11, end_line: 11 },
+      id: "UnusedPrivateField",
+      message: "Avoid unused private fields such as '$unusedVariable'.",
+      links: %w[https://phpmd.org/rules/unusedcode.html#unusedprivatefield],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHPMD", version: "2.8.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "php_7.3",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "app.php",
-        location: { start_line: 7, end_line: 7 },
-        id: "UnusedLocalVariable",
-        message: "Avoid unused local variables such as '$hoge'.",
-        links: %w[https://phpmd.org/rules/unusedcode.html#unusedlocalvariable],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHPMD", version: "2.8.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "app.php",
+      location: { start_line: 7, end_line: 7 },
+      id: "UnusedLocalVariable",
+      message: "Avoid unused local variables such as '$hoge'.",
+      links: %w[https://phpmd.org/rules/unusedcode.html#unusedlocalvariable],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHPMD", version: "2.8.1" }
 )
 
-Smoke.add_test(
-  "with_php_version",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "PHPMD", version: "2.8.1" } }
-)
+s.add_test("with_php_version", type: "success", issues: [], analyzer: { name: "PHPMD", version: "2.8.1" })
 
-Smoke.add_test(
+s.add_test(
   "broken_sideci_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message:
-      "The value of the attribute `$.linter.phpmd.minimumpriority` in your `sideci.yml` is invalid. Please fix and retry.",
-    analyzer: nil
-  }
+  type: "failure",
+  message:
+    "The value of the attribute `$.linter.phpmd.minimumpriority` in your `sideci.yml` is invalid. Please fix and retry.",
+  analyzer: :_
 )
 
-Smoke.add_test(
+s.add_test(
   "custom_rule",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "foo.php",
-        location: { start_line: 3, end_line: 5 },
-        id: "NoFunctions",
-        message: "Please do not use functions.",
-        links: %w[https://example.com/phpmd/rules/no-functions],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "Custom_NoFunctions.php",
-        location: { start_line: 6, end_line: 9 },
-        id: "NoMethods",
-        message: "Please do not use methods.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "custom/rules/NoMethods.php",
-        location: { start_line: 8, end_line: 11 },
-        id: "NoMethods",
-        message: "Please do not use methods.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "PHPMD", version: "2.8.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "foo.php",
+      location: { start_line: 3, end_line: 5 },
+      id: "NoFunctions",
+      message: "Please do not use functions.",
+      links: %w[https://example.com/phpmd/rules/no-functions],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "Custom_NoFunctions.php",
+      location: { start_line: 6, end_line: 9 },
+      id: "NoMethods",
+      message: "Please do not use methods.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "custom/rules/NoMethods.php",
+      location: { start_line: 8, end_line: 11 },
+      id: "NoMethods",
+      message: "Please do not use methods.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHPMD", version: "2.8.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "invalid_output_xml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "Invalid XML was output. See the log for details.",
-    analyzer: { name: "PHPMD", version: "2.8.1" }
-  }
+  type: "failure",
+  message: "Invalid XML was output. See the log for details.",
+  analyzer: { name: "PHPMD", version: "2.8.1" }
 )

--- a/test/smokes/phpmd/expectations.rb
+++ b/test/smokes/phpmd/expectations.rb
@@ -58,11 +58,11 @@ s.add_test(
   analyzer: { name: "PHPMD", version: "2.8.1" },
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The `$.linter.phpmd.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/php/phpmd ).
-      MSG
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The `$.linter.phpmd.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/php/phpmd ).
+MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/pmd_java/expectations.rb
+++ b/test/smokes/pmd_java/expectations.rb
@@ -1,92 +1,84 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "PMD Java", version: "6.21.0" },
-    issues: [
-      {
-        message: "Do not add empty strings",
-        links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_performance.html#addemptystring],
-        id: "AddEmptyString",
-        path: "src/Hello.java",
-        location: { start_line: 17, start_column: 16, end_line: 17, end_column: 17 },
-        object: { ruleset: "Performance", priority: "3" },
-        git_blame_info: nil
-      },
-      {
-        message: "Avoid calling finalize() explicitly",
-        links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_errorprone.html#avoidcallingfinalize],
-        id: "AvoidCallingFinalize",
-        path: "src/Hello.java",
-        location: { start_line: 16, start_column: 9, end_line: 16, end_column: 16 },
-        object: { ruleset: "Error Prone", priority: "3" },
-        git_blame_info: nil
-      },
-      {
-        message: "Use block level rather than method level synchronization",
-        links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_multithreading.html#avoidsynchronizedatmethodlevel],
-        id: "AvoidSynchronizedAtMethodLevel",
-        path: "src/Hello.java",
-        location: { start_line: 20, start_column: 18, end_line: 20, end_column: 29 },
-        object: { ruleset: "Multithreading", priority: "3" },
-        git_blame_info: nil
-      },
-      {
-        message: "Exceptions should not extend java.lang.Error",
-        links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_design.html#donotextendjavalangerror],
-        id: "DoNotExtendJavaLangError",
-        path: "src/Hello.java",
-        location: { start_line: 22, start_column: 23, end_line: 22, end_column: 37 },
-        object: { ruleset: "Design", priority: "3" },
-        git_blame_info: nil
-      },
-      {
-        message: "Do not use hard coded encryption keys",
-        links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_security.html#hardcodedcryptokey],
-        id: "HardCodedCryptoKey",
-        path: "src/Hello.java",
-        location: { start_line: 12, start_column: 27, end_line: 12, end_column: 42 },
-        object: { ruleset: "Security", priority: "3" },
-        git_blame_info: nil
-      },
-      {
-        message: "System.out.println is used",
-        links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_bestpractices.html#systemprintln],
-        id: "SystemPrintln",
-        path: "src/Hello.java",
-        location: { start_line: 8, start_column: 9, end_line: 8, end_column: 26 },
-        object: { ruleset: "Best Practices", priority: "2" },
-        git_blame_info: nil
-      }
-    ]
-  },
+  type: "success",
+  analyzer: { name: "PMD Java", version: "6.21.0" },
+  issues: [
+    {
+      message: "Do not add empty strings",
+      links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_performance.html#addemptystring],
+      id: "AddEmptyString",
+      path: "src/Hello.java",
+      location: { start_line: 17, start_column: 16, end_line: 17, end_column: 17 },
+      object: { ruleset: "Performance", priority: "3" },
+      git_blame_info: nil
+    },
+    {
+      message: "Avoid calling finalize() explicitly",
+      links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_errorprone.html#avoidcallingfinalize],
+      id: "AvoidCallingFinalize",
+      path: "src/Hello.java",
+      location: { start_line: 16, start_column: 9, end_line: 16, end_column: 16 },
+      object: { ruleset: "Error Prone", priority: "3" },
+      git_blame_info: nil
+    },
+    {
+      message: "Use block level rather than method level synchronization",
+      links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_multithreading.html#avoidsynchronizedatmethodlevel],
+      id: "AvoidSynchronizedAtMethodLevel",
+      path: "src/Hello.java",
+      location: { start_line: 20, start_column: 18, end_line: 20, end_column: 29 },
+      object: { ruleset: "Multithreading", priority: "3" },
+      git_blame_info: nil
+    },
+    {
+      message: "Exceptions should not extend java.lang.Error",
+      links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_design.html#donotextendjavalangerror],
+      id: "DoNotExtendJavaLangError",
+      path: "src/Hello.java",
+      location: { start_line: 22, start_column: 23, end_line: 22, end_column: 37 },
+      object: { ruleset: "Design", priority: "3" },
+      git_blame_info: nil
+    },
+    {
+      message: "Do not use hard coded encryption keys",
+      links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_security.html#hardcodedcryptokey],
+      id: "HardCodedCryptoKey",
+      path: "src/Hello.java",
+      location: { start_line: 12, start_column: 27, end_line: 12, end_column: 42 },
+      object: { ruleset: "Security", priority: "3" },
+      git_blame_info: nil
+    },
+    {
+      message: "System.out.println is used",
+      links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_bestpractices.html#systemprintln],
+      id: "SystemPrintln",
+      path: "src/Hello.java",
+      location: { start_line: 8, start_column: 9, end_line: 8, end_column: 26 },
+      object: { ruleset: "Best Practices", priority: "2" },
+      git_blame_info: nil
+    }
+  ],
   warnings: [{ message: %r{PMDException: Error while parsing .+/src/Broken\.java}, file: "src/Broken.java" }]
 )
 
 # `java-optimizations` has become an old ruleset style since 6.0.0. However this style still kept for backwards-compatibility.
-Smoke.add_test(
+s.add_test(
   "old-rulesets-style",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "PMD Java", version: "6.21.0" },
-    issues: [
-      {
-        message: "Parameter 'args' is not assigned and could be declared final",
-        links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_codestyle.html#methodargumentcouldbefinal],
-        id: "MethodArgumentCouldBeFinal",
-        path: "Main.java",
-        location: { start_line: 5, start_column: 29, end_line: 5, end_column: 41 },
-        object: { ruleset: "Code Style", priority: "3" },
-        git_blame_info: nil
-      }
-    ]
-  },
+  type: "success",
+  analyzer: { name: "PMD Java", version: "6.21.0" },
+  issues: [
+    {
+      message: "Parameter 'args' is not assigned and could be declared final",
+      links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_codestyle.html#methodargumentcouldbefinal],
+      id: "MethodArgumentCouldBeFinal",
+      path: "Main.java",
+      location: { start_line: 5, start_column: 29, end_line: 5, end_column: 41 },
+      object: { ruleset: "Code Style", priority: "3" },
+      git_blame_info: nil
+    }
+  ],
   warnings: [
     {
       message:
@@ -151,96 +143,80 @@ Smoke.add_test(
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "config",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "PMD Java", version: "6.21.0" },
-    issues: [
-      {
-        message: "Parameter 'args' is not assigned and could be declared final",
-        links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_codestyle.html#methodargumentcouldbefinal],
-        id: "MethodArgumentCouldBeFinal",
-        path: "src/Main.java",
-        location: { start_line: 5, start_column: 29, end_line: 5, end_column: 41 },
-        object: { ruleset: "Code Style", priority: "3" },
-        git_blame_info: nil
-      },
-      {
-        message: "Avoid short class names like Main",
-        links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_codestyle.html#shortclassname],
-        id: "ShortClassName",
-        path: "src/Main.java",
-        location: { start_line: 3, start_column: 8, end_line: 8, end_column: 1 },
-        object: { ruleset: "Code Style", priority: "4" },
-        git_blame_info: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "PMD Java", version: "6.21.0" },
+  issues: [
+    {
+      message: "Parameter 'args' is not assigned and could be declared final",
+      links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_codestyle.html#methodargumentcouldbefinal],
+      id: "MethodArgumentCouldBeFinal",
+      path: "src/Main.java",
+      location: { start_line: 5, start_column: 29, end_line: 5, end_column: 41 },
+      object: { ruleset: "Code Style", priority: "3" },
+      git_blame_info: nil
+    },
+    {
+      message: "Avoid short class names like Main",
+      links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_codestyle.html#shortclassname],
+      id: "ShortClassName",
+      path: "src/Main.java",
+      location: { start_line: 3, start_column: 8, end_line: 8, end_column: 1 },
+      object: { ruleset: "Code Style", priority: "4" },
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "duplicate-rule-name",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "PMD Java", version: "6.21.0" },
-    issues: [
-      {
-        message: "Comment is too large: Line too long",
-        links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_documentation.html#commentsize],
-        id: "CommentSize",
-        path: "Main.java",
-        location: { start_line: 10, start_column: 1, end_line: 10, end_column: 2 },
-        object: { ruleset: "Documentation", priority: "3" },
-        git_blame_info: nil
-      },
-      {
-        message: "Comment is too large: Too many lines",
-        links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_documentation.html#commentsize],
-        id: "CommentSize",
-        path: "Main.java",
-        location: { start_line: 10, start_column: 1, end_line: 34, end_column: 2 },
-        object: { ruleset: "Documentation", priority: "3" },
-        git_blame_info: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "PMD Java", version: "6.21.0" },
+  issues: [
+    {
+      message: "Comment is too large: Line too long",
+      links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_documentation.html#commentsize],
+      id: "CommentSize",
+      path: "Main.java",
+      location: { start_line: 10, start_column: 1, end_line: 10, end_column: 2 },
+      object: { ruleset: "Documentation", priority: "3" },
+      git_blame_info: nil
+    },
+    {
+      message: "Comment is too large: Too many lines",
+      links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_documentation.html#commentsize],
+      id: "CommentSize",
+      path: "Main.java",
+      location: { start_line: 10, start_column: 1, end_line: 34, end_column: 2 },
+      object: { ruleset: "Documentation", priority: "3" },
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "failure",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    analyzer: { name: "PMD Java", version: "6.21.0" },
-    message: "Unexpected error occurred. Please see the analysis log."
-  }
+  type: "failure",
+  analyzer: { name: "PMD Java", version: "6.21.0" },
+  message: "Unexpected error occurred. Please see the analysis log."
 )
 
-Smoke.add_test(
+s.add_test(
   "deprecated-functions",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "PMD Java", version: "6.21.0" },
-    issues: [
-      {
-        message: "violation message",
-        links: [],
-        id: "typeof is deprecated",
-        path: "Foo.java",
-        location: { start_line: 3, start_column: 8, end_line: 3, end_column: 37 },
-        object: { ruleset: "Custom Rules", priority: "3" },
-        git_blame_info: nil
-      }
-    ]
-  },
+  type: "success",
+  analyzer: { name: "PMD Java", version: "6.21.0" },
+  issues: [
+    {
+      message: "violation message",
+      links: [],
+      id: "typeof is deprecated",
+      path: "Foo.java",
+      location: { start_line: 3, start_column: 8, end_line: 3, end_column: 37 },
+      object: { ruleset: "Custom Rules", priority: "3" },
+      git_blame_info: nil
+    }
+  ],
   warnings: [
     {
       message: "The XPath function typeof() is deprecated and will be removed in 7.0.0. Use typeIs() instead.",
@@ -249,37 +225,29 @@ Smoke.add_test(
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sideci_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    analyzer: nil,
-    message:
-      "The value of the attribute `$.linter.pmd_java.min_priority` in your `sideci.yml` is invalid. Please fix and retry."
-  }
+  type: "failure",
+  analyzer: :_,
+  message:
+    "The value of the attribute `$.linter.pmd_java.min_priority` in your `sideci.yml` is invalid. Please fix and retry."
 )
 
-Smoke.add_test(
+s.add_test(
   "deprecated-rules",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "PMD Java", version: "6.21.0" },
-    issues: [
-      {
-        message: "The String literal \"Howdy\" appears 4 times in this file; the first occurrence is on line 3",
-        links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_errorprone.html#avoidduplicateliterals],
-        id: "AvoidDuplicateLiterals",
-        path: "AvoidDupliatedLiterals.java",
-        location: { start_line: 3, start_column: 13, end_line: 3, end_column: 19 },
-        object: { ruleset: "Error Prone", priority: "3" },
-        git_blame_info: nil
-      }
-    ]
-  },
+  type: "success",
+  analyzer: { name: "PMD Java", version: "6.21.0" },
+  issues: [
+    {
+      message: "The String literal \"Howdy\" appears 4 times in this file; the first occurrence is on line 3",
+      links: %w[https://pmd.github.io/pmd-6.21.0/pmd_rules_java_errorprone.html#avoidduplicateliterals],
+      id: "AvoidDuplicateLiterals",
+      path: "AvoidDupliatedLiterals.java",
+      location: { start_line: 3, start_column: 13, end_line: 3, end_column: 19 },
+      object: { ruleset: "Error Prone", priority: "3" },
+      git_blame_info: nil
+    }
+  ],
   warnings: [
     {
       message:

--- a/test/smokes/querly/expectations.rb
+++ b/test/smokes/querly/expectations.rb
@@ -1,151 +1,131 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "foo.rb",
-        location: { start_line: 4, start_column: 0, end_line: 4, end_column: 19 },
+  timestamp: :_,
+  type: "success",
+  issues: [
+    {
+      path: "foo.rb",
+      location: { start_line: 4, start_column: 0, end_line: 4, end_column: 19 },
+      id: "com.method_chain",
+      message: "Method chain with `_`.\n" + "\n" + "message...\n",
+      links: [],
+      object: {
         id: "com.method_chain",
-        message: "Method chain with `_`.\n" + "\n" + "message...\n",
-        links: [],
-        object: {
-          id: "com.method_chain",
-          messages: ["Method chain with `_`.\n" + "\n" + "message...\n"],
-          justifications: [],
-          examples: []
-        },
-        git_blame_info: nil
+        messages: ["Method chain with `_`.\n" + "\n" + "message...\n"],
+        justifications: [],
+        examples: []
       },
-      {
-        path: "foo.rb",
-        location: { start_line: 1, start_column: 7, end_line: 1, end_column: 34 },
+      git_blame_info: nil
+    },
+    {
+      path: "foo.rb",
+      location: { start_line: 1, start_column: 7, end_line: 1, end_column: 34 },
+      id: "com.test.pathname",
+      message: "Use Pathname method instead",
+      links: [],
+      object: {
         id: "com.test.pathname",
-        message: "Use Pathname method instead",
-        links: [],
-        object: {
-          id: "com.test.pathname",
-          messages: ["Use Pathname method instead"],
-          justifications: ["Want to write this code."],
-          examples: [{ before: "Pathname.new(\"path\")", after: "Pathname(\"path\")" }]
-        },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Querly", version: "1.0.0" }
-  }
+        messages: ["Use Pathname method instead"],
+        justifications: ["Want to write this code."],
+        examples: [{ before: "Pathname.new(\"path\")", after: "Pathname(\"path\")" }]
+      },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Querly", version: "1.0.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "no_config_file",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "Querly", version: "1.0.0" } },
+  type: "success",
+  issues: [],
+  analyzer: { name: "Querly", version: "1.0.0" },
   warnings: [
     {
-      message: <<~MESSAGE
+      message: <<~MESSAGE,
         Sider cannot find the required configuration file `querly.yml`.
         Please set up Querly by following the instructions, or you can disable it in the repository settings.
 
         - https://github.com/soutaro/querly
         - https://help.sider.review/tools/ruby/querly
       MESSAGE
-        .strip,
       file: nil
     }
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "invalid_config_file",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "foo.rb",
-        location: { start_line: 1, start_column: 7, end_line: 1, end_column: 34 },
-        id: "com.test.pathname",
-        message: "Use Pathname method instead",
-        links: [],
-        object: {
-          id: "com.test.pathname", messages: ["Use Pathname method instead"], justifications: [], examples: []
-        },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Querly", version: "1.0.0" }
-  },
+  type: "success",
+  issues: [
+    {
+      path: "foo.rb",
+      location: { start_line: 1, start_column: 7, end_line: 1, end_column: 34 },
+      id: "com.test.pathname",
+      message: "Use Pathname method instead",
+      links: [],
+      object: { id: "com.test.pathname", messages: ["Use Pathname method instead"], justifications: [], examples: [] },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Querly", version: "1.0.0" },
   warnings: [{ message: "com.test.pathname:\t1st *after* example matched with some of patterns", file: "querly.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "slim",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "hello.slim",
-        location: { start_line: 1, start_column: :_, end_line: 1, end_column: :_ },
-        id: "link_to",
-        message: "link_to\n\nSome message.\n",
-        links: [],
-        object: { id: "link_to", messages: ["link_to\n\nSome message.\n"], justifications: [], examples: [] },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Querly", version: "1.0.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "hello.slim",
+      location: { start_line: 1, start_column: :_, end_line: 1, end_column: :_ },
+      id: "link_to",
+      message: "link_to\n\nSome message.\n",
+      links: [],
+      object: { id: "link_to", messages: ["link_to\n\nSome message.\n"], justifications: [], examples: [] },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Querly", version: "1.0.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "haml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "test.html.haml",
-        location: { start_line: 2, start_column: :_, end_line: 2, end_column: :_ },
-        id: "link_to",
-        message: "link_to\n\nSome message.\n",
-        links: [],
-        object: { id: "link_to", messages: ["link_to\n\nSome message.\n"], justifications: [], examples: [] },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Querly", version: "1.0.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "test.html.haml",
+      location: { start_line: 2, start_column: :_, end_line: 2, end_column: :_ },
+      id: "link_to",
+      message: "link_to\n\nSome message.\n",
+      links: [],
+      object: { id: "link_to", messages: ["link_to\n\nSome message.\n"], justifications: [], examples: [] },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Querly", version: "1.0.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "lowest_deps",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "foo.rb",
-        location: { start_line: 1, start_column: 7, end_line: 1, end_column: 34 },
+  type: "success",
+  issues: [
+    {
+      path: "foo.rb",
+      location: { start_line: 1, start_column: 7, end_line: 1, end_column: 34 },
+      id: "com.test.pathname",
+      message: "Use Pathname method instead",
+      links: [],
+      object: {
         id: "com.test.pathname",
-        message: "Use Pathname method instead",
-        links: [],
-        object: {
-          id: "com.test.pathname",
-          messages: ["Use Pathname method instead"],
-          justifications: ["Want to write this code."],
-          examples: [{ before: "Pathname.new(\"path\")", after: "Pathname(\"path\")" }]
-        },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Querly", version: "0.5.0" }
-  }
+        messages: ["Use Pathname method instead"],
+        justifications: ["Want to write this code."],
+        examples: [{ before: "Pathname.new(\"path\")", after: "Pathname(\"path\")" }]
+      },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Querly", version: "0.5.0" }
 )

--- a/test/smokes/querly/expectations.rb
+++ b/test/smokes/querly/expectations.rb
@@ -44,13 +44,13 @@ s.add_test(
   analyzer: { name: "Querly", version: "1.0.0" },
   warnings: [
     {
-      message: <<~MESSAGE,
-        Sider cannot find the required configuration file `querly.yml`.
-        Please set up Querly by following the instructions, or you can disable it in the repository settings.
+      message: <<~MESSAGE.strip,
+Sider cannot find the required configuration file `querly.yml`.
+Please set up Querly by following the instructions, or you can disable it in the repository settings.
 
-        - https://github.com/soutaro/querly
-        - https://help.sider.review/tools/ruby/querly
-      MESSAGE
+- https://github.com/soutaro/querly
+- https://help.sider.review/tools/ruby/querly
+MESSAGE
       file: nil
     }
   ]

--- a/test/smokes/rails_best_practices/expectations.rb
+++ b/test/smokes/rails_best_practices/expectations.rb
@@ -1,9 +1,7 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "sandbox_rails",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -46,192 +44,160 @@ Smoke.add_test(
   analyzer: { name: "Rails Best Practices", version: "1.19.4" }
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sideci_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    analyzer: nil,
-    message:
-      "The value of the attribute `$.linter.rails_best_practices.exclude` in your `sideci.yml` is invalid. Please fix and retry."
-  }
+  type: "failure",
+  analyzer: :_,
+  message:
+    "The value of the attribute `$.linter.rails_best_practices.exclude` in your `sideci.yml` is invalid. Please fix and retry."
 )
 
-Smoke.add_test(
+s.add_test(
   "valid_sideci_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "Rails Best Practices", version: "1.19.4" },
-    issues: [
-      {
-        message: "Don't rescue Exception",
-        links: %w[https://rails-bestpractices.com/posts/2012/11/01/don-t-rescue-exception-rescue-standarderror/],
-        id: "RailsBestPractices::Reviews::NotRescueExceptionReview",
-        path: "a.rb",
-        location: { start_line: 5, start_column: 0, end_line: 5, end_column: 0 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ]
-  },
-  {
-    warnings: [
-      {
-        message: <<~MSG
-          DEPRECATION WARNING!!!
-          The `$.linter.rails_best_practices.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-          Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rails-bestpractices ).
-        MSG
-          .strip,
-        file: "sideci.yml"
-      }
-    ]
-  }
-)
-
-Smoke.add_test(
-  "template_engine",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "Rails Best Practices", version: "1.19.1" },
-    issues: [
-      {
-        message: "simplify render in views",
-        links: %w[https://rails-bestpractices.com/posts/2010/12/04/simplify-render-in-views/],
-        id: "RailsBestPractices::Reviews::SimplifyRenderInViewsReview",
-        path: "app/views/index.html.erb",
-        location: { start_line: 2, start_column: 0, end_line: 2, end_column: 0 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "simplify render in views",
-        links: %w[https://rails-bestpractices.com/posts/2010/12/04/simplify-render-in-views/],
-        id: "RailsBestPractices::Reviews::SimplifyRenderInViewsReview",
-        path: "app/views/index.html.haml",
-        location: { start_line: 2, start_column: 0, end_line: 2, end_column: 0 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "simplify render in views",
-        links: %w[https://rails-bestpractices.com/posts/2010/12/04/simplify-render-in-views/],
-        id: "RailsBestPractices::Reviews::SimplifyRenderInViewsReview",
-        path: "app/views/index.html.slim",
-        location: { start_line: 2, start_column: 0, end_line: 2, end_column: 0 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ]
-  }
-)
-
-Smoke.add_test(
-  "lowest_deps",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "Rails Best Practices", version: "1.19.1" },
-    issues: [
-      {
-        message: "Don't rescue Exception",
-        links: %w[https://rails-bestpractices.com/posts/2012/11/01/don-t-rescue-exception-rescue-standarderror/],
-        id: "RailsBestPractices::Reviews::NotRescueExceptionReview",
-        path: "app/models/box.rb",
-        location: { start_line: 5, start_column: 0, end_line: 5, end_column: 0 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ]
-  }
-)
-
-Smoke.add_test(
-  "slim_with_sass",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "Rails Best Practices", version: "1.19.1" },
-    issues: [
-      {
-        message: "simplify render in views",
-        links: %w[https://rails-bestpractices.com/posts/2010/12/04/simplify-render-in-views/],
-        id: "RailsBestPractices::Reviews::SimplifyRenderInViewsReview",
-        path: "app/views/index.html.slim",
-        location: { start_line: 2, start_column: 0, end_line: 2, end_column: 0 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "simplify render in views",
-        links: %w[https://rails-bestpractices.com/posts/2010/12/04/simplify-render-in-views/],
-        id: "RailsBestPractices::Reviews::SimplifyRenderInViewsReview",
-        path: "app/views/show.html.slim",
-        location: { start_line: 2, start_column: 0, end_line: 2, end_column: 0 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ]
-  }
-)
-
-Smoke.add_test(
-  "sassc_v1",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "Rails Best Practices", version: "1.19.1" },
-    issues: [
-      {
-        message: "simplify render in views",
-        links: %w[https://rails-bestpractices.com/posts/2010/12/04/simplify-render-in-views/],
-        id: "RailsBestPractices::Reviews::SimplifyRenderInViewsReview",
-        path: "app/views/index.html.slim",
-        location: { start_line: 2, start_column: 0, end_line: 2, end_column: 0 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ]
-  }
-)
-
-Smoke.add_test(
-  "unsupported",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "Rails Best Practices", version: "1.19.4" },
-    issues: [
-      {
-        message: "Don't rescue Exception",
-        links: %w[https://rails-bestpractices.com/posts/2012/11/01/don-t-rescue-exception-rescue-standarderror/],
-        id: "RailsBestPractices::Reviews::NotRescueExceptionReview",
-        path: "app/models/box.rb",
-        location: { start_line: 5, start_column: 0, end_line: 5, end_column: 0 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ]
-  },
+  type: "success",
+  analyzer: { name: "Rails Best Practices", version: "1.19.4" },
+  issues: [
+    {
+      message: "Don't rescue Exception",
+      links: %w[https://rails-bestpractices.com/posts/2012/11/01/don-t-rescue-exception-rescue-standarderror/],
+      id: "RailsBestPractices::Reviews::NotRescueExceptionReview",
+      path: "a.rb",
+      location: { start_line: 5, start_column: 0, end_line: 5, end_column: 0 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
   warnings: [
     {
-      message: <<~MESSAGE
+      message: <<~MSG,
+        DEPRECATION WARNING!!!
+        The `$.linter.rails_best_practices.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rails-bestpractices ).
+      MSG
+      file: "sideci.yml"
+    }
+  ]
+)
+
+s.add_test(
+  "template_engine",
+  type: "success",
+  analyzer: { name: "Rails Best Practices", version: "1.19.1" },
+  issues: [
+    {
+      message: "simplify render in views",
+      links: %w[https://rails-bestpractices.com/posts/2010/12/04/simplify-render-in-views/],
+      id: "RailsBestPractices::Reviews::SimplifyRenderInViewsReview",
+      path: "app/views/index.html.erb",
+      location: { start_line: 2, start_column: 0, end_line: 2, end_column: 0 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "simplify render in views",
+      links: %w[https://rails-bestpractices.com/posts/2010/12/04/simplify-render-in-views/],
+      id: "RailsBestPractices::Reviews::SimplifyRenderInViewsReview",
+      path: "app/views/index.html.haml",
+      location: { start_line: 2, start_column: 0, end_line: 2, end_column: 0 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "simplify render in views",
+      links: %w[https://rails-bestpractices.com/posts/2010/12/04/simplify-render-in-views/],
+      id: "RailsBestPractices::Reviews::SimplifyRenderInViewsReview",
+      path: "app/views/index.html.slim",
+      location: { start_line: 2, start_column: 0, end_line: 2, end_column: 0 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ]
+)
+
+s.add_test(
+  "lowest_deps",
+  type: "success",
+  analyzer: { name: "Rails Best Practices", version: "1.19.1" },
+  issues: [
+    {
+      message: "Don't rescue Exception",
+      links: %w[https://rails-bestpractices.com/posts/2012/11/01/don-t-rescue-exception-rescue-standarderror/],
+      id: "RailsBestPractices::Reviews::NotRescueExceptionReview",
+      path: "app/models/box.rb",
+      location: { start_line: 5, start_column: 0, end_line: 5, end_column: 0 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ]
+)
+
+s.add_test(
+  "slim_with_sass",
+  type: "success",
+  analyzer: { name: "Rails Best Practices", version: "1.19.1" },
+  issues: [
+    {
+      message: "simplify render in views",
+      links: %w[https://rails-bestpractices.com/posts/2010/12/04/simplify-render-in-views/],
+      id: "RailsBestPractices::Reviews::SimplifyRenderInViewsReview",
+      path: "app/views/index.html.slim",
+      location: { start_line: 2, start_column: 0, end_line: 2, end_column: 0 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "simplify render in views",
+      links: %w[https://rails-bestpractices.com/posts/2010/12/04/simplify-render-in-views/],
+      id: "RailsBestPractices::Reviews::SimplifyRenderInViewsReview",
+      path: "app/views/show.html.slim",
+      location: { start_line: 2, start_column: 0, end_line: 2, end_column: 0 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ]
+)
+
+s.add_test(
+  "sassc_v1",
+  type: "success",
+  analyzer: { name: "Rails Best Practices", version: "1.19.1" },
+  issues: [
+    {
+      message: "simplify render in views",
+      links: %w[https://rails-bestpractices.com/posts/2010/12/04/simplify-render-in-views/],
+      id: "RailsBestPractices::Reviews::SimplifyRenderInViewsReview",
+      path: "app/views/index.html.slim",
+      location: { start_line: 2, start_column: 0, end_line: 2, end_column: 0 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ]
+)
+
+s.add_test(
+  "unsupported",
+  type: "success",
+  analyzer: { name: "Rails Best Practices", version: "1.19.4" },
+  issues: [
+    {
+      message: "Don't rescue Exception",
+      links: %w[https://rails-bestpractices.com/posts/2012/11/01/don-t-rescue-exception-rescue-standarderror/],
+      id: "RailsBestPractices::Reviews::NotRescueExceptionReview",
+      path: "app/models/box.rb",
+      location: { start_line: 5, start_column: 0, end_line: 5, end_column: 0 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  warnings: [
+    {
+      message: <<~MESSAGE,
         Sider tried to install `rails_best_practices 1.16.0` according to your `Gemfile.lock`, but it installs `1.19.4` instead.
         Because `1.16.0` does not satisfy the Sider constraints [">= 1.19.1", "< 2.0"].
 
         If you want to use a different version of `rails_best_practices`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
         See https://help.sider.review/getting-started/custom-configuration#gems-option
       MESSAGE
-        .strip,
       file: nil
     }
   ]

--- a/test/smokes/rails_best_practices/expectations.rb
+++ b/test/smokes/rails_best_practices/expectations.rb
@@ -69,11 +69,11 @@ s.add_test(
   ],
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The `$.linter.rails_best_practices.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rails-bestpractices ).
-      MSG
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The `$.linter.rails_best_practices.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rails-bestpractices ).
+MSG
       file: "sideci.yml"
     }
   ]
@@ -191,13 +191,13 @@ s.add_test(
   ],
   warnings: [
     {
-      message: <<~MESSAGE,
-        Sider tried to install `rails_best_practices 1.16.0` according to your `Gemfile.lock`, but it installs `1.19.4` instead.
-        Because `1.16.0` does not satisfy the Sider constraints [">= 1.19.1", "< 2.0"].
+      message: <<~MESSAGE.strip,
+Sider tried to install `rails_best_practices 1.16.0` according to your `Gemfile.lock`, but it installs `1.19.4` instead.
+Because `1.16.0` does not satisfy the Sider constraints [">= 1.19.1", "< 2.0"].
 
-        If you want to use a different version of `rails_best_practices`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
-        See https://help.sider.review/getting-started/custom-configuration#gems-option
-      MESSAGE
+If you want to use a different version of `rails_best_practices`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
+See https://help.sider.review/getting-started/custom-configuration#gems-option
+MESSAGE
       file: nil
     }
   ]

--- a/test/smokes/reek/expectations.rb
+++ b/test/smokes/reek/expectations.rb
@@ -1,9 +1,7 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "multiline",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -37,10 +35,8 @@ Smoke.add_test(
   analyzer: { name: "Reek", version: "6.0.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "recommend_config",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -56,32 +52,26 @@ Smoke.add_test(
   analyzer: { name: "Reek", version: "6.0.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "syntax_error",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "cat.rb",
-        location: { start_line: 1 },
-        id: "ModuleInitialize",
-        message: "`Cat` has initialize method",
-        links: %w[https://github.com/troessner/reek/blob/v6.0.0/docs/Module-Initialize.md],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Reek", version: "6.0.0" }
-  },
+  type: "success",
+  issues: [
+    {
+      path: "cat.rb",
+      location: { start_line: 1 },
+      id: "ModuleInitialize",
+      message: "`Cat` has initialize method",
+      links: %w[https://github.com/troessner/reek/blob/v6.0.0/docs/Module-Initialize.md],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Reek", version: "6.0.0" },
   warnings: [{ message: "Detected syntax error in `error.rb`", file: "error.rb" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "exist_reek_config",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -106,20 +96,12 @@ Smoke.add_test(
   analyzer: { name: "Reek", version: "6.0.0" }
 )
 
-Smoke.add_test(
-  "renamed_rule",
-  guid: "test-guid", timestamp: :_, type: "error", class: "Runners::Shell::ExecError", backtrace: :_, inspect: :_
-)
+s.add_test("renamed_rule", type: "error", class: "Runners::Shell::ExecError", backtrace: :_, inspect: :_)
 
-Smoke.add_test(
-  "v4_config_style",
-  guid: "test-guid", timestamp: :_, type: "error", class: "Runners::Shell::ExecError", backtrace: :_, inspect: :_
-)
+s.add_test("v4_config_style", type: "error", class: "Runners::Shell::ExecError", backtrace: :_, inspect: :_)
 
-Smoke.add_test(
+s.add_test(
   "v4_config_file_exists",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -135,10 +117,8 @@ Smoke.add_test(
   analyzer: { name: "Reek", version: "6.0.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "lowest_deps",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -154,117 +134,100 @@ Smoke.add_test(
   analyzer: { name: "Reek", version: "4.4.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "unsupported",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "cat.rb",
-        location: { start_line: 1 },
-        id: "ModuleInitialize",
-        message: "`Cat` has initialize method",
-        links: %w[https://github.com/troessner/reek/blob/v6.0.0/docs/Module-Initialize.md],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Reek", version: "6.0.0" }
-  },
+  type: "success",
+  issues: [
+    {
+      path: "cat.rb",
+      location: { start_line: 1 },
+      id: "ModuleInitialize",
+      message: "`Cat` has initialize method",
+      links: %w[https://github.com/troessner/reek/blob/v6.0.0/docs/Module-Initialize.md],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Reek", version: "6.0.0" },
   warnings: [
     {
-      message: <<~MESSAGE
+      message: <<~MESSAGE,
         Sider tried to install `reek 4.0.0` according to your `Gemfile.lock`, but it installs `6.0.0` instead.
         Because `4.0.0` does not satisfy the Sider constraints [\">= 4.4.0\", \"< 7.0.0\"].
 
         If you want to use a different version of `reek`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
         See https://help.sider.review/getting-started/custom-configuration#gems-option
       MESSAGE
-        .strip,
       file: nil
     }
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "regex_directory_directive",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "`Autumn#silver_week` performs a nil-check",
-        links: %w[https://github.com/troessner/reek/blob/v6.0.0/docs/Nil-Check.md],
-        id: "NilCheck",
-        path: "app/models/seasons/test/summer.rb",
-        location: { start_line: 8 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Reek", version: "6.0.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "`Autumn#silver_week` performs a nil-check",
+      links: %w[https://github.com/troessner/reek/blob/v6.0.0/docs/Nil-Check.md],
+      id: "NilCheck",
+      path: "app/models/seasons/test/summer.rb",
+      location: { start_line: 8 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Reek", version: "6.0.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_target",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "`A` has initialize method",
-        links: %i[_],
-        id: "ModuleInitialize",
-        path: "lib/a.rb",
-        location: { start_line: 1 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "`Sub::B` has initialize method",
-        links: %i[_],
-        id: "ModuleInitialize",
-        path: "lib/sub/b.rb",
-        location: { start_line: 1 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "`TargetTest` has initialize method",
-        links: %i[_],
-        id: "ModuleInitialize",
-        path: "test/target_test.rb",
-        location: { start_line: 1 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Reek", version: "6.0.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "`A` has initialize method",
+      links: %i[_],
+      id: "ModuleInitialize",
+      path: "lib/a.rb",
+      location: { start_line: 1 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "`Sub::B` has initialize method",
+      links: %i[_],
+      id: "ModuleInitialize",
+      path: "lib/sub/b.rb",
+      location: { start_line: 1 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "`TargetTest` has initialize method",
+      links: %i[_],
+      id: "ModuleInitialize",
+      path: "test/target_test.rb",
+      location: { start_line: 1 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Reek", version: "6.0.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_config",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "`nil_check` performs a nil-check",
-        links: %i[_],
-        id: "NilCheck",
-        path: "a.rb",
-        location: { start_line: 2 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "Reek", version: "6.0.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "`nil_check` performs a nil-check",
+      links: %i[_],
+      id: "NilCheck",
+      path: "a.rb",
+      location: { start_line: 2 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Reek", version: "6.0.0" }
 )

--- a/test/smokes/reek/expectations.rb
+++ b/test/smokes/reek/expectations.rb
@@ -151,13 +151,13 @@ s.add_test(
   analyzer: { name: "Reek", version: "6.0.0" },
   warnings: [
     {
-      message: <<~MESSAGE,
-        Sider tried to install `reek 4.0.0` according to your `Gemfile.lock`, but it installs `6.0.0` instead.
-        Because `4.0.0` does not satisfy the Sider constraints [\">= 4.4.0\", \"< 7.0.0\"].
+      message: <<~MESSAGE.strip,
+Sider tried to install `reek 4.0.0` according to your `Gemfile.lock`, but it installs `6.0.0` instead.
+Because `4.0.0` does not satisfy the Sider constraints [\">= 4.4.0\", \"< 7.0.0\"].
 
-        If you want to use a different version of `reek`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
-        See https://help.sider.review/getting-started/custom-configuration#gems-option
-      MESSAGE
+If you want to use a different version of `reek`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
+See https://help.sider.review/getting-started/custom-configuration#gems-option
+MESSAGE
       file: nil
     }
   ]

--- a/test/smokes/remark_lint/expectations.rb
+++ b/test/smokes/remark_lint/expectations.rb
@@ -1,230 +1,191 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "readme.md",
-        location: { start_line: 3 },
-        id: "no-undefined-references",
-        message: "Found reference to undefined definition",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "docs/zzz.markdown",
-        location: { start_line: 1 },
-        id: "no-unused-definitions",
-        message: "Found unused definition",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "remark-lint", version: "6.0.5" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "readme.md",
+      location: { start_line: 3 },
+      id: "no-undefined-references",
+      message: "Found reference to undefined definition",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "docs/zzz.markdown",
+      location: { start_line: 1 },
+      id: "no-unused-definitions",
+      message: "Found unused definition",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "remark-lint", version: "6.0.5" }
 )
 
-Smoke.add_test(
-  "no_files",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "remark-lint", version: "6.0.5" } }
-)
+s.add_test("no_files", type: "success", issues: [], analyzer: { name: "remark-lint", version: "6.0.5" })
 
-Smoke.add_test(
+s.add_test(
   "option_target",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "src/foo.md",
-        location: { start_line: 3 },
-        id: "heading-increment",
-        message: "Heading levels should increment by one level at a time",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "docs/bar.md",
-        location: { start_line: 1 },
-        id: "no-auto-link-without-protocol",
-        message: "All automatic links must start with a protocol",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "remark-lint", version: "6.0.5" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "src/foo.md",
+      location: { start_line: 3 },
+      id: "heading-increment",
+      message: "Heading levels should increment by one level at a time",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "docs/bar.md",
+      location: { start_line: 1 },
+      id: "no-auto-link-without-protocol",
+      message: "All automatic links must start with a protocol",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "remark-lint", version: "6.0.5" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_ext",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "readme.markdown",
-        location: { start_line: 1 },
-        id: "no-auto-link-without-protocol",
-        message: "All automatic links must start with a protocol",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "readme.mdown",
-        location: { start_line: 1 },
-        id: "no-auto-link-without-protocol",
-        message: "All automatic links must start with a protocol",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "remark-lint", version: "6.0.5" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "readme.markdown",
+      location: { start_line: 1 },
+      id: "no-auto-link-without-protocol",
+      message: "All automatic links must start with a protocol",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "readme.mdown",
+      location: { start_line: 1 },
+      id: "no-auto-link-without-protocol",
+      message: "All automatic links must start with a protocol",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "remark-lint", version: "6.0.5" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_rc_path",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "readme.md",
-        location: { start_line: 4 },
-        id: "no-auto-link-without-protocol",
-        message: "All automatic links must start with a protocol",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "remark-lint", version: "6.0.5" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "readme.md",
+      location: { start_line: 4 },
+      id: "no-auto-link-without-protocol",
+      message: "All automatic links must start with a protocol",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "remark-lint", version: "6.0.5" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_ignore_path",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "readme.md",
-        location: { start_line: 1 },
-        id: "no-auto-link-without-protocol",
-        message: "All automatic links must start with a protocol",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "remark-lint", version: "6.0.5" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "readme.md",
+      location: { start_line: 1 },
+      id: "no-auto-link-without-protocol",
+      message: "All automatic links must start with a protocol",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "remark-lint", version: "6.0.5" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_use",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "readme.markdown",
-        location: nil,
-        id: "file-extension",
-        message: "Incorrect extension: use `md`",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "readme.markdown",
-        location: { start_line: 1 },
-        id: "no-heading-punctuation",
-        message: "Don’t add a trailing `:` to headings",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "remark-lint", version: "6.0.5" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "readme.markdown",
+      location: nil,
+      id: "file-extension",
+      message: "Incorrect extension: use `md`",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "readme.markdown",
+      location: { start_line: 1 },
+      id: "no-heading-punctuation",
+      message: "Don’t add a trailing `:` to headings",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "remark-lint", version: "6.0.5" }
 )
 
-Smoke.add_test(
+s.add_test(
   "external_rules",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "readme.md",
-        location: { start_line: 1 },
-        id: "books-links",
-        message: "Missing PDF indication",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "readme.md",
-        location: { start_line: 1 },
-        id: "books-links",
-        message: "Missing a space before author",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "readme.md",
-        location: { start_line: 2 },
-        id: "books-links",
-        message: "Missing PDF indication",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "remark-lint", version: "6.0.3" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "readme.md",
+      location: { start_line: 1 },
+      id: "books-links",
+      message: "Missing PDF indication",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "readme.md",
+      location: { start_line: 1 },
+      id: "books-links",
+      message: "Missing a space before author",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "readme.md",
+      location: { start_line: 2 },
+      id: "books-links",
+      message: "Missing PDF indication",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "remark-lint", version: "6.0.3" }
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sider_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message:
-      "The value of the attribute `$.linter.remark_lint.rc-path` in your `sider.yml` is invalid. Please fix and retry.",
-    analyzer: nil
-  }
+  type: "failure",
+  message:
+    "The value of the attribute `$.linter.remark_lint.rc-path` in your `sider.yml` is invalid. Please fix and retry.",
+  analyzer: :_
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_remarkrc",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "2 errors reported. See the log for details.",
-    analyzer: { name: "remark-lint", version: "6.0.5" }
-  }
+  type: "failure",
+  message: "2 errors reported. See the log for details.",
+  analyzer: { name: "remark-lint", version: "6.0.5" }
 )

--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -389,12 +389,12 @@ s.add_test(
 s.add_test(
   "install_from_sideci.yml_when_installing_old_version_gems",
   type: "failure",
-  message: <<~MSG
+  message: <<~MSG,
     Failed to install gems. Sider automatically installs gems according to `sideci.yml` and `Gemfile.lock`.
     You can select the version of gems you want to install via `sideci.yml`.
     See https://help.sider.review/getting-started/custom-configuration#gems-option
-  MSG,
-  analyzer: nil
+  MSG
+  analyzer: :_
 )
 
 s.add_test(

--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -1,77 +1,69 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "sandbox_rails",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Literal `true` appeared as a condition.",
-        links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_lint.md#lintliteralascondition],
-        id: "Lint/LiteralAsCondition",
-        path: "app/controllers/users_controller.rb",
-        object: { severity: "warning", corrected: false },
-        git_blame_info: nil,
-        location: { start_line: 23, start_column: 8, end_line: 23, end_column: 11 }
-      },
-      {
-        message: "Shadowing outer local variable - `v`.",
-        links: %w[
-          https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_lint.md#lintshadowingouterlocalvariable
-        ],
-        id: "Lint/ShadowingOuterLocalVariable",
-        path: "app/controllers/users_controller.rb",
-        object: { severity: "warning", corrected: false },
-        git_blame_info: nil,
-        location: { start_line: 27, start_column: 30, end_line: 27, end_column: 30 }
-      },
-      {
-        message: "Useless assignment to variable - `v`.",
-        links: %w[
-          https://rubystyle.guide#underscore-unused-vars
-          https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_lint.md#lintuselessassignment
-        ],
-        id: "Lint/UselessAssignment",
-        path: "app/controllers/users_controller.rb",
-        object: { severity: "warning", corrected: false },
-        git_blame_info: nil,
-        location: { start_line: 26, start_column: 5, end_line: 26, end_column: 5 }
-      },
-      {
-        message: "Prefer symbols instead of strings as hash keys.",
-        links: %w[
-          https://rubystyle.guide#symbols-as-keys
-          https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_style.md#stylestringhashkeys
-        ],
-        id: "Style/StringHashKeys",
-        path: "config/environments/development.rb",
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil,
-        location: { start_line: 21, start_column: 7, end_line: 21, end_column: 21 }
-      },
-      {
-        message: "Prefer symbols instead of strings as hash keys.",
-        links: %w[
-          https://rubystyle.guide#symbols-as-keys
-          https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_style.md#stylestringhashkeys
-        ],
-        id: "Style/StringHashKeys",
-        path: "config/environments/test.rb",
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil,
-        location: { start_line: 18, start_column: 5, end_line: 18, end_column: 19 }
-      }
-    ],
-    analyzer: { name: "RuboCop", version: "0.80.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Literal `true` appeared as a condition.",
+      links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_lint.md#lintliteralascondition],
+      id: "Lint/LiteralAsCondition",
+      path: "app/controllers/users_controller.rb",
+      object: { severity: "warning", corrected: false },
+      git_blame_info: nil,
+      location: { start_line: 23, start_column: 8, end_line: 23, end_column: 11 }
+    },
+    {
+      message: "Shadowing outer local variable - `v`.",
+      links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_lint.md#lintshadowingouterlocalvariable],
+      id: "Lint/ShadowingOuterLocalVariable",
+      path: "app/controllers/users_controller.rb",
+      object: { severity: "warning", corrected: false },
+      git_blame_info: nil,
+      location: { start_line: 27, start_column: 30, end_line: 27, end_column: 30 }
+    },
+    {
+      message: "Useless assignment to variable - `v`.",
+      links: %w[
+        https://rubystyle.guide#underscore-unused-vars
+        https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_lint.md#lintuselessassignment
+      ],
+      id: "Lint/UselessAssignment",
+      path: "app/controllers/users_controller.rb",
+      object: { severity: "warning", corrected: false },
+      git_blame_info: nil,
+      location: { start_line: 26, start_column: 5, end_line: 26, end_column: 5 }
+    },
+    {
+      message: "Prefer symbols instead of strings as hash keys.",
+      links: %w[
+        https://rubystyle.guide#symbols-as-keys
+        https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_style.md#stylestringhashkeys
+      ],
+      id: "Style/StringHashKeys",
+      path: "config/environments/development.rb",
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil,
+      location: { start_line: 21, start_column: 7, end_line: 21, end_column: 21 }
+    },
+    {
+      message: "Prefer symbols instead of strings as hash keys.",
+      links: %w[
+        https://rubystyle.guide#symbols-as-keys
+        https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_style.md#stylestringhashkeys
+      ],
+      id: "Style/StringHashKeys",
+      path: "config/environments/test.rb",
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil,
+      location: { start_line: 18, start_column: 5, end_line: 18, end_column: 19 }
+    }
+  ],
+  analyzer: { name: "RuboCop", version: "0.80.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "without_display_cop_names",
-  guid: "test-guid",
-  timestamp: :_,
   type: "success",
   issues: [
     {
@@ -99,390 +91,331 @@ Smoke.add_test(
   analyzer: { name: "RuboCop", version: "0.80.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "renamed-cop",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Use 2 (not 1) spaces for indentation.",
-        links: %w[
-          https://rubystyle.guide#spaces-indentation
-          https://github.com/rubocop-hq/rubocop/blob/v0.79.0/manual/cops_layout.md#layoutindentationwidth
-        ],
-        id: "Layout/IndentationWidth",
-        path: "test.rb",
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil,
-        location: { start_line: 2, start_column: 1, end_line: 2, end_column: 1 }
-      },
-      {
-        message: "Tab detected.",
-        links: %w[
-          https://rubystyle.guide#spaces-indentation
-          https://github.com/rubocop-hq/rubocop/blob/v0.79.0/manual/cops_layout.md#layouttab
-        ],
-        id: "Layout/Tab",
-        path: "test.rb",
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil,
-        location: { start_line: 2, start_column: 1, end_line: 2, end_column: 1 }
-      },
-      {
-        path: "Gemfile",
-        location: { start_line: 1, start_column: 1, end_line: 1, end_column: 1 },
-        id: "Style/FrozenStringLiteralComment",
-        message: "Missing magic comment `# frozen_string_literal: true`.",
-        links: %w[
-          https://github.com/rubocop-hq/rubocop/blob/v0.79.0/manual/cops_style.md#stylefrozenstringliteralcomment
-        ],
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil
-      },
-      {
-        path: "test.rb",
-        location: { start_line: 1, start_column: 1, end_line: 1, end_column: 1 },
-        id: "Style/FrozenStringLiteralComment",
-        message: "Missing magic comment `# frozen_string_literal: true`.",
-        links: %w[
-          https://github.com/rubocop-hq/rubocop/blob/v0.79.0/manual/cops_style.md#stylefrozenstringliteralcomment
-        ],
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "RuboCop", version: "0.79.0" }
-  },
+  type: "success",
+  issues: [
+    {
+      message: "Use 2 (not 1) spaces for indentation.",
+      links: %w[
+        https://rubystyle.guide#spaces-indentation
+        https://github.com/rubocop-hq/rubocop/blob/v0.79.0/manual/cops_layout.md#layoutindentationwidth
+      ],
+      id: "Layout/IndentationWidth",
+      path: "test.rb",
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil,
+      location: { start_line: 2, start_column: 1, end_line: 2, end_column: 1 }
+    },
+    {
+      message: "Tab detected.",
+      links: %w[
+        https://rubystyle.guide#spaces-indentation
+        https://github.com/rubocop-hq/rubocop/blob/v0.79.0/manual/cops_layout.md#layouttab
+      ],
+      id: "Layout/Tab",
+      path: "test.rb",
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil,
+      location: { start_line: 2, start_column: 1, end_line: 2, end_column: 1 }
+    },
+    {
+      path: "Gemfile",
+      location: { start_line: 1, start_column: 1, end_line: 1, end_column: 1 },
+      id: "Style/FrozenStringLiteralComment",
+      message: "Missing magic comment `# frozen_string_literal: true`.",
+      links: %w[
+        https://github.com/rubocop-hq/rubocop/blob/v0.79.0/manual/cops_style.md#stylefrozenstringliteralcomment
+      ],
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil
+    },
+    {
+      path: "test.rb",
+      location: { start_line: 1, start_column: 1, end_line: 1, end_column: 1 },
+      id: "Style/FrozenStringLiteralComment",
+      message: "Missing magic comment `# frozen_string_literal: true`.",
+      links: %w[
+        https://github.com/rubocop-hq/rubocop/blob/v0.79.0/manual/cops_style.md#stylefrozenstringliteralcomment
+      ],
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "RuboCop", version: "0.79.0" },
   warnings: [{ message: "Style/Tab has the wrong namespace - should be Layout", file: ".rubocop.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "inherit_from",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Line is too long. [218/200]",
-        links: %w[
-          https://rubystyle.guide#80-character-limits
-          https://github.com/rubocop-hq/rubocop/blob/v0.79.0/manual/cops_layout.md#layoutlinelength
-        ],
-        id: "Layout/LineLength",
-        path: "cat.rb",
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil,
-        location: { start_line: 3, start_column: 201, end_line: 3, end_column: 218 }
-      }
-    ],
-    analyzer: { name: "RuboCop", version: "0.79.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Line is too long. [218/200]",
+      links: %w[
+        https://rubystyle.guide#80-character-limits
+        https://github.com/rubocop-hq/rubocop/blob/v0.79.0/manual/cops_layout.md#layoutlinelength
+      ],
+      id: "Layout/LineLength",
+      path: "cat.rb",
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil,
+      location: { start_line: 3, start_column: 201, end_line: 3, end_column: 218 }
+    }
+  ],
+  analyzer: { name: "RuboCop", version: "0.79.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "no_rubocop_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Use the `&&` operator to compare multiple values.",
-        links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_lint.md#lintmultiplecomparison],
-        id: "Lint/MultipleComparison",
-        path: "test.rb",
-        object: { severity: "warning", corrected: false },
-        git_blame_info: nil,
-        location: { start_line: 2, start_column: 4, end_line: 2, end_column: 14 }
-      }
-    ],
-    analyzer: { name: "RuboCop", version: "0.80.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Use the `&&` operator to compare multiple values.",
+      links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_lint.md#lintmultiplecomparison],
+      id: "Lint/MultipleComparison",
+      path: "test.rb",
+      object: { severity: "warning", corrected: false },
+      git_blame_info: nil,
+      location: { start_line: 2, start_column: 4, end_line: 2, end_column: 14 }
+    }
+  ],
+  analyzer: { name: "RuboCop", version: "0.80.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "exit2",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "Error: Cops cannot be both enabled by default and disabled by default",
-    analyzer: { name: "RuboCop", version: "0.80.1" }
-  }
+  type: "failure",
+  message: "Error: Cops cannot be both enabled by default and disabled by default",
+  analyzer: { name: "RuboCop", version: "0.80.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sideci_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    analyzer: nil,
-    message:
-      "The value of the attribute `$.linter.rubocop.gems[0]` in your `sideci.yml` is invalid. Please fix and retry."
-  }
+  type: "failure",
+  analyzer: :_,
+  message:
+    "The value of the attribute `$.linter.rubocop.gems[0]` in your `sideci.yml` is invalid. Please fix and retry."
 )
 
-Smoke.add_test(
+s.add_test(
   "with_safe_cops",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Empty `ensure` block detected.",
-        links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_lint.md#lintemptyensure],
-        id: "Lint/EmptyEnsure",
-        path: "drink.rb",
-        location: { start_line: 12, start_column: 3, end_line: 12, end_column: 8 },
-        object: { severity: "warning", corrected: false },
-        git_blame_info: nil
-      },
-      {
-        message: "Do not chain ordinary method call after safe navigation operator.",
-        links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_lint.md#lintsafenavigationchain],
-        id: "Lint/SafeNavigationChain",
-        path: "drink.rb",
-        location: { start_line: 18, start_column: 21, end_line: 18, end_column: 27 },
-        object: { severity: "warning", corrected: false },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "RuboCop", version: "0.80.1" }
-  },
-  {
-    warnings: [
-      {
-        message: <<~MSG
-          DEPRECATION WARNING!!!
-          The `$.linter.rubocop.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-          Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rubocop ).
-        MSG
-          .strip,
-        file: "sideci.yml"
-      },
-      { message: "Metrics/LineLength has the wrong namespace - should be Layout", file: "my.rubocop.yml" }
-    ]
-  }
-)
-
-Smoke.add_test(
-  "v0.71_rails",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Line is too long. [218/200]",
-        links: %w[
-          https://github.com/rubocop-hq/ruby-style-guide#80-character-limits
-          https://github.com/rubocop-hq/rubocop/blob/v0.71.0/manual/cops_metrics.md#metricslinelength
-        ],
-        id: "Metrics/LineLength",
-        path: "cat.rb",
-        location: { start_line: 3, start_column: 201, end_line: 3, end_column: 218 },
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "RuboCop", version: "0.71.0" }
-  },
+  type: "success",
+  issues: [
+    {
+      message: "Empty `ensure` block detected.",
+      links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_lint.md#lintemptyensure],
+      id: "Lint/EmptyEnsure",
+      path: "drink.rb",
+      location: { start_line: 12, start_column: 3, end_line: 12, end_column: 8 },
+      object: { severity: "warning", corrected: false },
+      git_blame_info: nil
+    },
+    {
+      message: "Do not chain ordinary method call after safe navigation operator.",
+      links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.80.1/manual/cops_lint.md#lintsafenavigationchain],
+      id: "Lint/SafeNavigationChain",
+      path: "drink.rb",
+      location: { start_line: 18, start_column: 21, end_line: 18, end_column: 27 },
+      object: { severity: "warning", corrected: false },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "RuboCop", version: "0.80.1" },
   warnings: [
     {
-      message: <<~WARNING
+      message: <<~MSG,
+        DEPRECATION WARNING!!!
+        The `$.linter.rubocop.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rubocop ).
+      MSG
+      file: "sideci.yml"
+    },
+    { message: "Metrics/LineLength has the wrong namespace - should be Layout", file: "my.rubocop.yml" }
+  ]
+)
+
+s.add_test(
+  "v0.71_rails",
+  type: "success",
+  issues: [
+    {
+      message: "Line is too long. [218/200]",
+      links: %w[
+        https://github.com/rubocop-hq/ruby-style-guide#80-character-limits
+        https://github.com/rubocop-hq/rubocop/blob/v0.71.0/manual/cops_metrics.md#metricslinelength
+      ],
+      id: "Metrics/LineLength",
+      path: "cat.rb",
+      location: { start_line: 3, start_column: 201, end_line: 3, end_column: 218 },
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "RuboCop", version: "0.71.0" },
+  warnings: [
+    {
+      message: <<~WARNING,
         Rails cops will be removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
         https://github.com/rubocop-hq/rubocop/blob/master/manual/migrate_rails_cops.md
         https://help.sider.review/getting-started/custom-configuration#gems-option
       WARNING
-        .strip,
       file: :_
     }
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "v0.72_rails",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Line is too long. [218/200]",
-        links: %w[
-          https://rubystyle.guide#80-character-limits
-          https://github.com/rubocop-hq/rubocop/blob/v0.72.0/manual/cops_metrics.md#metricslinelength
-        ],
-        id: "Metrics/LineLength",
-        path: "cat.rb",
-        location: { start_line: 3, start_column: 201, end_line: 3, end_column: 218 },
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "RuboCop", version: "0.72.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Line is too long. [218/200]",
+      links: %w[
+        https://rubystyle.guide#80-character-limits
+        https://github.com/rubocop-hq/rubocop/blob/v0.72.0/manual/cops_metrics.md#metricslinelength
+      ],
+      id: "Metrics/LineLength",
+      path: "cat.rb",
+      location: { start_line: 3, start_column: 201, end_line: 3, end_column: 218 },
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "RuboCop", version: "0.72.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "v0.72_rails_option",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Line is too long. [218/200]",
-        links: %w[
-          https://rubystyle.guide#80-character-limits
-          https://github.com/rubocop-hq/rubocop/blob/v0.72.0/manual/cops_metrics.md#metricslinelength
-        ],
-        id: "Metrics/LineLength",
-        path: "cat.rb",
-        location: { start_line: 3, start_column: 201, end_line: 3, end_column: 218 },
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "RuboCop", version: "0.72.0" }
-  },
+  type: "success",
+  issues: [
+    {
+      message: "Line is too long. [218/200]",
+      links: %w[
+        https://rubystyle.guide#80-character-limits
+        https://github.com/rubocop-hq/rubocop/blob/v0.72.0/manual/cops_metrics.md#metricslinelength
+      ],
+      id: "Metrics/LineLength",
+      path: "cat.rb",
+      location: { start_line: 3, start_column: 201, end_line: 3, end_column: 218 },
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "RuboCop", version: "0.72.0" },
   warnings: [
     {
-      message: <<~WARNING
+      message: <<~WARNING,
         `rails` option is ignored because the option was removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
         See https://help.sider.review/getting-started/custom-configuration#gems-option
       WARNING
-        .strip,
       file: "sideci.yml"
     }
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "rails_and_performance",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Use `caller(2..2).first` instead of `caller[1]`.",
-        links: %w[
-          https://github.com/rubocop-hq/rubocop-performance/blob/v1.5.0/manual/cops_performance.md#performancecaller
-        ],
-        id: "Performance/Caller",
-        path: "app/foo.rb",
-        location: { start_line: 1, start_column: 1, end_line: 1, end_column: 9 },
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil
-      },
-      {
-        message: "Do not use `exit` in Rails applications.",
-        links: %w[https://github.com/rubocop-hq/rubocop-rails/blob/v2.3.2/manual/cops_rails.md#railsexit],
-        id: "Rails/Exit",
-        path: "app/foo.rb",
-        location: { start_line: 3, start_column: 1, end_line: 3, end_column: 4 },
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil
-      },
-      {
-        message: "Please use `Rails.root.join('path', 'to')` instead.",
-        links: %w[https://github.com/rubocop-hq/rubocop-rails/blob/v2.3.2/manual/cops_rails.md#railsfilepath],
-        id: "Rails/FilePath",
-        path: "app/foo.rb",
-        location: { start_line: 2, start_column: 1, end_line: 2, end_column: 33 },
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "RuboCop", version: "0.79.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Use `caller(2..2).first` instead of `caller[1]`.",
+      links: %w[
+        https://github.com/rubocop-hq/rubocop-performance/blob/v1.5.0/manual/cops_performance.md#performancecaller
+      ],
+      id: "Performance/Caller",
+      path: "app/foo.rb",
+      location: { start_line: 1, start_column: 1, end_line: 1, end_column: 9 },
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil
+    },
+    {
+      message: "Do not use `exit` in Rails applications.",
+      links: %w[https://github.com/rubocop-hq/rubocop-rails/blob/v2.3.2/manual/cops_rails.md#railsexit],
+      id: "Rails/Exit",
+      path: "app/foo.rb",
+      location: { start_line: 3, start_column: 1, end_line: 3, end_column: 4 },
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil
+    },
+    {
+      message: "Please use `Rails.root.join('path', 'to')` instead.",
+      links: %w[https://github.com/rubocop-hq/rubocop-rails/blob/v2.3.2/manual/cops_rails.md#railsfilepath],
+      id: "Rails/FilePath",
+      path: "app/foo.rb",
+      location: { start_line: 2, start_column: 1, end_line: 2, end_column: 33 },
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "RuboCop", version: "0.79.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "rails_and_performance_old",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Use `caller(2..2).first` instead of `caller[1]`.",
-        links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.67.0/manual/cops_performance.md#performancecaller],
-        id: "Performance/Caller",
-        path: "app/foo.rb",
-        location: { start_line: 1, start_column: 1, end_line: 1, end_column: 9 },
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil
-      },
-      {
-        message: "Do not use `exit` in Rails applications.",
-        links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.67.0/manual/cops_rails.md#railsexit],
-        id: "Rails/Exit",
-        path: "app/foo.rb",
-        location: { start_line: 3, start_column: 1, end_line: 3, end_column: 4 },
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil
-      },
-      {
-        message: "Please use `Rails.root.join('path', 'to')` instead.",
-        links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.67.0/manual/cops_rails.md#railsfilepath],
-        id: "Rails/FilePath",
-        path: "app/foo.rb",
-        location: { start_line: 2, start_column: 1, end_line: 2, end_column: 33 },
-        object: { severity: "convention", corrected: false },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "RuboCop", version: "0.67.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      message: "Use `caller(2..2).first` instead of `caller[1]`.",
+      links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.67.0/manual/cops_performance.md#performancecaller],
+      id: "Performance/Caller",
+      path: "app/foo.rb",
+      location: { start_line: 1, start_column: 1, end_line: 1, end_column: 9 },
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil
+    },
+    {
+      message: "Do not use `exit` in Rails applications.",
+      links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.67.0/manual/cops_rails.md#railsexit],
+      id: "Rails/Exit",
+      path: "app/foo.rb",
+      location: { start_line: 3, start_column: 1, end_line: 3, end_column: 4 },
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil
+    },
+    {
+      message: "Please use `Rails.root.join('path', 'to')` instead.",
+      links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.67.0/manual/cops_rails.md#railsfilepath],
+      id: "Rails/FilePath",
+      path: "app/foo.rb",
+      location: { start_line: 2, start_column: 1, end_line: 2, end_column: 33 },
+      object: { severity: "convention", corrected: false },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "RuboCop", version: "0.67.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "install_from_sideci.yml_when_installing_old_version_gems",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: <<~MSG
-      Failed to install gems. Sider automatically installs gems according to `sideci.yml` and `Gemfile.lock`.
-      You can select the version of gems you want to install via `sideci.yml`.
-      See https://help.sider.review/getting-started/custom-configuration#gems-option
-    MSG
-      .strip,
-    analyzer: nil
-  }
+  type: "failure",
+  message: <<~MSG
+    Failed to install gems. Sider automatically installs gems according to `sideci.yml` and `Gemfile.lock`.
+    You can select the version of gems you want to install via `sideci.yml`.
+    See https://help.sider.review/getting-started/custom-configuration#gems-option
+  MSG,
+  analyzer: nil
 )
 
-Smoke.add_test(
+s.add_test(
   "old_ruocop_is_specified",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "RuboCop", version: "0.80.1" } },
+  type: "success",
+  issues: [],
+  analyzer: { name: "RuboCop", version: "0.80.1" },
   warnings: [
     {
-      message: <<~MSG
+      message: <<~MSG,
         Sider tried to install `rubocop 0.60.0` according to your `Gemfile.lock`, but it installs `0.80.1` instead.
         Because `0.60.0` does not satisfy the Sider constraints [\">= 0.61.0\", \"< 1.0.0\"].
 
         If you want to use a different version of `rubocop`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
         See https://help.sider.review/getting-started/custom-configuration#gems-option
       MSG
-        .strip,
       file: nil
     }
   ]
 )
 
-Smoke.add_test(
-  "old_bundler_via_gemspec",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "RuboCop", version: "0.80.1" } }
-)
+s.add_test("old_bundler_via_gemspec", type: "success", issues: [], analyzer: { name: "RuboCop", version: "0.80.1" })
 
-Smoke.add_test(
-  "latest_bundler_via_gemspec",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "RuboCop", version: "0.80.1" } }
-)
+s.add_test("latest_bundler_via_gemspec", type: "success", issues: [], analyzer: { name: "RuboCop", version: "0.80.1" })

--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -224,11 +224,11 @@ s.add_test(
   analyzer: { name: "RuboCop", version: "0.80.1" },
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The `$.linter.rubocop.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rubocop ).
-      MSG
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The `$.linter.rubocop.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rubocop ).
+MSG
       file: "sideci.yml"
     },
     { message: "Metrics/LineLength has the wrong namespace - should be Layout", file: "my.rubocop.yml" }
@@ -255,11 +255,11 @@ s.add_test(
   analyzer: { name: "RuboCop", version: "0.71.0" },
   warnings: [
     {
-      message: <<~WARNING,
-        Rails cops will be removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
-        https://github.com/rubocop-hq/rubocop/blob/master/manual/migrate_rails_cops.md
-        https://help.sider.review/getting-started/custom-configuration#gems-option
-      WARNING
+      message: <<~WARNING.strip,
+Rails cops will be removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
+https://github.com/rubocop-hq/rubocop/blob/master/manual/migrate_rails_cops.md
+https://help.sider.review/getting-started/custom-configuration#gems-option
+WARNING
       file: :_
     }
   ]
@@ -305,10 +305,10 @@ s.add_test(
   analyzer: { name: "RuboCop", version: "0.72.0" },
   warnings: [
     {
-      message: <<~WARNING,
-        `rails` option is ignored because the option was removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
-        See https://help.sider.review/getting-started/custom-configuration#gems-option
-      WARNING
+      message: <<~WARNING.strip,
+`rails` option is ignored because the option was removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
+See https://help.sider.review/getting-started/custom-configuration#gems-option
+WARNING
       file: "sideci.yml"
     }
   ]
@@ -389,11 +389,11 @@ s.add_test(
 s.add_test(
   "install_from_sideci.yml_when_installing_old_version_gems",
   type: "failure",
-  message: <<~MSG,
-    Failed to install gems. Sider automatically installs gems according to `sideci.yml` and `Gemfile.lock`.
-    You can select the version of gems you want to install via `sideci.yml`.
-    See https://help.sider.review/getting-started/custom-configuration#gems-option
-  MSG
+  message: <<~MSG.strip,
+Failed to install gems. Sider automatically installs gems according to `sideci.yml` and `Gemfile.lock`.
+You can select the version of gems you want to install via `sideci.yml`.
+See https://help.sider.review/getting-started/custom-configuration#gems-option
+MSG
   analyzer: :_
 )
 
@@ -404,13 +404,13 @@ s.add_test(
   analyzer: { name: "RuboCop", version: "0.80.1" },
   warnings: [
     {
-      message: <<~MSG,
-        Sider tried to install `rubocop 0.60.0` according to your `Gemfile.lock`, but it installs `0.80.1` instead.
-        Because `0.60.0` does not satisfy the Sider constraints [\">= 0.61.0\", \"< 1.0.0\"].
+      message: <<~MSG.strip,
+Sider tried to install `rubocop 0.60.0` according to your `Gemfile.lock`, but it installs `0.80.1` instead.
+Because `0.60.0` does not satisfy the Sider constraints [\">= 0.61.0\", \"< 1.0.0\"].
 
-        If you want to use a different version of `rubocop`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
-        See https://help.sider.review/getting-started/custom-configuration#gems-option
-      MSG
+If you want to use a different version of `rubocop`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
+See https://help.sider.review/getting-started/custom-configuration#gems-option
+MSG
       file: nil
     }
   ]

--- a/test/smokes/scss_lint/expectations.rb
+++ b/test/smokes/scss_lint/expectations.rb
@@ -1,147 +1,130 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message:
-          "Color literals like `#fff` should only be used in variable declarations; they should be referred to via variable everywhere else.",
-        links: [],
-        id: "ColorVariable",
-        path: "test.scss",
-        object: nil,
-        git_blame_info: nil,
-        location: { start_line: 2 }
-      },
-      {
-        message: "Line should be indented 2 spaces, but was indented 4 spaces",
-        links: [],
-        id: "Indentation",
-        path: "test.scss",
-        object: nil,
-        git_blame_info: nil,
-        location: { start_line: 2 }
-      },
-      {
-        message: "Begin pseudo elements with double colons: `::`",
-        links: [],
-        id: "PseudoElement",
-        path: "test.scss",
-        object: nil,
-        git_blame_info: nil,
-        location: { start_line: 1 }
-      },
-      {
-        message: "Declaration should be terminated by a semicolon",
-        links: [],
-        id: "TrailingSemicolon",
-        path: "test.scss",
-        object: nil,
-        git_blame_info: nil,
-        location: { start_line: 2 }
-      }
-    ],
-    analyzer: { name: "SCSS-Lint", version: "0.59.0" }
-  },
-  {
-    warnings: [
-      {
-        message: <<-MSG
+  type: "success",
+  issues: [
+    {
+      message:
+        "Color literals like `#fff` should only be used in variable declarations; they should be referred to via variable everywhere else.",
+      links: [],
+      id: "ColorVariable",
+      path: "test.scss",
+      object: nil,
+      git_blame_info: nil,
+      location: { start_line: 2 }
+    },
+    {
+      message: "Line should be indented 2 spaces, but was indented 4 spaces",
+      links: [],
+      id: "Indentation",
+      path: "test.scss",
+      object: nil,
+      git_blame_info: nil,
+      location: { start_line: 2 }
+    },
+    {
+      message: "Begin pseudo elements with double colons: `::`",
+      links: [],
+      id: "PseudoElement",
+      path: "test.scss",
+      object: nil,
+      git_blame_info: nil,
+      location: { start_line: 1 }
+    },
+    {
+      message: "Declaration should be terminated by a semicolon",
+      links: [],
+      id: "TrailingSemicolon",
+      path: "test.scss",
+      object: nil,
+      git_blame_info: nil,
+      location: { start_line: 2 }
+    }
+  ],
+  analyzer: { name: "SCSS-Lint", version: "0.59.0" },
+  warnings: [
+    {
+      message: <<-MSG,
 DEPRECATION WARNING!!!
 The support for SCSS-Lint is deprecated. Sider will drop these versions in the near future.
 Please consider using an alternative tool stylelint. See https://github.com/sds/scss-lint/blob/master/README.md#notice-consider-other-tools-before-adopting-scss-lint
 MSG
-          .strip,
-        file: "sider.yml"
-      }
-    ]
-  }
+      file: "sider.yml"
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "no_scss_files",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "SCSS-Lint", version: "0.59.0" } },
+  type: "success",
+  issues: [],
+  analyzer: { name: "SCSS-Lint", version: "0.59.0" },
   warnings: [
     { message: /SCSS-Lint is deprecated/, file: "sider.yml" },
     { message: "No files, paths, or patterns were specified", file: nil }
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "with_config_option",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message:
-          "Color literals like `#fff` should only be used in variable declarations; they should be referred to via variable everywhere else.",
-        links: [],
-        id: "ColorVariable",
-        path: "test.scss",
-        object: nil,
-        git_blame_info: nil,
-        location: { start_line: 2 }
-      },
-      {
-        message: "Begin pseudo elements with double colons: `::`",
-        links: [],
-        id: "PseudoElement",
-        path: "test.scss",
-        object: nil,
-        git_blame_info: nil,
-        location: { start_line: 1 }
-      },
-      {
-        message: "Declaration should be terminated by a semicolon",
-        links: [],
-        id: "TrailingSemicolon",
-        path: "test.scss",
-        object: nil,
-        git_blame_info: nil,
-        location: { start_line: 2 }
-      }
-    ],
-    analyzer: { name: "SCSS-Lint", version: "0.59.0" }
-  },
-  { warnings: [{ message: /SCSS-Lint is deprecated/, file: "sideci.yml" }] }
+  type: "success",
+  issues: [
+    {
+      message:
+        "Color literals like `#fff` should only be used in variable declarations; they should be referred to via variable everywhere else.",
+      links: [],
+      id: "ColorVariable",
+      path: "test.scss",
+      object: nil,
+      git_blame_info: nil,
+      location: { start_line: 2 }
+    },
+    {
+      message: "Begin pseudo elements with double colons: `::`",
+      links: [],
+      id: "PseudoElement",
+      path: "test.scss",
+      object: nil,
+      git_blame_info: nil,
+      location: { start_line: 1 }
+    },
+    {
+      message: "Declaration should be terminated by a semicolon",
+      links: [],
+      id: "TrailingSemicolon",
+      path: "test.scss",
+      object: nil,
+      git_blame_info: nil,
+      location: { start_line: 2 }
+    }
+  ],
+  analyzer: { name: "SCSS-Lint", version: "0.59.0" },
+  warnings: [{ message: /SCSS-Lint is deprecated/, file: "sideci.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "syntax_error",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Syntax Error: Invalid CSS after \"  color: black;\": expected \"}\", was \"\"",
-        links: [],
-        id: "Syntax",
-        path: "err.scss",
-        object: nil,
-        git_blame_info: nil,
-        location: { start_line: 3 }
-      }
-    ],
-    analyzer: { name: "SCSS-Lint", version: "0.59.0" }
-  },
-  { warnings: [{ message: /SCSS-Lint is deprecated/, file: "sider.yml" }] }
+  type: "success",
+  issues: [
+    {
+      message: "Syntax Error: Invalid CSS after \"  color: black;\": expected \"}\", was \"\"",
+      links: [],
+      id: "Syntax",
+      path: "err.scss",
+      object: nil,
+      git_blame_info: nil,
+      location: { start_line: 3 }
+    }
+  ],
+  analyzer: { name: "SCSS-Lint", version: "0.59.0" },
+  warnings: [{ message: /SCSS-Lint is deprecated/, file: "sider.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sideci_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message:
-      "The value of the attribute `$.linter.scss_lint.config` in your `sideci.yml` is invalid. Please fix and retry.",
-    analyzer: nil
-  }
+  type: "failure",
+  message:
+    "The value of the attribute `$.linter.scss_lint.config` in your `sideci.yml` is invalid. Please fix and retry.",
+  analyzer: :_
 )

--- a/test/smokes/scss_lint/expectations.rb
+++ b/test/smokes/scss_lint/expectations.rb
@@ -45,7 +45,7 @@ s.add_test(
   analyzer: { name: "SCSS-Lint", version: "0.59.0" },
   warnings: [
     {
-      message: <<-MSG,
+      message: <<~MSG.strip,
 DEPRECATION WARNING!!!
 The support for SCSS-Lint is deprecated. Sider will drop these versions in the near future.
 Please consider using an alternative tool stylelint. See https://github.com/sds/scss-lint/blob/master/README.md#notice-consider-other-tools-before-adopting-scss-lint

--- a/test/smokes/shellcheck/expectations.rb
+++ b/test/smokes/shellcheck/expectations.rb
@@ -1,403 +1,353 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "SC2006",
-        path: "test_script",
-        location: { start_line: 3, start_column: 3, end_line: 3, end_column: 8 },
-        message: "Use $(...) notation instead of legacy backticked `...`.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2006],
-        object: { code: 2_006, severity: "style", fix: { replacements: :_ } },
-        git_blame_info: nil
+  type: "success",
+  issues: [
+    {
+      id: "SC2006",
+      path: "test_script",
+      location: { start_line: 3, start_column: 3, end_line: 3, end_column: 8 },
+      message: "Use $(...) notation instead of legacy backticked `...`.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2006],
+      object: { code: 2_006, severity: "style", fix: { replacements: :_ } },
+      git_blame_info: nil
+    },
+    {
+      id: "SC2020",
+      path: "test.bash",
+      location: { start_line: 3, start_column: 25, end_line: 3, end_column: 32 },
+      message: "tr replaces sets of chars, not words (mentioned due to duplicates).",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2020],
+      object: { code: 2_020, severity: "info", fix: nil },
+      git_blame_info: nil
+    },
+    {
+      id: "SC2034",
+      path: "test-bats",
+      location: { start_line: 3, start_column: 1, end_line: 3, end_column: 2 },
+      message: "a appears unused. Verify use (or export if used externally).",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2034],
+      object: { code: 2_034, severity: "warning", fix: nil },
+      git_blame_info: nil
+    },
+    {
+      id: "SC2034",
+      path: "test.ksh",
+      location: { start_line: 3, start_column: 1, end_line: 3, end_column: 7 },
+      message: "arr appears unused. Verify use (or export if used externally).",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2034],
+      object: { code: 2_034, severity: "warning", fix: nil },
+      git_blame_info: nil
+    },
+    {
+      id: "SC2039",
+      path: "test.sh",
+      location: { start_line: 3, start_column: 1, end_line: 3, end_column: 17 },
+      message: "In POSIX sh, [[ ]] is undefined.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2039],
+      object: { code: 2_039, severity: "warning", fix: nil },
+      git_blame_info: nil
+    },
+    {
+      id: "SC2060",
+      path: "test.dash",
+      location: { start_line: 3, start_column: 8, end_line: 3, end_column: 17 },
+      message: "Quote parameters to tr to prevent glob expansion.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2060],
+      object: { code: 2_060, severity: "warning", fix: nil },
+      git_blame_info: nil
+    },
+    {
+      id: "SC2086",
+      path: "test.bats",
+      location: { start_line: 5, start_column: 5, end_line: 5, end_column: 12 },
+      message: "Double quote to prevent globbing and word splitting.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2086],
+      object: {
+        code: 2_086,
+        severity: "info",
+        fix: {
+          replacements: [
+            {
+              line: 5,
+              column: 5,
+              endLine: 5,
+              endColumn: 5,
+              precedence: 12,
+              insertionPoint: "afterEnd",
+              replacement: "\""
+            },
+            {
+              line: 5,
+              column: 12,
+              endLine: 5,
+              endColumn: 12,
+              precedence: 12,
+              insertionPoint: "beforeStart",
+              replacement: "\""
+            }
+          ]
+        }
       },
-      {
-        id: "SC2020",
-        path: "test.bash",
-        location: { start_line: 3, start_column: 25, end_line: 3, end_column: 32 },
-        message: "tr replaces sets of chars, not words (mentioned due to duplicates).",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2020],
-        object: { code: 2_020, severity: "info", fix: nil },
-        git_blame_info: nil
-      },
-      {
-        id: "SC2034",
-        path: "test-bats",
-        location: { start_line: 3, start_column: 1, end_line: 3, end_column: 2 },
-        message: "a appears unused. Verify use (or export if used externally).",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2034],
-        object: { code: 2_034, severity: "warning", fix: nil },
-        git_blame_info: nil
-      },
-      {
-        id: "SC2034",
-        path: "test.ksh",
-        location: { start_line: 3, start_column: 1, end_line: 3, end_column: 7 },
-        message: "arr appears unused. Verify use (or export if used externally).",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2034],
-        object: { code: 2_034, severity: "warning", fix: nil },
-        git_blame_info: nil
-      },
-      {
-        id: "SC2039",
-        path: "test.sh",
-        location: { start_line: 3, start_column: 1, end_line: 3, end_column: 17 },
-        message: "In POSIX sh, [[ ]] is undefined.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2039],
-        object: { code: 2_039, severity: "warning", fix: nil },
-        git_blame_info: nil
-      },
-      {
-        id: "SC2060",
-        path: "test.dash",
-        location: { start_line: 3, start_column: 8, end_line: 3, end_column: 17 },
-        message: "Quote parameters to tr to prevent glob expansion.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2060],
-        object: { code: 2_060, severity: "warning", fix: nil },
-        git_blame_info: nil
-      },
-      {
-        id: "SC2086",
-        path: "test.bats",
-        location: { start_line: 5, start_column: 5, end_line: 5, end_column: 12 },
-        message: "Double quote to prevent globbing and word splitting.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2086],
-        object: {
-          code: 2_086,
-          severity: "info",
-          fix: {
-            replacements: [
-              {
-                line: 5,
-                column: 5,
-                endLine: 5,
-                endColumn: 5,
-                precedence: 12,
-                insertionPoint: "afterEnd",
-                replacement: "\""
-              },
-              {
-                line: 5,
-                column: 12,
-                endLine: 5,
-                endColumn: 12,
-                precedence: 12,
-                insertionPoint: "beforeStart",
-                replacement: "\""
-              }
-            ]
-          }
-        },
-        git_blame_info: nil
-      },
-      {
-        id: "SC2162",
-        path: "src/test_script2",
-        location: { start_line: 4, start_column: 1, end_line: 4, end_column: 5 },
-        message: "read without -r will mangle backslashes.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2162],
-        object: { code: 2_162, severity: "info", fix: nil },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ShellCheck", version: "0.7.0" }
-  }
+      git_blame_info: nil
+    },
+    {
+      id: "SC2162",
+      path: "src/test_script2",
+      location: { start_line: 4, start_column: 1, end_line: 4, end_column: 5 },
+      message: "read without -r will mangle backslashes.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2162],
+      object: { code: 2_162, severity: "info", fix: nil },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ShellCheck", version: "0.7.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "shellcheckrc",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "SC1091",
-        path: "test.bash",
-        location: { start_line: 7, start_column: 3, end_line: 7, end_column: 9 },
-        message: "Not following: lib.sh was not specified as input (see shellcheck -x).",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC1091],
-        object: { code: 1_091, severity: "info", fix: nil },
-        git_blame_info: nil
-      },
-      {
-        id: "SC2249",
-        path: "test.bash",
-        location: { start_line: 3, start_column: 1, end_line: 3, end_column: 36 },
-        message: "Consider adding a default *) case, even if it just exits with error.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2249],
-        object: { code: 2_249, severity: "info", fix: nil },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ShellCheck", version: "0.7.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "SC1091",
+      path: "test.bash",
+      location: { start_line: 7, start_column: 3, end_line: 7, end_column: 9 },
+      message: "Not following: lib.sh was not specified as input (see shellcheck -x).",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC1091],
+      object: { code: 1_091, severity: "info", fix: nil },
+      git_blame_info: nil
+    },
+    {
+      id: "SC2249",
+      path: "test.bash",
+      location: { start_line: 3, start_column: 1, end_line: 3, end_column: 36 },
+      message: "Consider adding a default *) case, even if it just exits with error.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2249],
+      object: { code: 2_249, severity: "info", fix: nil },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ShellCheck", version: "0.7.0" }
 )
 
-Smoke.add_test(
-  "no_files",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "ShellCheck", version: "0.7.0" } }
-)
+s.add_test("no_files", type: "success", issues: [], analyzer: { name: "ShellCheck", version: "0.7.0" })
 
-Smoke.add_test(
+s.add_test(
   "option_target",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "SC1113",
-        path: "src/test.sh",
-        location: { start_line: 1, start_column: 2, end_line: 1, end_column: 2 },
-        message: "Use #!, not just #, for the shebang.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC1113],
-        object: { code: 1_113, severity: "error", fix: nil },
-        git_blame_info: nil
-      },
-      {
-        id: "SC1113",
-        path: "test.bash",
-        location: { start_line: 1, start_column: 2, end_line: 1, end_column: 2 },
-        message: "Use #!, not just #, for the shebang.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC1113],
-        object: { code: 1_113, severity: "error", fix: nil },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ShellCheck", version: "0.7.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "SC1113",
+      path: "src/test.sh",
+      location: { start_line: 1, start_column: 2, end_line: 1, end_column: 2 },
+      message: "Use #!, not just #, for the shebang.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC1113],
+      object: { code: 1_113, severity: "error", fix: nil },
+      git_blame_info: nil
+    },
+    {
+      id: "SC1113",
+      path: "test.bash",
+      location: { start_line: 1, start_column: 2, end_line: 1, end_column: 2 },
+      message: "Use #!, not just #, for the shebang.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC1113],
+      object: { code: 1_113, severity: "error", fix: nil },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ShellCheck", version: "0.7.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_target_complex",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "SC2034",
-        path: "test.sh",
-        location: { start_line: 3, start_column: 1, end_line: 3, end_column: 4 },
-        message: "foo appears unused. Verify use (or export if used externally).",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2034],
-        object: { code: 2_034, severity: "warning", fix: nil },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ShellCheck", version: "0.7.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "SC2034",
+      path: "test.sh",
+      location: { start_line: 3, start_column: 1, end_line: 3, end_column: 4 },
+      message: "foo appears unused. Verify use (or export if used externally).",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2034],
+      object: { code: 2_034, severity: "warning", fix: nil },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ShellCheck", version: "0.7.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_include",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "SC2104",
-        path: "test.bash",
-        location: { start_line: 6, start_column: 5, end_line: 6, end_column: 10 },
-        message: "In functions, use return instead of break.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2104],
-        object: { code: 2_104, severity: "error", fix: nil },
-        git_blame_info: nil
-      },
-      {
-        id: "SC2105",
-        path: "test.bash",
-        location: { start_line: 13, start_column: 5, end_line: 13, end_column: 10 },
-        message: "break is only valid in loops.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2105],
-        object: { code: 2_105, severity: "error", fix: nil },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ShellCheck", version: "0.7.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "SC2104",
+      path: "test.bash",
+      location: { start_line: 6, start_column: 5, end_line: 6, end_column: 10 },
+      message: "In functions, use return instead of break.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2104],
+      object: { code: 2_104, severity: "error", fix: nil },
+      git_blame_info: nil
+    },
+    {
+      id: "SC2105",
+      path: "test.bash",
+      location: { start_line: 13, start_column: 5, end_line: 13, end_column: 10 },
+      message: "break is only valid in loops.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2105],
+      object: { code: 2_105, severity: "error", fix: nil },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ShellCheck", version: "0.7.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_exclude",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "SC2034",
-        path: "test.bash",
-        location: { start_line: 12, start_column: 5, end_line: 12, end_column: 12 },
-        message: "verbose appears unused. Verify use (or export if used externally).",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2034],
-        object: { code: 2_034, severity: "warning", fix: nil },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ShellCheck", version: "0.7.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "SC2034",
+      path: "test.bash",
+      location: { start_line: 12, start_column: 5, end_line: 12, end_column: 12 },
+      message: "verbose appears unused. Verify use (or export if used externally).",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2034],
+      object: { code: 2_034, severity: "warning", fix: nil },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ShellCheck", version: "0.7.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_enable",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "SC2248",
-        path: "test.bash",
-        location: { start_line: 6, start_column: 6, end_line: 6, end_column: 10 },
-        message: "Prefer double quoting even when variables don't contain special characters.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2248],
-        object: { code: 2_248, severity: "style", fix: { replacements: :_ } },
-        git_blame_info: nil
-      },
-      {
-        id: "SC2249",
-        path: "test.bash",
-        location: { start_line: 3, start_column: 1, end_line: 3, end_column: 36 },
-        message: "Consider adding a default *) case, even if it just exits with error.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2249],
-        object: { code: 2_249, severity: "info", fix: nil },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ShellCheck", version: "0.7.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "SC2248",
+      path: "test.bash",
+      location: { start_line: 6, start_column: 6, end_line: 6, end_column: 10 },
+      message: "Prefer double quoting even when variables don't contain special characters.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2248],
+      object: { code: 2_248, severity: "style", fix: { replacements: :_ } },
+      git_blame_info: nil
+    },
+    {
+      id: "SC2249",
+      path: "test.bash",
+      location: { start_line: 3, start_column: 1, end_line: 3, end_column: 36 },
+      message: "Consider adding a default *) case, even if it just exits with error.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2249],
+      object: { code: 2_249, severity: "info", fix: nil },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ShellCheck", version: "0.7.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_enable_all",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "SC2248",
-        path: "test.bash",
-        location: { start_line: 6, start_column: 6, end_line: 6, end_column: 10 },
-        message: "Prefer double quoting even when variables don't contain special characters.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2248],
-        object: { code: 2_248, severity: "style", fix: { replacements: :_ } },
-        git_blame_info: nil
-      },
-      {
-        id: "SC2249",
-        path: "test.bash",
-        location: { start_line: 3, start_column: 1, end_line: 3, end_column: 36 },
-        message: "Consider adding a default *) case, even if it just exits with error.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2249],
-        object: { code: 2_249, severity: "info", fix: nil },
-        git_blame_info: nil
-      },
-      {
-        id: "SC2250",
-        path: "test.bash",
-        location: { start_line: 6, start_column: 6, end_line: 6, end_column: 10 },
-        message: "Prefer putting braces around variable references even when not strictly required.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2250],
-        object: { code: 2_250, severity: "style", fix: { replacements: :_ } },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ShellCheck", version: "0.7.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "SC2248",
+      path: "test.bash",
+      location: { start_line: 6, start_column: 6, end_line: 6, end_column: 10 },
+      message: "Prefer double quoting even when variables don't contain special characters.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2248],
+      object: { code: 2_248, severity: "style", fix: { replacements: :_ } },
+      git_blame_info: nil
+    },
+    {
+      id: "SC2249",
+      path: "test.bash",
+      location: { start_line: 3, start_column: 1, end_line: 3, end_column: 36 },
+      message: "Consider adding a default *) case, even if it just exits with error.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2249],
+      object: { code: 2_249, severity: "info", fix: nil },
+      git_blame_info: nil
+    },
+    {
+      id: "SC2250",
+      path: "test.bash",
+      location: { start_line: 6, start_column: 6, end_line: 6, end_column: 10 },
+      message: "Prefer putting braces around variable references even when not strictly required.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2250],
+      object: { code: 2_250, severity: "style", fix: { replacements: :_ } },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ShellCheck", version: "0.7.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_shell",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "SC2039",
-        path: "test.bash",
-        location: { start_line: 3, start_column: 1, end_line: 3, end_column: 12 },
-        message: "In POSIX sh, [[ ]] is undefined.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2039],
-        object: { code: 2_039, severity: "warning", fix: nil },
-        git_blame_info: nil
-      },
-      {
-        id: "SC2039",
-        path: "test.sh",
-        location: { start_line: 1, start_column: 1, end_line: 1, end_column: 12 },
-        message: "In POSIX sh, [[ ]] is undefined.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2039],
-        object: { code: 2_039, severity: "warning", fix: nil },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ShellCheck", version: "0.7.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "SC2039",
+      path: "test.bash",
+      location: { start_line: 3, start_column: 1, end_line: 3, end_column: 12 },
+      message: "In POSIX sh, [[ ]] is undefined.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2039],
+      object: { code: 2_039, severity: "warning", fix: nil },
+      git_blame_info: nil
+    },
+    {
+      id: "SC2039",
+      path: "test.sh",
+      location: { start_line: 1, start_column: 1, end_line: 1, end_column: 12 },
+      message: "In POSIX sh, [[ ]] is undefined.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2039],
+      object: { code: 2_039, severity: "warning", fix: nil },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ShellCheck", version: "0.7.0" }
 )
 
-Smoke.add_test(
+s.add_test(
   "option_severity",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "SC2104",
-        path: "test.bash",
-        location: { start_line: 6, start_column: 5, end_line: 6, end_column: 10 },
-        message: "In functions, use return instead of break.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2104],
-        object: { code: 2_104, severity: "error", fix: nil },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ShellCheck", version: "0.7.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      id: "SC2104",
+      path: "test.bash",
+      location: { start_line: 6, start_column: 5, end_line: 6, end_column: 10 },
+      message: "In functions, use return instead of break.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2104],
+      object: { code: 2_104, severity: "error", fix: nil },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ShellCheck", version: "0.7.0" }
 )
 
-Smoke.add_test(
-  "option_norc",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "ShellCheck", version: "0.7.0" } }
-)
+s.add_test("option_norc", type: "success", issues: [], analyzer: { name: "ShellCheck", version: "0.7.0" })
 
 # Test specified files with the `ignore` options will be ignored.
-Smoke.add_test(
+s.add_test(
   "with_ignore",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "abc.bash",
-        location: { start_line: 3, start_column: 3, end_line: 3, end_column: 8 },
-        id: "SC2006",
-        message: "Use $(...) notation instead of legacy backticked `...`.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2006],
-        object: { code: 2_006, severity: "style", fix: { replacements: :_ } },
-        git_blame_info: nil
-      },
-      {
-        path: "abc.sh",
-        location: { start_line: 3, start_column: 3, end_line: 3, end_column: 8 },
-        id: "SC2006",
-        message: "Use $(...) notation instead of legacy backticked `...`.",
-        links: %w[https://github.com/koalaman/shellcheck/wiki/SC2006],
-        object: { code: 2_006, severity: "style", fix: { replacements: :_ } },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "ShellCheck", version: "0.7.0" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "abc.bash",
+      location: { start_line: 3, start_column: 3, end_line: 3, end_column: 8 },
+      id: "SC2006",
+      message: "Use $(...) notation instead of legacy backticked `...`.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2006],
+      object: { code: 2_006, severity: "style", fix: { replacements: :_ } },
+      git_blame_info: nil
+    },
+    {
+      path: "abc.sh",
+      location: { start_line: 3, start_column: 3, end_line: 3, end_column: 8 },
+      id: "SC2006",
+      message: "Use $(...) notation instead of legacy backticked `...`.",
+      links: %w[https://github.com/koalaman/shellcheck/wiki/SC2006],
+      object: { code: 2_006, severity: "style", fix: { replacements: :_ } },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ShellCheck", version: "0.7.0" }
 )

--- a/test/smokes/stylelint/expectations.rb
+++ b/test/smokes/stylelint/expectations.rb
@@ -478,11 +478,11 @@ s.add_test(
   issues: [],
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The `$.linter.stylelint.options` option(s) in your `sider.yml` are deprecated and will be removed in the near future.
-        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/css/stylelint ).
-      MSG
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The `$.linter.stylelint.options` option(s) in your `sider.yml` are deprecated and will be removed in the near future.
+Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/css/stylelint ).
+MSG
       file: "sider.yml"
     }
   ]

--- a/test/smokes/stylelint/expectations.rb
+++ b/test/smokes/stylelint/expectations.rb
@@ -1,665 +1,589 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    analyzer: { name: "stylelint", version: "10.0.1" },
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "test.sss",
-        location: { start_line: 2 },
-        id: "block-closing-brace-newline-before",
-        message: "Expected newline before \"}\" of a multi-line block",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/block-closing-brace-newline-before]
-      },
-      {
-        path: "test.sss",
-        location: { start_line: 1 },
-        id: "block-opening-brace-space-before",
-        message: "Expected single space before \"{\"",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/block-opening-brace-space-before]
-      },
-      {
-        path: "test.less",
-        location: { start_line: 8 },
-        id: "declaration-block-trailing-semicolon",
-        message: "Expected a trailing semicolon",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/declaration-block-trailing-semicolon]
-      },
-      {
-        path: "test.sss",
-        location: { start_line: 2 },
-        id: "declaration-block-trailing-semicolon",
-        message: "Expected a trailing semicolon",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/declaration-block-trailing-semicolon]
-      },
-      {
-        path: "test.scss",
-        location: { start_line: 2 },
-        id: "indentation",
-        message: "Expected indentation of 2 spaces",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/indentation]
-      },
-      {
-        path: "test.less",
-        location: { start_line: 11 },
-        id: "max-empty-lines",
-        message: "Expected no more than 1 empty line",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/max-empty-lines]
-      },
-      {
-        path: "test.less",
-        location: { start_line: 12 },
-        id: "max-empty-lines",
-        message: "Expected no more than 1 empty line",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/max-empty-lines]
-      },
-      {
-        path: "test.css",
-        location: { start_line: 2 },
-        id: "property-no-unknown",
-        message: "Unexpected unknown property \"someattr\"",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/property-no-unknown]
-      },
-      {
-        path: "test.scss",
-        location: { start_line: 6 },
-        id: "property-no-unknown",
-        message: "Unexpected unknown property \"font-color\"",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/property-no-unknown]
-      },
-      {
-        path: "test.scss",
-        location: { start_line: 3 },
-        id: "rule-empty-line-before",
-        message: "Expected empty line before rule",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/rule-empty-line-before]
-      },
-      {
-        path: "test.scss",
-        location: { start_line: 5 },
-        id: "rule-empty-line-before",
-        message: "Expected empty line before rule",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/rule-empty-line-before]
-      },
-      {
-        path: "test.scss",
-        location: { start_line: 11 },
-        id: "scss/dollar-variable-pattern",
-        message: "Expected $ variable name to match specified pattern",
-        object: { severity: "warning" },
-        git_blame_info: nil,
-        links: []
-      },
-      {
-        path: "test.less",
-        location: { start_line: 13 },
-        id: "selector-type-no-unknown",
-        message: "Unexpected unknown type selector \"hoge\"",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/selector-type-no-unknown]
-      }
-    ]
-  }
+  analyzer: { name: "stylelint", version: "10.0.1" },
+  type: "success",
+  issues: [
+    {
+      path: "test.sss",
+      location: { start_line: 2 },
+      id: "block-closing-brace-newline-before",
+      message: "Expected newline before \"}\" of a multi-line block",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/block-closing-brace-newline-before]
+    },
+    {
+      path: "test.sss",
+      location: { start_line: 1 },
+      id: "block-opening-brace-space-before",
+      message: "Expected single space before \"{\"",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/block-opening-brace-space-before]
+    },
+    {
+      path: "test.less",
+      location: { start_line: 8 },
+      id: "declaration-block-trailing-semicolon",
+      message: "Expected a trailing semicolon",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/declaration-block-trailing-semicolon]
+    },
+    {
+      path: "test.sss",
+      location: { start_line: 2 },
+      id: "declaration-block-trailing-semicolon",
+      message: "Expected a trailing semicolon",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/declaration-block-trailing-semicolon]
+    },
+    {
+      path: "test.scss",
+      location: { start_line: 2 },
+      id: "indentation",
+      message: "Expected indentation of 2 spaces",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/indentation]
+    },
+    {
+      path: "test.less",
+      location: { start_line: 11 },
+      id: "max-empty-lines",
+      message: "Expected no more than 1 empty line",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/max-empty-lines]
+    },
+    {
+      path: "test.less",
+      location: { start_line: 12 },
+      id: "max-empty-lines",
+      message: "Expected no more than 1 empty line",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/max-empty-lines]
+    },
+    {
+      path: "test.css",
+      location: { start_line: 2 },
+      id: "property-no-unknown",
+      message: "Unexpected unknown property \"someattr\"",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/property-no-unknown]
+    },
+    {
+      path: "test.scss",
+      location: { start_line: 6 },
+      id: "property-no-unknown",
+      message: "Unexpected unknown property \"font-color\"",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/property-no-unknown]
+    },
+    {
+      path: "test.scss",
+      location: { start_line: 3 },
+      id: "rule-empty-line-before",
+      message: "Expected empty line before rule",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/rule-empty-line-before]
+    },
+    {
+      path: "test.scss",
+      location: { start_line: 5 },
+      id: "rule-empty-line-before",
+      message: "Expected empty line before rule",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/rule-empty-line-before]
+    },
+    {
+      path: "test.scss",
+      location: { start_line: 11 },
+      id: "scss/dollar-variable-pattern",
+      message: "Expected $ variable name to match specified pattern",
+      object: { severity: "warning" },
+      git_blame_info: nil,
+      links: []
+    },
+    {
+      path: "test.less",
+      location: { start_line: 13 },
+      id: "selector-type-no-unknown",
+      message: "Unexpected unknown type selector \"hoge\"",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/selector-type-no-unknown]
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "no_config",
-  {
-    analyzer: { name: "stylelint", version: "13.2.0" },
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "test.css",
-        location: { start_line: 2 },
-        id: "color-no-invalid-hex",
-        message: "Unexpected invalid hex color \"#100000000\"",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/color-no-invalid-hex],
-        object: { severity: "error" },
-        git_blame_info: nil
-      },
-      {
-        path: "test.css",
-        location: { start_line: 1 },
-        id: "selector-type-no-unknown",
-        message: "Unexpected unknown type selector \"foo\"",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/selector-type-no-unknown],
-        object: { severity: "error" },
-        git_blame_info: nil
-      }
-    ]
-  }
+  analyzer: { name: "stylelint", version: "13.2.0" },
+  type: "success",
+  issues: [
+    {
+      path: "test.css",
+      location: { start_line: 2 },
+      id: "color-no-invalid-hex",
+      message: "Unexpected invalid hex color \"#100000000\"",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/color-no-invalid-hex],
+      object: { severity: "error" },
+      git_blame_info: nil
+    },
+    {
+      path: "test.css",
+      location: { start_line: 1 },
+      id: "selector-type-no-unknown",
+      message: "Unexpected unknown type selector \"foo\"",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/selector-type-no-unknown],
+      object: { severity: "error" },
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "analyse-only-css",
-  {
-    analyzer: { name: "stylelint", version: "13.2.0" },
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: /Error: Could not find "stylelint-config-standard"/
-  }
+  analyzer: { name: "stylelint", version: "13.2.0" },
+  type: "failure",
+  message: /Error: Could not find "stylelint-config-standard"/
 )
 
-Smoke.add_test(
-  "without-css",
-  { analyzer: { name: "stylelint", version: "13.2.0" }, guid: "test-guid", timestamp: :_, type: "success", issues: [] }
-)
+s.add_test("without-css", analyzer: { name: "stylelint", version: "13.2.0" }, type: "success", issues: [])
 
-Smoke.add_test(
-  "without-css-v9",
-  { analyzer: { name: "stylelint", version: "9.10.1" }, guid: "test-guid", timestamp: :_, type: "success", issues: [] }
-)
+s.add_test("without-css-v9", analyzer: { name: "stylelint", version: "9.10.1" }, type: "success", issues: [])
 
-Smoke.add_test(
+s.add_test(
   "with_options",
-  {
-    analyzer: { name: "stylelint", version: "8.4.0" },
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Unnecessary curly bracket",
-        links: [],
-        id: "CssSyntaxError",
-        path: "test.scss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 1 }
-      },
-      {
-        message: "Expected newline before \"}\" of a multi-line block",
-        links: %w[https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/block-closing-brace-newline-before],
-        id: "block-closing-brace-newline-before",
-        path: "test.sss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 2 }
-      },
-      {
-        message: "Expected single space before \"{\"",
-        links: %w[https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/block-opening-brace-space-before],
-        id: "block-opening-brace-space-before",
-        path: "test.sss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 1 }
-      },
-      {
-        message: "Expected a trailing semicolon",
-        links: %w[https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/declaration-block-trailing-semicolon],
-        id: "declaration-block-trailing-semicolon",
-        path: "test.sss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 2 }
-      }
-    ]
-  }
+  analyzer: { name: "stylelint", version: "8.4.0" },
+  type: "success",
+  issues: [
+    {
+      message: "Unnecessary curly bracket",
+      links: [],
+      id: "CssSyntaxError",
+      path: "test.scss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 1 }
+    },
+    {
+      message: "Expected newline before \"}\" of a multi-line block",
+      links: %w[https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/block-closing-brace-newline-before],
+      id: "block-closing-brace-newline-before",
+      path: "test.sss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 2 }
+    },
+    {
+      message: "Expected single space before \"{\"",
+      links: %w[https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/block-opening-brace-space-before],
+      id: "block-opening-brace-space-before",
+      path: "test.sss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 1 }
+    },
+    {
+      message: "Expected a trailing semicolon",
+      links: %w[https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/declaration-block-trailing-semicolon],
+      id: "declaration-block-trailing-semicolon",
+      path: "test.sss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 2 }
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "syntax-error",
-  {
-    analyzer: { name: "stylelint", version: "13.2.0" },
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Unclosed block",
-        links: [],
-        id: "CssSyntaxError",
-        path: "ng.css",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 1 }
-      },
-      {
-        message: "Unexpected unknown property \"someattr\"",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
-        id: "property-no-unknown",
-        path: "ok.css",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 2 }
-      }
-    ]
-  }
+  analyzer: { name: "stylelint", version: "13.2.0" },
+  type: "success",
+  issues: [
+    {
+      message: "Unclosed block",
+      links: [],
+      id: "CssSyntaxError",
+      path: "ng.css",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 1 }
+    },
+    {
+      message: "Unexpected unknown property \"someattr\"",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
+      id: "property-no-unknown",
+      path: "ok.css",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 2 }
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "only_stylelintrc",
-  {
-    analyzer: { name: "stylelint", version: "13.2.0" },
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Unexpected unknown property \"someattr\"",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
-        id: "property-no-unknown",
-        path: "test.css",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 2 }
-      },
-      {
-        message: "Unexpected unknown property \"font-color\"",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
-        id: "property-no-unknown",
-        path: "test.scss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 6 }
-      },
-      {
-        message: "Unexpected unknown type selector \"hoge\"",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/selector-type-no-unknown],
-        id: "selector-type-no-unknown",
-        path: "test.less",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 13 }
-      }
-    ]
-  }
+  analyzer: { name: "stylelint", version: "13.2.0" },
+  type: "success",
+  issues: [
+    {
+      message: "Unexpected unknown property \"someattr\"",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
+      id: "property-no-unknown",
+      path: "test.css",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 2 }
+    },
+    {
+      message: "Unexpected unknown property \"font-color\"",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
+      id: "property-no-unknown",
+      path: "test.scss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 6 }
+    },
+    {
+      message: "Unexpected unknown type selector \"hoge\"",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/selector-type-no-unknown],
+      id: "selector-type-no-unknown",
+      path: "test.less",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 13 }
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "only_stylelintrc_without_packages",
-  {
-    analyzer: { name: "stylelint", version: "13.2.0" },
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Expected empty line before closing brace",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/block-closing-brace-empty-line-before],
-        id: "block-closing-brace-empty-line-before",
-        path: "test.scss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 16 }
-      },
-      {
-        message: "Expected empty line before closing brace",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/block-closing-brace-empty-line-before],
-        id: "block-closing-brace-empty-line-before",
-        path: "test.scss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 17 }
-      },
-      {
-        message: "Expected empty line before closing brace",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/block-closing-brace-empty-line-before],
-        id: "block-closing-brace-empty-line-before",
-        path: "test.scss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 20 }
-      },
-      {
-        message: "Expected empty line before closing brace",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/block-closing-brace-empty-line-before],
-        id: "block-closing-brace-empty-line-before",
-        path: "test.scss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 21 }
-      },
-      {
-        message: "Expected a trailing semicolon",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/declaration-block-trailing-semicolon],
-        id: "declaration-block-trailing-semicolon",
-        path: "test.scss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 1 }
-      },
-      {
-        message: "Expected a trailing semicolon",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/declaration-block-trailing-semicolon],
-        id: "declaration-block-trailing-semicolon",
-        path: "test.scss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 19 }
-      }
-    ]
-  }
+  analyzer: { name: "stylelint", version: "13.2.0" },
+  type: "success",
+  issues: [
+    {
+      message: "Expected empty line before closing brace",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/block-closing-brace-empty-line-before],
+      id: "block-closing-brace-empty-line-before",
+      path: "test.scss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 16 }
+    },
+    {
+      message: "Expected empty line before closing brace",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/block-closing-brace-empty-line-before],
+      id: "block-closing-brace-empty-line-before",
+      path: "test.scss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 17 }
+    },
+    {
+      message: "Expected empty line before closing brace",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/block-closing-brace-empty-line-before],
+      id: "block-closing-brace-empty-line-before",
+      path: "test.scss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 20 }
+    },
+    {
+      message: "Expected empty line before closing brace",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/block-closing-brace-empty-line-before],
+      id: "block-closing-brace-empty-line-before",
+      path: "test.scss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 21 }
+    },
+    {
+      message: "Expected a trailing semicolon",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/declaration-block-trailing-semicolon],
+      id: "declaration-block-trailing-semicolon",
+      path: "test.scss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 1 }
+    },
+    {
+      message: "Expected a trailing semicolon",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/declaration-block-trailing-semicolon],
+      id: "declaration-block-trailing-semicolon",
+      path: "test.scss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 19 }
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "pinned_stylelint_version",
-  {
-    analyzer: nil,
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: /Your `stylelint` settings could not satisfy the required constraints/
-  }
+  analyzer: :_, type: "failure", message: /Your `stylelint` settings could not satisfy the required constraints/
 )
 
-Smoke.add_test(
+s.add_test(
   "only_stylelint_in_package_json",
-  {
-    analyzer: { name: "stylelint", version: "8.4.0" },
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Unexpected missing generic font family",
-        links: %w[
-          https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/font-family-no-missing-generic-family-keyword
-        ],
-        id: "font-family-no-missing-generic-family-keyword",
-        path: "test.css",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 6 }
-      },
-      {
-        message: "Unexpected unknown property \"someattr\"",
-        links: %w[https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/property-no-unknown],
-        id: "property-no-unknown",
-        path: "test.css",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 2 }
-      },
-      {
-        message: "Unexpected unknown type selector \"hoge\"",
-        links: %w[https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/selector-type-no-unknown],
-        id: "selector-type-no-unknown",
-        path: "test.less",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 13 }
-      }
-    ]
-  }
+  analyzer: { name: "stylelint", version: "8.4.0" },
+  type: "success",
+  issues: [
+    {
+      message: "Unexpected missing generic font family",
+      links: %w[
+        https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/font-family-no-missing-generic-family-keyword
+      ],
+      id: "font-family-no-missing-generic-family-keyword",
+      path: "test.css",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 6 }
+    },
+    {
+      message: "Unexpected unknown property \"someattr\"",
+      links: %w[https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/property-no-unknown],
+      id: "property-no-unknown",
+      path: "test.css",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 2 }
+    },
+    {
+      message: "Unexpected unknown type selector \"hoge\"",
+      links: %w[https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/selector-type-no-unknown],
+      id: "selector-type-no-unknown",
+      path: "test.less",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 13 }
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "npm_install_without_stylelint",
-  {
-    analyzer: { name: "stylelint", version: "13.2.0" },
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Expected a trailing semicolon",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/declaration-block-trailing-semicolon],
-        id: "declaration-block-trailing-semicolon",
-        path: "test.less",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 8 }
-      },
-      {
-        message: "Expected indentation of 2 spaces",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/indentation],
-        id: "indentation",
-        path: "test.scss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 2 }
-      },
-      {
-        message: "Expected no more than 1 empty line",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/max-empty-lines],
-        id: "max-empty-lines",
-        path: "test.less",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 11 }
-      },
-      {
-        message: "Expected no more than 1 empty line",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/max-empty-lines],
-        id: "max-empty-lines",
-        path: "test.less",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 12 }
-      },
-      {
-        message: "Unexpected unknown property \"font-color\"",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
-        id: "property-no-unknown",
-        path: "test.scss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 6 }
-      },
-      {
-        message: "Expected empty line before rule",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/rule-empty-line-before],
-        id: "rule-empty-line-before",
-        path: "test.scss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 3 }
-      },
-      {
-        message: "Expected empty line before rule",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/rule-empty-line-before],
-        id: "rule-empty-line-before",
-        path: "test.scss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 5 }
-      },
-      {
-        message: "Unexpected unknown type selector \"hoge\"",
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/selector-type-no-unknown],
-        id: "selector-type-no-unknown",
-        path: "test.less",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 13 }
-      }
-    ]
-  },
-  {
-    warnings: [
-      { message: /The required dependency `stylelint` may not have been correctly installed/, file: "package.json" }
-    ]
-  }
+  analyzer: { name: "stylelint", version: "13.2.0" },
+  type: "success",
+  issues: [
+    {
+      message: "Expected a trailing semicolon",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/declaration-block-trailing-semicolon],
+      id: "declaration-block-trailing-semicolon",
+      path: "test.less",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 8 }
+    },
+    {
+      message: "Expected indentation of 2 spaces",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/indentation],
+      id: "indentation",
+      path: "test.scss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 2 }
+    },
+    {
+      message: "Expected no more than 1 empty line",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/max-empty-lines],
+      id: "max-empty-lines",
+      path: "test.less",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 11 }
+    },
+    {
+      message: "Expected no more than 1 empty line",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/max-empty-lines],
+      id: "max-empty-lines",
+      path: "test.less",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 12 }
+    },
+    {
+      message: "Unexpected unknown property \"font-color\"",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
+      id: "property-no-unknown",
+      path: "test.scss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 6 }
+    },
+    {
+      message: "Expected empty line before rule",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/rule-empty-line-before],
+      id: "rule-empty-line-before",
+      path: "test.scss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 3 }
+    },
+    {
+      message: "Expected empty line before rule",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/rule-empty-line-before],
+      id: "rule-empty-line-before",
+      path: "test.scss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 5 }
+    },
+    {
+      message: "Unexpected unknown type selector \"hoge\"",
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/selector-type-no-unknown],
+      id: "selector-type-no-unknown",
+      path: "test.less",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 13 }
+    }
+  ],
+  warnings: [
+    { message: /The required dependency `stylelint` may not have been correctly installed/, file: "package.json" }
+  ]
 )
 
-Smoke.add_test(
-  "failed_to_npm_install",
-  { analyzer: nil, guid: "test-guid", timestamp: :_, type: "failure", message: /`npm install` failed./ }
-)
+s.add_test("failed_to_npm_install", analyzer: :_, type: "failure", message: /`npm install` failed./)
 
-Smoke.add_test(
+s.add_test(
   "without_npm_install",
-  {
-    analyzer: { 'name': "stylelint", version: "8.4.0" },
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: /Could not find "stylelint-processor-html"/
-  }
+  analyzer: { 'name': "stylelint", version: "8.4.0" },
+  type: "failure",
+  message: /Could not find "stylelint-processor-html"/
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sideci_yml",
-  {
-    analyzer: nil,
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message:
-      "The value of the attribute `$.linter.stylelint.options.ignore-path` in your `sideci.yml` is invalid. Please fix and retry."
-  }
+  analyzer: :_,
+  type: "failure",
+  message:
+    "The value of the attribute `$.linter.stylelint.options.ignore-path` in your `sideci.yml` is invalid. Please fix and retry."
 )
 
-Smoke.add_test(
+s.add_test(
   "options_is_deprecated",
-  { analyzer: { name: "stylelint", version: "13.2.0" }, guid: "test-guid", timestamp: :_, type: "success", issues: [] },
-  {
-    warnings: [
-      {
-        message: <<~MSG
-    DEPRECATION WARNING!!!
-    The `$.linter.stylelint.options` option(s) in your `sider.yml` are deprecated and will be removed in the near future.
-    Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/css/stylelint ).
-  MSG
-          .strip,
-        file: "sider.yml"
-      }
-    ]
-  }
+  analyzer: { name: "stylelint", version: "13.2.0" },
+  type: "success",
+  issues: [],
+  warnings: [
+    {
+      message: <<~MSG,
+        DEPRECATION WARNING!!!
+        The `$.linter.stylelint.options` option(s) in your `sider.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/css/stylelint ).
+      MSG
+      file: "sider.yml"
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "additional_options",
-  {
-    analyzer: { 'name': "stylelint", version: "9.10.1" },
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Expected newline before \"}\" of a multi-line block",
-        links: %w[https://github.com/stylelint/stylelint/tree/9.10.1/lib/rules/block-closing-brace-newline-before],
-        id: "block-closing-brace-newline-before",
-        path: "test.sss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 2 }
-      },
-      {
-        message: "Expected single space before \"{\"",
-        links: %w[https://github.com/stylelint/stylelint/tree/9.10.1/lib/rules/block-opening-brace-space-before],
-        id: "block-opening-brace-space-before",
-        path: "test.sss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 1 }
-      },
-      {
-        message: "Expected a trailing semicolon",
-        links: %w[https://github.com/stylelint/stylelint/tree/9.10.1/lib/rules/declaration-block-trailing-semicolon],
-        id: "declaration-block-trailing-semicolon",
-        path: "test.sss",
-        object: { severity: "error" },
-        git_blame_info: nil,
-        location: { start_line: 2 }
-      }
-    ]
-  }
+  analyzer: { 'name': "stylelint", version: "9.10.1" },
+  type: "success",
+  issues: [
+    {
+      message: "Expected newline before \"}\" of a multi-line block",
+      links: %w[https://github.com/stylelint/stylelint/tree/9.10.1/lib/rules/block-closing-brace-newline-before],
+      id: "block-closing-brace-newline-before",
+      path: "test.sss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 2 }
+    },
+    {
+      message: "Expected single space before \"{\"",
+      links: %w[https://github.com/stylelint/stylelint/tree/9.10.1/lib/rules/block-opening-brace-space-before],
+      id: "block-opening-brace-space-before",
+      path: "test.sss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 1 }
+    },
+    {
+      message: "Expected a trailing semicolon",
+      links: %w[https://github.com/stylelint/stylelint/tree/9.10.1/lib/rules/declaration-block-trailing-semicolon],
+      id: "declaration-block-trailing-semicolon",
+      path: "test.sss",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 2 }
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "allow_empty_input_option_with_v10.0.0",
-  {
-    analyzer: { 'name': "stylelint", version: "10.0.0" }, guid: "test-guid", timestamp: :_, type: "success", issues: []
-  }
+  analyzer: { 'name': "stylelint", version: "10.0.0" }, type: "success", issues: []
 )
 
-Smoke.add_test(
+s.add_test(
   "mismatched_yarnlock_and_package_json",
-  {
-    analyzer: nil,
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "`yarn install` failed. Please confirm `yarn.lock` is consistent with `package.json`."
-  }
+  analyzer: :_,
+  type: "failure",
+  message: "`yarn install` failed. Please confirm `yarn.lock` is consistent with `package.json`."
 )
 
-Smoke.add_test(
+s.add_test(
   "default_glob",
-  {
-    analyzer: { name: "stylelint", version: "13.2.0" },
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "a.css",
-        id: "property-no-unknown",
-        message: /Unexpected unknown property/,
-        location: { start_line: 2 },
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
-        object: { severity: "error" },
-        git_blame_info: nil
-      },
-      {
-        path: "a.less",
-        id: "property-no-unknown",
-        message: /Unexpected unknown property/,
-        location: { start_line: 2 },
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
-        object: { severity: "error" },
-        git_blame_info: nil
-      },
-      {
-        path: "a.sass",
-        id: "property-no-unknown",
-        message: /Unexpected unknown property/,
-        location: { start_line: 2 },
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
-        object: { severity: "error" },
-        git_blame_info: nil
-      },
-      {
-        path: "a.scss",
-        id: "property-no-unknown",
-        message: /Unexpected unknown property/,
-        location: { start_line: 2 },
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
-        object: { severity: "error" },
-        git_blame_info: nil
-      },
-      {
-        path: "a.sss",
-        id: "property-no-unknown",
-        message: /Unexpected unknown property/,
-        location: { start_line: 2 },
-        links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
-        object: { severity: "error" },
-        git_blame_info: nil
-      }
-    ]
-  }
+  analyzer: { name: "stylelint", version: "13.2.0" },
+  type: "success",
+  issues: [
+    {
+      path: "a.css",
+      id: "property-no-unknown",
+      message: /Unexpected unknown property/,
+      location: { start_line: 2 },
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
+      object: { severity: "error" },
+      git_blame_info: nil
+    },
+    {
+      path: "a.less",
+      id: "property-no-unknown",
+      message: /Unexpected unknown property/,
+      location: { start_line: 2 },
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
+      object: { severity: "error" },
+      git_blame_info: nil
+    },
+    {
+      path: "a.sass",
+      id: "property-no-unknown",
+      message: /Unexpected unknown property/,
+      location: { start_line: 2 },
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
+      object: { severity: "error" },
+      git_blame_info: nil
+    },
+    {
+      path: "a.scss",
+      id: "property-no-unknown",
+      message: /Unexpected unknown property/,
+      location: { start_line: 2 },
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
+      object: { severity: "error" },
+      git_blame_info: nil
+    },
+    {
+      path: "a.sss",
+      id: "property-no-unknown",
+      message: /Unexpected unknown property/,
+      location: { start_line: 2 },
+      links: %w[https://github.com/stylelint/stylelint/tree/13.2.0/lib/rules/property-no-unknown],
+      object: { severity: "error" },
+      git_blame_info: nil
+    }
+  ]
 )

--- a/test/smokes/swiftlint/expectations.rb
+++ b/test/smokes/swiftlint/expectations.rb
@@ -1,208 +1,183 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "SwiftLint", version: "0.39.1" },
-    issues: [
-      {
-        path: "test.swift",
-        location: { start_line: 1 },
-        id: "identifier_name",
-        message: "Function name should start with a lowercase character: 'Hello田()'",
-        object: nil,
-        git_blame_info: nil,
-        links: []
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "SwiftLint", version: "0.39.1" },
+  issues: [
+    {
+      path: "test.swift",
+      location: { start_line: 1 },
+      id: "identifier_name",
+      message: "Function name should start with a lowercase character: 'Hello田()'",
+      object: nil,
+      git_blame_info: nil,
+      links: []
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "sideciyml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "SwiftLint", version: "0.39.1" },
-    issues: [
-      {
-        path: "test.swift",
-        location: { start_line: 1 },
-        id: "class_delegate_protocol",
-        message: "Delegate protocols should be class-only so they can be weakly referenced.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "test.swift",
-        location: { start_line: 6 },
-        id: "closure_parameter_position",
-        message: "Closure parameters should be on the same line as opening brace.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "test.swift",
-        location: { start_line: 1 },
-        id: "explicit_acl",
-        message: "All declarations should specify Access Control Level keywords explicitly.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "test.swift",
-        location: { start_line: 1 },
-        id: "explicit_top_level_acl",
-        message: "Top-level declarations should specify Access Control Level keywords explicitly.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "test.swift",
-        location: { start_line: 1 },
-        id: "file_name",
-        message: "File name should match a type or extension declared in the file (if any).",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "test.swift",
-        location: { start_line: 6 },
-        id: "indentation_width",
-        message: "Code should be indented using one tab or 4 spaces.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "test.swift",
-        location: { start_line: 8 },
-        id: "multiline_arguments_brackets",
-        message: "Multiline arguments should have their surrounding brackets in a new line.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "test.swift",
-        location: { start_line: 5 },
-        id: "trailing_closure",
-        message: "Trailing closure syntax should be used whenever possible.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "test.swift",
-        location: { start_line: 2 },
-        id: "trailing_whitespace",
-        message: "Lines should not have trailing whitespace.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "test.swift",
-        location: { start_line: 2 },
-        id: "vertical_whitespace_closing_braces",
-        message: "Don't include vertical whitespace (empty line) before closing braces.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        path: "test.swift",
-        location: { start_line: 2 },
-        id: "vertical_whitespace_opening_braces",
-        message: "Don't include vertical whitespace (empty line) after opening braces.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "SwiftLint", version: "0.39.1" },
+  issues: [
+    {
+      path: "test.swift",
+      location: { start_line: 1 },
+      id: "class_delegate_protocol",
+      message: "Delegate protocols should be class-only so they can be weakly referenced.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "test.swift",
+      location: { start_line: 6 },
+      id: "closure_parameter_position",
+      message: "Closure parameters should be on the same line as opening brace.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "test.swift",
+      location: { start_line: 1 },
+      id: "explicit_acl",
+      message: "All declarations should specify Access Control Level keywords explicitly.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "test.swift",
+      location: { start_line: 1 },
+      id: "explicit_top_level_acl",
+      message: "Top-level declarations should specify Access Control Level keywords explicitly.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "test.swift",
+      location: { start_line: 1 },
+      id: "file_name",
+      message: "File name should match a type or extension declared in the file (if any).",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "test.swift",
+      location: { start_line: 6 },
+      id: "indentation_width",
+      message: "Code should be indented using one tab or 4 spaces.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "test.swift",
+      location: { start_line: 8 },
+      id: "multiline_arguments_brackets",
+      message: "Multiline arguments should have their surrounding brackets in a new line.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "test.swift",
+      location: { start_line: 5 },
+      id: "trailing_closure",
+      message: "Trailing closure syntax should be used whenever possible.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "test.swift",
+      location: { start_line: 2 },
+      id: "trailing_whitespace",
+      message: "Lines should not have trailing whitespace.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "test.swift",
+      location: { start_line: 2 },
+      id: "vertical_whitespace_closing_braces",
+      message: "Don't include vertical whitespace (empty line) before closing braces.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "test.swift",
+      location: { start_line: 2 },
+      id: "vertical_whitespace_opening_braces",
+      message: "Don't include vertical whitespace (empty line) after opening braces.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "ignore_warnings",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    analyzer: { name: "SwiftLint", version: "0.39.1" },
-    issues: [
-      {
-        path: "test.swift",
-        location: { start_line: 3 },
-        id: "force_cast",
-        message: "Force casts should be avoided.",
-        object: nil,
-        git_blame_info: nil,
-        links: []
-      }
-    ]
-  }
+  type: "success",
+  analyzer: { name: "SwiftLint", version: "0.39.1" },
+  issues: [
+    {
+      path: "test.swift",
+      location: { start_line: 3 },
+      id: "force_cast",
+      message: "Force casts should be avoided.",
+      object: nil,
+      git_blame_info: nil,
+      links: []
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "no_swift_file",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "SwiftLint", version: "0.39.1" } },
-  { warnings: [{ message: "No lintable files found.", file: nil }] }
+  type: "success",
+  issues: [],
+  analyzer: { name: "SwiftLint", version: "0.39.1" },
+  warnings: [{ message: "No lintable files found.", file: nil }]
 )
 
-Smoke.add_test(
+s.add_test(
   "no_config_file",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: /\ASwiftLint aborted\.\n(.+)\nCould not read configuration file at path (.+)/m,
-    analyzer: { name: "SwiftLint", version: "0.39.1" }
-  },
-  {
-    warnings: [
-      {
-        message: <<~MSG
-    DEPRECATION WARNING!!!
-    The `$.linter.swiftlint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-    Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/swift/swiftlint ).
-  MSG
-          .strip,
-        file: "sideci.yml"
-      }
-    ]
-  }
+  type: "failure",
+  message: /\ASwiftLint aborted\.\n(.+)\nCould not read configuration file at path (.+)/m,
+  analyzer: { name: "SwiftLint", version: "0.39.1" },
+  warnings: [
+    {
+      message: <<~MSG,
+        DEPRECATION WARNING!!!
+        The `$.linter.swiftlint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/swift/swiftlint ).
+      MSG
+      file: "sideci.yml"
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sideci_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message:
-      "The value of the attribute `$.linter.swiftlint.lenient` in your `sideci.yml` is invalid. Please fix and retry.",
-    analyzer: nil
-  }
+  type: "failure",
+  message:
+    "The value of the attribute `$.linter.swiftlint.lenient` in your `sideci.yml` is invalid. Please fix and retry.",
+  analyzer: :_
 )
 
-Smoke.add_test(
+s.add_test(
   "wrong_swiftlint_version_set",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    # TODO: The message sometimes can be "". It should be "Loading configuration from '.swiftlint.yml'".
-    message: :_,
-    analyzer: { name: "SwiftLint", version: "0.39.1" }
-  }
+  type: "failure",
+  # TODO: The message sometimes can be "". It should be "Loading configuration from '.swiftlint.yml'".
+  message: :_,
+  analyzer: { name: "SwiftLint", version: "0.39.1" }
 )

--- a/test/smokes/swiftlint/expectations.rb
+++ b/test/smokes/swiftlint/expectations.rb
@@ -156,11 +156,11 @@ s.add_test(
   analyzer: { name: "SwiftLint", version: "0.39.1" },
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The `$.linter.swiftlint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/swift/swiftlint ).
-      MSG
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The `$.linter.swiftlint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/swift/swiftlint ).
+MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/tslint/expectations.rb
+++ b/test/smokes/tslint/expectations.rb
@@ -1,363 +1,307 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "no-console",
-        path: "range.ts",
-        location: { start_line: 11, end_line: 11 },
-        message: "Calls to 'console.log' are not allowed.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        id: "no-shadowed-variable",
-        path: "range.ts",
-        location: { start_line: 1, end_line: 1 },
-        message: "Shadowed name: 'range'",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "TSLint", version: "6.0.0" }
-  },
-  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
+  type: "success",
+  issues: [
+    {
+      id: "no-console",
+      path: "range.ts",
+      location: { start_line: 11, end_line: 11 },
+      message: "Calls to 'console.log' are not allowed.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      id: "no-shadowed-variable",
+      path: "range.ts",
+      location: { start_line: 1, end_line: 1 },
+      message: "Shadowed name: 'range'",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "TSLint", version: "6.0.0" },
+  warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "with-tslint-json",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "trailing-comma",
-        path: "range.ts",
-        location: { start_line: 8, end_line: 8 },
-        message: "Missing trailing comma",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "TSLint", version: "6.0.0" }
-  },
-  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
+  type: "success",
+  issues: [
+    {
+      id: "trailing-comma",
+      path: "range.ts",
+      location: { start_line: 8, end_line: 8 },
+      message: "Missing trailing comma",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "TSLint", version: "6.0.0" },
+  warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "npm-install",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "interface-name",
-        path: "hello.tsx",
-        location: { start_line: 3, end_line: 3 },
-        message: "interface name must start with a capitalized I",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        id: "jsx-self-close",
-        path: "hello.tsx",
-        location: { start_line: 12, end_line: 12 },
-        message: "JSX elements with no children must be self-closing",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        id: "member-access",
-        path: "hello.tsx",
-        location: { start_line: 8, end_line: 8 },
-        message: "The class method 'render' must be marked either 'private', 'public', or 'protected'",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "TSLint", version: "5.2.0" }
-  },
-  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
+  type: "success",
+  issues: [
+    {
+      id: "interface-name",
+      path: "hello.tsx",
+      location: { start_line: 3, end_line: 3 },
+      message: "interface name must start with a capitalized I",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      id: "jsx-self-close",
+      path: "hello.tsx",
+      location: { start_line: 12, end_line: 12 },
+      message: "JSX elements with no children must be self-closing",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      id: "member-access",
+      path: "hello.tsx",
+      location: { start_line: 8, end_line: 8 },
+      message: "The class method 'render' must be marked either 'private', 'public', or 'protected'",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "TSLint", version: "5.2.0" },
+  warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "custom-rules",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "no-cats",
-        path: "cat.ts",
-        location: { start_line: 11, end_line: 16 },
-        message: "Meow!",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "TSLint", version: "5.4.3" }
-  },
-  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
+  type: "success",
+  issues: [
+    {
+      id: "no-cats",
+      path: "cat.ts",
+      location: { start_line: 11, end_line: 16 },
+      message: "Meow!",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "TSLint", version: "5.4.3" },
+  warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "tsconfig",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "no-console",
-        path: "range.ts",
-        location: { start_line: 11, end_line: 11 },
-        message: "Calls to 'console.log' are not allowed.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        id: "no-shadowed-variable",
-        path: "range.ts",
-        location: { start_line: 1, end_line: 1 },
-        message: "Shadowed name: 'range'",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "TSLint", version: "6.0.0" }
-  },
-  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sideci.yml" }] }
+  type: "success",
+  issues: [
+    {
+      id: "no-console",
+      path: "range.ts",
+      location: { start_line: 11, end_line: 11 },
+      message: "Calls to 'console.log' are not allowed.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      id: "no-shadowed-variable",
+      path: "range.ts",
+      location: { start_line: 1, end_line: 1 },
+      message: "Shadowed name: 'range'",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "TSLint", version: "6.0.0" },
+  warnings: [{ message: /The support for TSLint is deprecated/, file: "sideci.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "raise-deprecated",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: <<~MESSAGE,
-      --type-check is deprecated. You only need --project to enable rules which need type information.
-      Error at range.ts:2:18: Property 'min' does not exist on type 'string'.
-      Error at range.ts:2:31: Property 'middle' does not exist on type 'string'.
-      Error at range.ts:2:47: Property 'middle' does not exist on type 'string'.
-      Error at range.ts:2:63: Property 'max' does not exist on type 'string'.
-      Error at range.ts:11:24: Argument of type '{ min: number; middle: number; max: number; }' is not assignable to parameter of type 'string'.
-      MESSAGE
-    analyzer: { name: "TSLint", version: "6.0.0" }
-  },
-  {
-    warnings: [
-      {
-        message: <<~MSG
-          DEPRECATION WARNING!!!
-          The support for TSLint is deprecated. Sider will drop these versions on December 1, 2020.
-          Please consider using an alternative tool ESLint. See https://github.com/palantir/tslint/issues/4534
-        MSG
-          .strip,
-        file: "sideci.yml"
-      }
-    ]
-  }
+  type: "failure",
+  message: <<~MESSAGE
+    --type-check is deprecated. You only need --project to enable rules which need type information.
+    Error at range.ts:2:18: Property 'min' does not exist on type 'string'.
+    Error at range.ts:2:31: Property 'middle' does not exist on type 'string'.
+    Error at range.ts:2:47: Property 'middle' does not exist on type 'string'.
+    Error at range.ts:2:63: Property 'max' does not exist on type 'string'.
+    Error at range.ts:11:24: Argument of type '{ min: number; middle: number; max: number; }' is not assignable to parameter of type 'string'.
+  MESSAGE,
+  analyzer: { name: "TSLint", version: "6.0.0" },
+  warnings: [
+    {
+      message: <<~MSG,
+        DEPRECATION WARNING!!!
+        The support for TSLint is deprecated. Sider will drop these versions on December 1, 2020.
+        Please consider using an alternative tool ESLint. See https://github.com/palantir/tslint/issues/4534
+      MSG
+      file: "sideci.yml"
+    }
+  ]
 )
 
-Smoke.add_test(
+s.add_test(
   "deprecated-rules",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "no-unused-variable",
-        path: "index.ts",
-        location: { start_line: 2, end_line: 2 },
-        message: "'a' is declared but its value is never read.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        id: "no-unused-variable",
-        path: "index.ts",
-        location: { start_line: 2, end_line: 2 },
-        message: "'b' is declared but its value is never read.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        id: "no-unused-variable",
-        path: "index.ts",
-        location: { start_line: 5, end_line: 5 },
-        message: "All destructured elements are unused.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "TSLint", version: "5.11.0" }
-  },
-  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sideci.yml" }] }
+  type: "success",
+  issues: [
+    {
+      id: "no-unused-variable",
+      path: "index.ts",
+      location: { start_line: 2, end_line: 2 },
+      message: "'a' is declared but its value is never read.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      id: "no-unused-variable",
+      path: "index.ts",
+      location: { start_line: 2, end_line: 2 },
+      message: "'b' is declared but its value is never read.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      id: "no-unused-variable",
+      path: "index.ts",
+      location: { start_line: 5, end_line: 5 },
+      message: "All destructured elements are unused.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "TSLint", version: "5.11.0" },
+  warnings: [{ message: /The support for TSLint is deprecated/, file: "sideci.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "broken_sideci_yml",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message:
-      "The value of the attribute `$.linter.tslint.config` in your `sideci.yml` is invalid. Please fix and retry.",
-    analyzer: nil
-  }
+  type: "failure",
+  message: "The value of the attribute `$.linter.tslint.config` in your `sideci.yml` is invalid. Please fix and retry.",
+  analyzer: :_
 )
 
-Smoke.add_test(
+s.add_test(
   "with_options",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Type declaration of 'any' loses type-safety. Consider replacing it with a more precise type.",
-        links: [],
-        id: "no-any",
-        path: "src/range.ts",
-        location: { start_line: 1, end_line: 1 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "TSLint", version: "5.15.0" }
-  },
-  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sideci.yml" }] }
+  type: "success",
+  issues: [
+    {
+      message: "Type declaration of 'any' loses type-safety. Consider replacing it with a more precise type.",
+      links: [],
+      id: "no-any",
+      path: "src/range.ts",
+      location: { start_line: 1, end_line: 1 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "TSLint", version: "5.15.0" },
+  warnings: [{ message: /The support for TSLint is deprecated/, file: "sideci.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "rules-dir",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "no-cats",
-        path: "cat.ts",
-        location: { start_line: 11, end_line: 16 },
-        message: "Meow!",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "TSLint", version: "5.15.0" }
-  },
-  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sideci.yml" }] }
+  type: "success",
+  issues: [
+    {
+      id: "no-cats",
+      path: "cat.ts",
+      location: { start_line: 11, end_line: 16 },
+      message: "Meow!",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "TSLint", version: "5.15.0" },
+  warnings: [{ message: /The support for TSLint is deprecated/, file: "sideci.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "multiple-custom-rules",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        message: "Meow!",
-        links: [],
-        id: "no-cats",
-        path: "cat.ts",
-        location: { start_line: 11, end_line: 16 },
-        object: nil,
-        git_blame_info: nil
-      },
-      {
-        message: "Bow!",
-        links: [],
-        id: "no-dogs",
-        path: "dog.ts",
-        location: { start_line: 11, end_line: 16 },
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "TSLint", version: "5.15.0" }
-  },
-  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sideci.yml" }] }
+  type: "success",
+  issues: [
+    {
+      message: "Meow!",
+      links: [],
+      id: "no-cats",
+      path: "cat.ts",
+      location: { start_line: 11, end_line: 16 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "Bow!",
+      links: [],
+      id: "no-dogs",
+      path: "dog.ts",
+      location: { start_line: 11, end_line: 16 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "TSLint", version: "5.15.0" },
+  warnings: [{ message: /The support for TSLint is deprecated/, file: "sideci.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "invalid-tslint-version",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: /Your `tslint` settings could not satisfy the required constraints/,
-    analyzer: nil
-  },
-  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
+  type: "failure",
+  message: /Your `tslint` settings could not satisfy the required constraints/,
+  analyzer: :_,
+  warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "without-tslint-in-package-json",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "TSLint", version: "6.0.0" } },
-  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
+  type: "success",
+  issues: [],
+  analyzer: { name: "TSLint", version: "6.0.0" },
+  warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "without-tslint-and-with-typescript-in-package-json",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "TSLint", version: "6.0.0" } },
-  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
+  type: "success",
+  issues: [],
+  analyzer: { name: "TSLint", version: "6.0.0" },
+  warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "mismatched_package_version",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "`yarn install` failed. Please confirm `yarn.lock` is consistent with `package.json`.",
-    analyzer: nil
-  },
-  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
+  type: "failure",
+  message: "`yarn install` failed. Please confirm `yarn.lock` is consistent with `package.json`.",
+  analyzer: :_,
+  warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "tslint-v6",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        id: "no-console",
-        path: "foo.ts",
-        location: { start_line: 1, end_line: 1 },
-        message: "Calls to 'console.log' are not allowed.",
-        links: [],
-        object: nil,
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "TSLint", version: "6.0.0" }
-  },
-  { warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }] }
+  type: "success",
+  issues: [
+    {
+      id: "no-console",
+      path: "foo.ts",
+      location: { start_line: 1, end_line: 1 },
+      message: "Calls to 'console.log' are not allowed.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "TSLint", version: "6.0.0" },
+  warnings: [{ message: /The support for TSLint is deprecated/, file: "sider.yml" }]
 )

--- a/test/smokes/tslint/expectations.rb
+++ b/test/smokes/tslint/expectations.rb
@@ -129,14 +129,14 @@ s.add_test(
 s.add_test(
   "raise-deprecated",
   type: "failure",
-  message: <<~MESSAGE
+  message: <<~MESSAGE,
     --type-check is deprecated. You only need --project to enable rules which need type information.
     Error at range.ts:2:18: Property 'min' does not exist on type 'string'.
     Error at range.ts:2:31: Property 'middle' does not exist on type 'string'.
     Error at range.ts:2:47: Property 'middle' does not exist on type 'string'.
     Error at range.ts:2:63: Property 'max' does not exist on type 'string'.
     Error at range.ts:11:24: Argument of type '{ min: number; middle: number; max: number; }' is not assignable to parameter of type 'string'.
-  MESSAGE,
+  MESSAGE
   analyzer: { name: "TSLint", version: "6.0.0" },
   warnings: [
     {

--- a/test/smokes/tslint/expectations.rb
+++ b/test/smokes/tslint/expectations.rb
@@ -130,21 +130,21 @@ s.add_test(
   "raise-deprecated",
   type: "failure",
   message: <<~MESSAGE,
-    --type-check is deprecated. You only need --project to enable rules which need type information.
-    Error at range.ts:2:18: Property 'min' does not exist on type 'string'.
-    Error at range.ts:2:31: Property 'middle' does not exist on type 'string'.
-    Error at range.ts:2:47: Property 'middle' does not exist on type 'string'.
-    Error at range.ts:2:63: Property 'max' does not exist on type 'string'.
-    Error at range.ts:11:24: Argument of type '{ min: number; middle: number; max: number; }' is not assignable to parameter of type 'string'.
-  MESSAGE
+--type-check is deprecated. You only need --project to enable rules which need type information.
+Error at range.ts:2:18: Property 'min' does not exist on type 'string'.
+Error at range.ts:2:31: Property 'middle' does not exist on type 'string'.
+Error at range.ts:2:47: Property 'middle' does not exist on type 'string'.
+Error at range.ts:2:63: Property 'max' does not exist on type 'string'.
+Error at range.ts:11:24: Argument of type '{ min: number; middle: number; max: number; }' is not assignable to parameter of type 'string'.
+MESSAGE
   analyzer: { name: "TSLint", version: "6.0.0" },
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The support for TSLint is deprecated. Sider will drop these versions on December 1, 2020.
-        Please consider using an alternative tool ESLint. See https://github.com/palantir/tslint/issues/4534
-      MSG
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The support for TSLint is deprecated. Sider will drop these versions on December 1, 2020.
+Please consider using an alternative tool ESLint. See https://github.com/palantir/tslint/issues/4534
+MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/tyscan/expectations.rb
+++ b/test/smokes/tyscan/expectations.rb
@@ -1,180 +1,147 @@
-Smoke = Runners::Testing::Smoke
+s = Runners::Testing::Smoke
 
 # Smoke test allows testing by input and output of the analysis.
 # Following example, create "success" directory and put files, configurations, etc in this directory.
 #
-Smoke.add_test(
+s.add_test(
   "success",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "index.tsx",
-        location: { start_line: 14, start_column: 19, end_line: 14, end_column: 28 },
-        id: "com.example.user_name",
-        message: "Note that the `name` is not full name, but nickname",
-        links: [],
-        object: { id: "com.example.user_name", message: "Note that the `name` is not full name, but nickname" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "TyScan", version: "0.2.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "index.tsx",
+      location: { start_line: 14, start_column: 19, end_line: 14, end_column: 28 },
+      id: "com.example.user_name",
+      message: "Note that the `name` is not full name, but nickname",
+      links: [],
+      object: { id: "com.example.user_name", message: "Note that the `name` is not full name, but nickname" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "TyScan", version: "0.2.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "default_config_not_found",
-  { guid: "test-guid", timestamp: :_, type: "success", issues: [], analyzer: { name: "TyScan", version: "0.3.1" } },
+  type: "success",
+  issues: [],
+  analyzer: { name: "TyScan", version: "0.3.1" },
   warnings: [
     {
-      message: <<~MESSAGE
+      message: <<~MESSAGE,
         `tyscan.yml` does not exist in your repository.
 
         To start performing analysis, `tyscan.yml` is required.
         See also: https://help.sider.review/tools/javascript/tyscan
       MESSAGE
-        .strip,
       file: nil
     }
   ]
 )
 
-Smoke.add_test(
+s.add_test(
   "package_json_not_found",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "index.tsx",
-        location: { start_line: 14, start_column: 19, end_line: 14, end_column: 28 },
-        id: "com.example.user_name",
-        message: "Note that the `name` is not full name, but nickname",
-        links: [],
-        object: { id: "com.example.user_name", message: "Note that the `name` is not full name, but nickname" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "TyScan", version: "0.3.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "index.tsx",
+      location: { start_line: 14, start_column: 19, end_line: 14, end_column: 28 },
+      id: "com.example.user_name",
+      message: "Note that the `name` is not full name, but nickname",
+      links: [],
+      object: { id: "com.example.user_name", message: "Note that the `name` is not full name, but nickname" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "TyScan", version: "0.3.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "typescript_not_found",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: /Your `tyscan` settings could not satisfy the required constraints/,
-    analyzer: nil
-  }
+  type: "failure", message: /Your `tyscan` settings could not satisfy the required constraints/, analyzer: :_
 )
 
-Smoke.add_test(
+s.add_test(
   "tyscan_not_found",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "index.tsx",
-        location: { start_line: 14, start_column: 19, end_line: 14, end_column: 28 },
-        id: "com.example.user_name",
-        message: "Note that the `name` is not full name, but nickname",
-        links: [],
-        object: { id: "com.example.user_name", message: "Note that the `name` is not full name, but nickname" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "TyScan", version: "0.3.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "index.tsx",
+      location: { start_line: 14, start_column: 19, end_line: 14, end_column: 28 },
+      id: "com.example.user_name",
+      message: "Note that the `name` is not full name, but nickname",
+      links: [],
+      object: { id: "com.example.user_name", message: "Note that the `name` is not full name, but nickname" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "TyScan", version: "0.3.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "invalid_pattern",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "failure",
-    message: "TyScan was failed with the exit status 1 since an unexpected error occurred.",
-    analyzer: { name: "TyScan", version: "0.2.1" }
-  },
+  type: "failure",
+  message: "TyScan was failed with the exit status 1 since an unexpected error occurred.",
+  analyzer: { name: "TyScan", version: "0.2.1" },
   warnings: [{ message: "`tyscan test` failed. It may cause an unintended match.", file: "tyscan.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "options",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "frontend/index.tsx",
-        location: { start_line: 14, start_column: 19, end_line: 14, end_column: 28 },
-        id: "com.example.user_name",
-        message: "Note that the `name` is not full name, but nickname",
-        links: [],
-        object: { id: "com.example.user_name", message: "Note that the `name` is not full name, but nickname" },
-        git_blame_info: nil
-      },
-      {
-        path: "frontend/src/index.tsx",
-        location: { start_line: 14, start_column: 19, end_line: 14, end_column: 28 },
-        id: "com.example.user_name",
-        message: "Note that the `name` is not full name, but nickname",
-        links: [],
-        object: { id: "com.example.user_name", message: "Note that the `name` is not full name, but nickname" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "TyScan", version: "0.2.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      path: "frontend/index.tsx",
+      location: { start_line: 14, start_column: 19, end_line: 14, end_column: 28 },
+      id: "com.example.user_name",
+      message: "Note that the `name` is not full name, but nickname",
+      links: [],
+      object: { id: "com.example.user_name", message: "Note that the `name` is not full name, but nickname" },
+      git_blame_info: nil
+    },
+    {
+      path: "frontend/src/index.tsx",
+      location: { start_line: 14, start_column: 19, end_line: 14, end_column: 28 },
+      id: "com.example.user_name",
+      message: "Note that the `name` is not full name, but nickname",
+      links: [],
+      object: { id: "com.example.user_name", message: "Note that the `name` is not full name, but nickname" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "TyScan", version: "0.2.1" }
 )
 
-Smoke.add_test(
+s.add_test(
   "tests_failed",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        path: "index.tsx",
-        location: { start_line: 14, start_column: 19, end_line: 14, end_column: 28 },
-        id: "com.example.user_name",
-        message: "Note that the `name` is not full name, but nickname",
-        links: [],
-        object: { id: "com.example.user_name", message: "Note that the `name` is not full name, but nickname" },
-        git_blame_info: nil
-      }
-    ],
-    analyzer: { name: "TyScan", version: "0.2.1" }
-  },
+  type: "success",
+  issues: [
+    {
+      path: "index.tsx",
+      location: { start_line: 14, start_column: 19, end_line: 14, end_column: 28 },
+      id: "com.example.user_name",
+      message: "Note that the `name` is not full name, but nickname",
+      links: [],
+      object: { id: "com.example.user_name", message: "Note that the `name` is not full name, but nickname" },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "TyScan", version: "0.2.1" },
   warnings: [{ message: "`tyscan test` failed. It may cause an unintended match.", file: "tyscan.yml" }]
 )
 
-Smoke.add_test(
+s.add_test(
   "jsx_element",
-  {
-    guid: "test-guid",
-    timestamp: :_,
-    type: "success",
-    issues: [
-      {
-        object: { id: "smoke.jsx", message: "Est-ce que nous avons confirmé français au le `id`." },
-        git_blame_info: nil,
-        message: "Est-ce que nous avons confirmé français au le `id`.",
-        links: [],
-        id: "smoke.jsx",
-        path: "index.tsx",
-        location: { start_line: 12, start_column: 7, end_line: 12, end_column: 43 }
-      }
-    ],
-    analyzer: { name: "TyScan", version: "0.2.1" }
-  }
+  type: "success",
+  issues: [
+    {
+      object: { id: "smoke.jsx", message: "Est-ce que nous avons confirmé français au le `id`." },
+      git_blame_info: nil,
+      message: "Est-ce que nous avons confirmé français au le `id`.",
+      links: [],
+      id: "smoke.jsx",
+      path: "index.tsx",
+      location: { start_line: 12, start_column: 7, end_line: 12, end_column: 43 }
+    }
+  ],
+  analyzer: { name: "TyScan", version: "0.2.1" }
 )

--- a/test/smokes/tyscan/expectations.rb
+++ b/test/smokes/tyscan/expectations.rb
@@ -27,12 +27,12 @@ s.add_test(
   analyzer: { name: "TyScan", version: "0.3.1" },
   warnings: [
     {
-      message: <<~MESSAGE,
-        `tyscan.yml` does not exist in your repository.
+      message: <<~MESSAGE.strip,
+`tyscan.yml` does not exist in your repository.
 
-        To start performing analysis, `tyscan.yml` is required.
-        See also: https://help.sider.review/tools/javascript/tyscan
-      MESSAGE
+To start performing analysis, `tyscan.yml` is required.
+See also: https://help.sider.review/tools/javascript/tyscan
+MESSAGE
       file: nil
     }
   ]


### PR DESCRIPTION
This change aims to make it easier writing a smoke test by improving the `Smoke.add_test` API.
The current API has a problem that it can produce many duplications.

I recommend [viewing the diff with ignored whitespaces](https://github.com/sider/runners/pull/989/files?diff=unified&w=1).