### PR TITLE
Refactor Dockerfile: ShellCheck, SwiftLint, and Misspell

### DIFF
--- a/images/misspell/Dockerfile
+++ b/images/misspell/Dockerfile
@@ -4,12 +4,9 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM sider/devon_rex_base:master
 
-USER root
 ARG MISSPELL_VERSION=0.3.4
-RUN curl -sSL https://git.io/misspell -o install-misspell && \
-    chmod +x install-misspell && \
-    ./install-misspell -b /usr/local/bin "v${MISSPELL_VERSION}" && \
-    rm install-misspell && \
+
+RUN curl -fsSL https://git.io/misspell | bash -s -- -b "${RUNNER_USER_HOME}/bin" "v${MISSPELL_VERSION}" && \
     misspell -v
 
 

--- a/images/misspell/Dockerfile.erb
+++ b/images/misspell/Dockerfile.erb
@@ -1,11 +1,8 @@
 FROM sider/devon_rex_base:master
 
-USER root
 ARG MISSPELL_VERSION=0.3.4
-RUN curl -sSL https://git.io/misspell -o install-misspell && \
-    chmod +x install-misspell && \
-    ./install-misspell -b /usr/local/bin "v${MISSPELL_VERSION}" && \
-    rm install-misspell && \
+
+RUN curl -fsSL https://git.io/misspell | bash -s -- -b "${RUNNER_USER_HOME}/bin" "v${MISSPELL_VERSION}" && \
     misspell -v
 
 <%= render_erb 'images/Dockerfile.base.erb' %>

--- a/images/shellcheck/Dockerfile
+++ b/images/shellcheck/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends file && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+USER $RUNNER_USER
 
-ENV PATH ${RUNNER_USER_HOME}/bin:${PATH}
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} --from=koalaman/shellcheck:v0.7.1 /bin/shellcheck ${RUNNER_USER_HOME}/bin/
 
 

--- a/images/shellcheck/Dockerfile.erb
+++ b/images/shellcheck/Dockerfile.erb
@@ -5,8 +5,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends file && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+USER $RUNNER_USER
 
-ENV PATH ${RUNNER_USER_HOME}/bin:${PATH}
 COPY --chown=<%= chown %> --from=koalaman/shellcheck:v0.7.1 /bin/shellcheck ${RUNNER_USER_HOME}/bin/
 
 <%= render_erb 'images/Dockerfile.base.erb' %>

--- a/images/swiftlint/Dockerfile
+++ b/images/swiftlint/Dockerfile
@@ -6,8 +6,6 @@ FROM sider/devon_rex_swift:master
 
 ARG SWIFTLINT_VERSION=0.39.2
 
-ENV PATH ${RUNNER_USER_HOME}/bin:${PATH}
-
 # Build SwiftLint
 RUN cd /tmp && \
     curl -sSL --compressed https://github.com/realm/SwiftLint/archive/${SWIFTLINT_VERSION}.tar.gz | tar -xz && \

--- a/images/swiftlint/Dockerfile.erb
+++ b/images/swiftlint/Dockerfile.erb
@@ -2,8 +2,6 @@ FROM sider/devon_rex_swift:master
 
 ARG SWIFTLINT_VERSION=0.39.2
 
-ENV PATH ${RUNNER_USER_HOME}/bin:${PATH}
-
 # Build SwiftLint
 RUN cd /tmp && \
     curl -sSL --compressed https://github.com/realm/SwiftLint/archive/${SWIFTLINT_VERSION}.tar.gz | tar -xz && \


### PR DESCRIPTION
`~/bin` is set to PATH already. See https://github.com/sider/devon_rex/pull/196
