### PR TITLE
[GolangCI-Lint] Change default linters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - [FxCop] [roslyn-analyzers-runner](https://github.com/sider/roslyn-analyzers-runner) provides a static code analysis without running build [#971](https://github.com/sider/runners/pull/971)
 - [PMD Java] Bump pmd-java from 6.21.0 to 6.22.0 [#922](https://github.com/sider/runners/pull/922)
 - [SwiftLint] Bump SwiftLint from 0.39.1 to 0.39.2 [#938](https://github.com/sider/runners/pull/938)
+- [GolangCI-Lint] Change default linters [#1001](https://github.com/sider/runners/pull/1001)
 
 ## 0.22.4
 

--- a/images/golangci_lint/sider_golangci.yml
+++ b/images/golangci_lint/sider_golangci.yml
@@ -4,9 +4,10 @@ linters-settings:
       - diagnostic
       - performance
       - style
+
 linters:
   enable:
     - bodyclose
-    - gocyclo
-    - stylecheck
     - gocritic
+    - gocyclo
+    - golint

--- a/test/smokes/golangci_lint/expectations.rb
+++ b/test/smokes/golangci_lint/expectations.rb
@@ -188,6 +188,15 @@ s.add_test(
     },
     {
       path: "sample.go",
+      location: { start_line: 18 },
+      id: "golint",
+      message: "don't use underscores in Go names; func redundant_append should be redundantAppend",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      path: "sample.go",
       location: { start_line: 13 },
       id: "gosec:G401",
       message: "G401: Use of weak cryptographic primitive",
@@ -218,15 +227,6 @@ s.add_test(
       location: { start_line: 10 },
       id: "staticcheck:SA9003",
       message: "SA9003: empty branch",
-      links: [],
-      object: nil,
-      git_blame_info: nil
-    },
-    {
-      path: "sample.go",
-      location: { start_line: 18 },
-      id: "stylecheck:ST1003",
-      message: "ST1003: should not use underscores in Go names; func redundant_append should be redundantAppend",
       links: [],
       object: nil,
       git_blame_info: nil


### PR DESCRIPTION
This change aims to make it easy to migrate from Golint to GolangCI-Lint.

Before: [stylecheck](https://github.com/dominikh/go-tools/tree/master/stylecheck)
After: [golint](https://github.com/golang/lint)

Surely, stylecheck is a replacement for golint and adds some extra rules.
But stylecheck is a 3rd-party tool, on the other hand, golint is a standard tool.
I judge that the standard tool is more suitable as a default.

See also https://github.com/sider/runners/pull/661#issuecomment-583803958

