### PR TITLE
Run Sider also on dependabot branches

### DIFF
--- a/sider.yml
+++ b/sider.yml
@@ -9,7 +9,3 @@ linter:
 
 ignore:
   - test/smokes/
-
-branches:
-  exclude:
-    - /^dependabot/


### PR DESCRIPTION
Sider is necessary for PRs such as #1023.
