### PR TITLE
[Checkstyle] Shorten official issue ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - [FxCop] Bump FxCop from 2.9.8 to 3.0.0 [#1020](https://github.com/sider/runners/pull/1020)
 - [hadolint] Bump hadolint/hadolint from v1.17.5-debian to v1.17.6-debian [#1025](https://github.com/sider/runners/pull/1025)
 - [PHP_CodeSniffer] Bump squizlabs/php_codesniffer from 3.5.4 to 3.5.5 [#1032](https://github.com/sider/runners/pull/1032)
+- [Checkstyle] Shorten official issue ID [#1035](https://github.com/sider/runners/pull/1035)
 
 ## 0.22.4
 

--- a/test/smokes/checkstyle/expectations.rb
+++ b/test/smokes/checkstyle/expectations.rb
@@ -6,38 +6,38 @@ s.add_test(
   analyzer: { name: "Checkstyle", version: "8.32" },
   issues: [
     {
-      message: "The name of the outer type and the file do not match.",
-      links: %w[https://checkstyle.org/config_misc.html#OuterTypeFilename],
-      id: "com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck#b81ef5",
-      path: "src/Hello.java",
-      location: { start_line: 3 },
-      object: { severity: "warning" },
-      git_blame_info: nil
-    },
-    {
-      message: "'method def' child has incorrect indentation level 8, expected level should be 4.",
-      links: %w[https://checkstyle.org/config_misc.html#Indentation],
-      id: "com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck#2aa7da",
-      path: "src/Hello.java",
-      location: { start_line: 6 },
-      object: { severity: "warning" },
-      git_blame_info: nil
-    },
-    {
       message: "'method def modifier' has incorrect indentation level 4, expected level should be 2.",
       links: %w[https://checkstyle.org/config_misc.html#Indentation],
-      id: "com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck#d0bdde",
+      id: "IndentationCheck",
       path: "src/Hello.java",
       location: { start_line: 5 },
       object: { severity: "warning" },
       git_blame_info: nil
     },
     {
+      message: "'method def' child has incorrect indentation level 8, expected level should be 4.",
+      links: %w[https://checkstyle.org/config_misc.html#Indentation],
+      id: "IndentationCheck",
+      path: "src/Hello.java",
+      location: { start_line: 6 },
+      object: { severity: "warning" },
+      git_blame_info: nil
+    },
+    {
       message: "'method def rcurly' has incorrect indentation level 4, expected level should be 2.",
       links: %w[https://checkstyle.org/config_misc.html#Indentation],
-      id: "com.puppycrawl.tools.checkstyle.checks.indentation.IndentationCheck#e7930a",
+      id: "IndentationCheck",
       path: "src/Hello.java",
       location: { start_line: 7 },
+      object: { severity: "warning" },
+      git_blame_info: nil
+    },
+    {
+      message: "The name of the outer type and the file do not match.",
+      links: %w[https://checkstyle.org/config_misc.html#OuterTypeFilename],
+      id: "OuterTypeFilenameCheck",
+      path: "src/Hello.java",
+      location: { start_line: 3 },
       object: { severity: "warning" },
       git_blame_info: nil
     }
@@ -52,7 +52,7 @@ s.add_test(
     {
       message: "Parameter args should be final.",
       links: %w[https://checkstyle.org/config_misc.html#FinalParameters],
-      id: "com.puppycrawl.tools.checkstyle.checks.FinalParametersCheck#0bbcea",
+      id: "FinalParametersCheck",
       path: "src/Main.java",
       location: { start_line: 5 },
       object: { severity: "error" },
@@ -61,7 +61,7 @@ s.add_test(
     {
       message: "Utility classes should not have a public or default constructor.",
       links: %w[https://checkstyle.org/config_design.html#HideUtilityClassConstructor],
-      id: "com.puppycrawl.tools.checkstyle.checks.design.HideUtilityClassConstructorCheck#97f5fb",
+      id: "HideUtilityClassConstructorCheck",
       path: "src/Main.java",
       location: { start_line: 3 },
       object: { severity: "error" },
@@ -70,7 +70,7 @@ s.add_test(
     {
       message: "Missing package-info.java file.",
       links: %w[https://checkstyle.org/config_javadoc.html#JavadocPackage],
-      id: "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck#1cbcec",
+      id: "JavadocPackageCheck",
       path: "src/Main.java",
       location: { start_line: 1 },
       object: { severity: "error" },
@@ -79,7 +79,7 @@ s.add_test(
     {
       message: "Missing a Javadoc comment.",
       links: %w[https://checkstyle.org/config_javadoc.html#MissingJavadocMethod],
-      id: "com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck#0cbebf",
+      id: "MissingJavadocMethodCheck",
       path: "src/Main.java",
       location: { start_line: 5 },
       object: { severity: "error" },
@@ -108,10 +108,10 @@ s.add_test(
   type: "success",
   issues: [
     {
-      message: "Line is longer than 50 characters (found 67).",
+      message: "Line is longer than 50 characters (found 57).",
       links: %w[https://checkstyle.org/config_sizes.html#LineLength],
-      id: "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck#446163",
-      path: "src/Main.java",
+      id: "LineLengthCheck",
+      path: "myruleset.xml",
       location: { start_line: 3 },
       object: { severity: "error" },
       git_blame_info: nil
@@ -119,7 +119,7 @@ s.add_test(
     {
       message: "Line is longer than 50 characters (found 63).",
       links: %w[https://checkstyle.org/config_sizes.html#LineLength],
-      id: "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck#6a9962",
+      id: "LineLengthCheck",
       path: "myruleset.xml",
       location: { start_line: 4 },
       object: { severity: "error" },
@@ -128,17 +128,17 @@ s.add_test(
     {
       message: "Line is longer than 50 characters (found 54).",
       links: %w[https://checkstyle.org/config_sizes.html#LineLength],
-      id: "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck#8de3eb",
+      id: "LineLengthCheck",
       path: "myruleset.xml",
       location: { start_line: 8 },
       object: { severity: "error" },
       git_blame_info: nil
     },
     {
-      message: "Line is longer than 50 characters (found 57).",
+      message: "Line is longer than 50 characters (found 67).",
       links: %w[https://checkstyle.org/config_sizes.html#LineLength],
-      id: "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck#a134cc",
-      path: "myruleset.xml",
+      id: "LineLengthCheck",
+      path: "src/Main.java",
       location: { start_line: 3 },
       object: { severity: "error" },
       git_blame_info: nil


### PR DESCRIPTION
I think we no longer need to distinguish issue IDs in detail.
Too long IDs make it hard for users to read issues.

- Remove the message hash.
- Remove the rule namespace.

For example:

```diff
-com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck#a134cc
+LineLengthCheck
```

Note that this change limits to the **official** rules.
We will support for users to specify third-party rules, via the issue #1000.
