### PR TITLE
Run smoke tests in processors instead of threads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,7 @@ jobs:
           TAG: ${{ steps.define_vars.outputs.tag }}
       - name: Run smoke test
         run: |
+          if [[ $ANALYZER == 'swiftlint' ]]; then export JOBS=1 ; fi
           bundle exec rake docker:smoke
         env:
           ANALYZER: ${{ matrix.analyzer }}

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -34,8 +34,7 @@ module Runners
       def run
         load expectations.to_s
 
-        threads = ENV["JOBS"]&.to_i || Parallel.processor_count * 2
-        results = Parallel.map(self.class.tests, in_threads: threads) do |name, pattern|
+        results = Parallel.map(self.class.tests, in_processes: ENV["JOBS"]&.to_i) do |name, pattern|
           out = StringIO.new(''.dup)
           result = run_test(name, pattern, out)
           print out.string


### PR DESCRIPTION
SwiftLint's smoke test on CI is unstable, so this change tries to reduce the failures by running the test in 1 processor.
