### PR TITLE
[Misspell] Deprecate `targets` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Misc:
 - **FxCop** [roslyn-analyzers-runner](https://github.com/sider/roslyn-analyzers-runner) provides a static code analysis without running build [#971](https://github.com/sider/runners/pull/971)
 - **GolangCI-Lint** Change default linters [#1001](https://github.com/sider/runners/pull/1001)
 - **SwiftLint** Some improvements [#1005](https://github.com/sider/runners/pull/1005)
+- **Misspell** Deprecate `targets` option [#1046](https://github.com/sider/runners/pull/1046)
 
 ## 0.22.4
 

--- a/lib/runners/processor/misspell.rb
+++ b/lib/runners/processor/misspell.rb
@@ -5,6 +5,7 @@ module Runners
         fields.merge!({
                         exclude: array?(string),
                         targets: array?(string),
+                        target: array?(string),
                         locale: enum?(literal('US'), literal('UK')),
                         ignore: string?,
                         # DO NOT ADD ANY OPTIONS under `options`.
@@ -23,7 +24,7 @@ module Runners
     end
 
     def setup
-      add_warning_if_deprecated_options([:options])
+      add_warning_if_deprecated_options([:options, :targets])
       yield
     end
 
@@ -76,7 +77,7 @@ module Runners
     end
 
     def analysis_targets
-      Array(config_linter[:targets] || '.')
+      Array(config_linter[:target] || config_linter[:targets] || '.')
     end
 
     def delete_targets

--- a/test/smokes/misspell/expectations.rb
+++ b/test/smokes/misspell/expectations.rb
@@ -129,7 +129,8 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Misspell", version: "0.3.4" }
+  analyzer: { name: "Misspell", version: "0.3.4" },
+  warnings: [{ message: /DEPRECATION WARNING!!!\nThe `\$\.linter\.misspell\.targets` option/, file: "sideci.yml" }]
 )
 
 s.add_test(
@@ -218,4 +219,30 @@ s.add_test(
   message:
     "The value of the attribute `$.linter.misspell.locale` in your `sideci.yml` is invalid. Please fix and retry.",
   analyzer: :_
+)
+
+s.add_test(
+  "option_target",
+  type: "success",
+  issues: [
+    {
+      message: "\"infomation\" is a misspelling of \"information\"",
+      links: [],
+      id: "\"infomation\" is a misspelling of \"information\"",
+      path: "dir1/file.rb",
+      location: { start_line: 1, start_column: 4, end_line: 1, end_column: 14 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "\"infomation\" is a misspelling of \"information\"",
+      links: [],
+      id: "\"infomation\" is a misspelling of \"information\"",
+      path: "file1.rb",
+      location: { start_line: 1, start_column: 4, end_line: 1, end_column: 14 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Misspell", version: "0.3.4" }
 )

--- a/test/smokes/misspell/option_target/dir1/file.rb
+++ b/test/smokes/misspell/option_target/dir1/file.rb
@@ -1,0 +1,3 @@
+def infomation
+  puts 1
+end

--- a/test/smokes/misspell/option_target/dir2/file.rb
+++ b/test/smokes/misspell/option_target/dir2/file.rb
@@ -1,0 +1,3 @@
+def infomation
+  puts 1
+end

--- a/test/smokes/misspell/option_target/file1.rb
+++ b/test/smokes/misspell/option_target/file1.rb
@@ -1,0 +1,3 @@
+def infomation
+  puts 1
+end

--- a/test/smokes/misspell/option_target/file2.rb
+++ b/test/smokes/misspell/option_target/file2.rb
@@ -1,0 +1,3 @@
+def information
+  puts 1
+end

--- a/test/smokes/misspell/option_target/sider.yml
+++ b/test/smokes/misspell/option_target/sider.yml
@@ -1,0 +1,5 @@
+linter:
+  misspell:
+    target:
+      - dir1/
+      - file1.rb


### PR DESCRIPTION
Other runners support `target` option instead of `targets`. This is confusing for users.
So, this change adds `target` option and deprecates `targets` option instead.

See also:
https://github.com/sider/runners/blob/d50b250e3d496898fc9b210f74b48d7e9eb0ccd0/lib/runners/processor/cpplint.rb#L6
https://github.com/sider/runners/blob/d50b250e3d496898fc9b210f74b48d7e9eb0ccd0/lib/runners/processor/cppcheck.rb#L6

