### PR TITLE
Extend `limit` option of `TraceWriter#message`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -534,6 +534,7 @@ All notable changes to this project will be documented in this file.
 - Bump default eslint from 6.4.0 to 6.5.1 [#235](https://github.com/sider/runners/pull/235)
 - Bump devon_rex images to 2.3.1 [#244](https://github.com/sider/runners/pull/244)
 - Bump rubocop from 0.74.0 to 0.75.0 [#229](https://github.com/sider/runners/pull/229)
+- Extend `limit` option of `TraceWriter#message` [#1036](https://github.com/sider/runners/pull/1036)
 
 ## 0.3.1
 

--- a/lib/runners/trace_writer.rb
+++ b/lib/runners/trace_writer.rb
@@ -37,7 +37,7 @@ module Runners
       end
     end
 
-    def message(message, recorded_at: now, max_length: 4_000, limit: 40_000, omission: "...(truncated)")
+    def message(message, recorded_at: now, max_length: 4_000, limit: 100_000, omission: "...(truncated)")
       string = masked_string(message.strip)
 
       if string.size > limit


### PR DESCRIPTION
With the current value, it seems that users feel a bit hard to view the log page.
