### PR TITLE
[Misspell] Remove excluding files safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Misc:
 - **FxCop** [roslyn-analyzers-runner](https://github.com/sider/roslyn-analyzers-runner) provides a static code analysis without running build [#971](https://github.com/sider/runners/pull/971)
 - **GolangCI-Lint** Change default linters [#1001](https://github.com/sider/runners/pull/1001)
 - **SwiftLint** Some improvements [#1005](https://github.com/sider/runners/pull/1005)
+- **Misspell** Remove excluding files safely [#1045](https://github.com/sider/runners/pull/1045)
 
 ## 0.22.4
 

--- a/lib/runners/processor/misspell.rb
+++ b/lib/runners/processor/misspell.rb
@@ -82,9 +82,13 @@ module Runners
     def delete_targets
       exclude_targets = Array(config_linter[:exclude])
       return if exclude_targets.empty?
+
       trace_writer.message "Excluding #{exclude_targets.join(', ')} ..." do
-        paths = exclude_targets.flat_map { |target| Dir.glob(working_dir + target.to_s) }.uniq
-        FileUtils.rm_r(paths, secure: true)
+        exclude_targets.each do |target|
+          current_dir.glob(target) do |path|
+            FileUtils.remove_entry_secure(path, true)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Currently when trying to delete a file or directory that does not exist, `Errno::ENOENT` error occurs.
For example:

```yaml
linters:
  misspell:
    exclude: ["not_exist/file.rb"]
```

I think this behavior is too strict, so this change is to use "force deleting".

See also:
- https://ruby-doc.org/stdlib-2.7.1/libdoc/fileutils/rdoc/FileUtils.html#method-c-remove_entry_secure
- https://ruby-doc.org/stdlib-2.7.1/libdoc/fileutils/rdoc/FileUtils.html#method-c-rm_rf
