### PR TITLE
Extend the deadline for deprecated Go tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - [FxCop] [roslyn-analyzers-runner](https://github.com/sider/roslyn-analyzers-runner) provides a static code analysis without running build [#971](https://github.com/sider/runners/pull/971)
 - [PMD Java] Bump pmd-java from 6.21.0 to 6.22.0 [#922](https://github.com/sider/runners/pull/922)
 - [SwiftLint] Bump SwiftLint from 0.39.1 to 0.39.2 [#938](https://github.com/sider/runners/pull/938)
+- Extend the deadline for deprecated Go tools [#1002](https://github.com/sider/runners/pull/1002)
 
 ## 0.22.4
 

--- a/lib/runners/processor/go_vet.rb
+++ b/lib/runners/processor/go_vet.rb
@@ -15,7 +15,7 @@ module Runners
     def setup
       add_warning_for_deprecated_linter(alternative: analyzers.name(:golangci_lint),
                                         ref: analyzer_doc,
-                                        deadline: Time.new(2020, 4, 30))
+                                        deadline: Time.new(2020, 5, 31))
       yield
     end
 

--- a/lib/runners/processor/golint.rb
+++ b/lib/runners/processor/golint.rb
@@ -15,7 +15,7 @@ module Runners
     def setup
       add_warning_for_deprecated_linter(alternative: analyzers.name(:golangci_lint),
                                         ref: analyzer_doc,
-                                        deadline: Time.new(2020, 4, 30))
+                                        deadline: Time.new(2020, 5, 31))
       yield
     end
 

--- a/lib/runners/processor/gometalinter.rb
+++ b/lib/runners/processor/gometalinter.rb
@@ -33,7 +33,7 @@ module Runners
     def setup
       add_warning_for_deprecated_linter(alternative: analyzers.name(:golangci_lint),
                                         ref: "https://github.com/alecthomas/gometalinter/issues/590",
-                                        deadline: Time.new(2020, 4, 30))
+                                        deadline: Time.new(2020, 5, 31))
 
       with_import_path do |path|
         if path

--- a/test/smokes/go_vet/expectations.rb
+++ b/test/smokes/go_vet/expectations.rb
@@ -19,7 +19,7 @@ s.add_test(
     {
       message: <<~MSG.strip,
 DEPRECATION WARNING!!!
-The support for go vet is deprecated. Sider will drop these versions on April 30, 2020.
+The support for go vet is deprecated. Sider will drop these versions on May 31, 2020.
 Please consider using an alternative tool GolangCI-Lint. See https://help.sider.review/tools/go/govet
 MSG
       file: "sider.yml"

--- a/test/smokes/golint/expectations.rb
+++ b/test/smokes/golint/expectations.rb
@@ -19,7 +19,7 @@ s.add_test(
     {
       message: <<~MSG.strip,
 DEPRECATION WARNING!!!
-The support for Golint is deprecated. Sider will drop these versions on April 30, 2020.
+The support for Golint is deprecated. Sider will drop these versions on May 31, 2020.
 Please consider using an alternative tool GolangCI-Lint. See https://help.sider.review/tools/go/golint
 MSG
       file: "sider.yml"

--- a/test/smokes/gometalinter/expectations.rb
+++ b/test/smokes/gometalinter/expectations.rb
@@ -9,7 +9,7 @@ s.add_test(
     {
       message: <<~MSG.strip,
 DEPRECATION WARNING!!!
-The support for Go Meta Linter is deprecated. Sider will drop these versions on April 30, 2020.
+The support for Go Meta Linter is deprecated. Sider will drop these versions on May 31, 2020.
 Please consider using an alternative tool GolangCI-Lint. See https://github.com/alecthomas/gometalinter/issues/590
 MSG
       file: "sider.yml"


### PR DESCRIPTION
April 30 -> May 31

See also https://github.com/sider/sider-docs/pull/362