### PR TITLE
[Refactor] Report file handling

### DIFF
--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -190,22 +190,29 @@ module Runners
       # noop by default
     end
 
-    def read_output_file(file_path)
-      file_path_s = file_path.to_s
-      trace_writer.message "Reading output from #{file_path_s}..."
-      File.read(file_path_s).tap do |output|
+    def report_file
+      @report_file ||= Tempfile.create(["#{analyzer_id}_report_", ".txt"]).path
+    end
+
+    def report_file_exist?
+      File.file? report_file
+    end
+
+    def read_report_file(file_path = report_file)
+      trace_writer.message "Reading output from #{file_path}..."
+      File.read(file_path).tap do |output|
         if output.empty?
           trace_writer.message "No output"
         else
-          trace_writer.message output, limit: 24_000 # Prevent timeout
+          trace_writer.message output
         end
       end
     end
 
     class InvalidXML < SystemError; end
 
-    def read_output_xml(file_path)
-      output = read_output_file(file_path)
+    def read_report_xml(file_path = report_file)
+      output = read_report_file(file_path)
       REXML::Document.new(output).tap do |document|
         unless document.root
           message = "Output XML is invalid from #{file_path}"
@@ -215,8 +222,8 @@ module Runners
       end
     end
 
-    def read_output_json(file_path)
-      output = read_output_file(file_path)
+    def read_report_json(file_path = report_file)
+      output = read_report_file(file_path)
       if output.empty? && block_given?
         yield
       else

--- a/lib/runners/processor/checkstyle.rb
+++ b/lib/runners/processor/checkstyle.rb
@@ -30,12 +30,10 @@ module Runners
     def analyze(changes)
       delete_unchanged_files(changes, only: ["*.java"])
 
-      output_file = Tempfile.create(["checkstyle-output-", ".xml"]).path
-
-      capture3(analyzer_bin, *check_directory, *checkstyle_args(output: output_file))
+      capture3(analyzer_bin, *check_directory, *checkstyle_args)
 
       begin
-        xml_root = read_output_xml(output_file).root
+        xml_root = read_report_xml.root
       rescue InvalidXML
         message = "Analysis failed. See the log for details."
         return Results::Failure.new(guid: guid, analyzer: analyzer, message: message)
@@ -50,10 +48,10 @@ module Runners
 
     private
 
-    def checkstyle_args(output:)
+    def checkstyle_args
       [].tap do |args|
         args << "-f" << "xml"
-        args << "-o" << output
+        args << "-o" << report_file
 
         config_file&.tap do |config|
           args << "-c" << config

--- a/lib/runners/processor/code_sniffer.rb
+++ b/lib/runners/processor/code_sniffer.rb
@@ -123,12 +123,10 @@ module Runners
     end
 
     def run_analyzer(options, target)
-      output_file = Tempfile.create(["phpcs-", ".json"]).path
-
       capture3!(
         analyzer_bin,
-        '--report=json',
-        "--report-json=#{output_file}",
+        "--report=json",
+        "--report-json=#{report_file}",
         "-q", # Enable quiet mode. See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#quieting-output
         "--runtime-set", "ignore_errors_on_exit", "1", # See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#ignoring-errors-when-generating-the-exit-code
         "--runtime-set", "ignore_warnings_on_exit", "1", # See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#ignoring-warnings-when-generating-the-exit-code
@@ -139,7 +137,7 @@ module Runners
       Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
         issues = []
 
-        read_output_json(output_file)[:files].each do |path, suggests|
+        read_report_json[:files].each do |path, suggests|
           suggests[:messages].each do |suggest|
             issues << Issue.new(
               path: relative_path(path.to_s),

--- a/lib/runners/processor/eslint.rb
+++ b/lib/runners/processor/eslint.rb
@@ -179,18 +179,17 @@ module Runners
       # NOTE: We must use the `--output-file` option because some plugins may output a non-JSON text to STDOUT.
       #
       # @see https://github.com/typescript-eslint/typescript-eslint/blob/v2.6.0/packages/typescript-estree/src/parser.ts#L237-L247
-      output_file = Tempfile.create(["eslint-", ".json"]).path
 
       _stdout, stderr, status = capture3(
         nodejs_analyzer_bin,
         "--format=#{custom_formatter}",
-        "--output-file=#{output_file}",
-        '--no-color',
+        "--output-file=#{report_file}",
+        "--no-color",
         *additional_options,
         *target_dir
       )
 
-      output_json = File.file?(output_file) ? read_output_json(output_file) { nil } : nil
+      output_json = report_file_exist? ? read_report_json { nil } : nil
 
       if [0, 1].include?(status.exitstatus) && output_json
         Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|

--- a/lib/runners/processor/flake8.rb
+++ b/lib/runners/processor/flake8.rb
@@ -118,16 +118,15 @@ module Runners
 
     def run_analyzer
       Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
-        output_path = Tempfile.create(["flake8-", ".txt"]).path
         capture3!(
           analyzer_bin,
           '--exit-zero',
-          "--output-file=#{output_path}",
+          "--output-file=#{report_file}",
           "--format=#{FLAKE8_OUTPUT_FORMAT}",
           "--append-config=#{ignored_config_path}",
           './'
         )
-        output = read_output_file(output_path)
+        output = read_report_file
         break result if output.empty?
         parse_result(output).each { |v| result.add_issue(v) }
       end

--- a/lib/runners/processor/fxcop.rb
+++ b/lib/runners/processor/fxcop.rb
@@ -17,9 +17,8 @@ module Runners
     end
 
     def analyze(changes)
-      output_file = Tempfile.create(["fxcop-", ""]).path
       capture3!('Sider.RoslynAnalyzersRunner',
-        '--outputfile', output_file,
+        '--outputfile', report_file,
         *changes
           .changed_paths
           .select{|p| p.extname.eql?(".cs")}
@@ -27,7 +26,7 @@ module Runners
           .map(&:to_s))
 
       Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
-        construct_result(result, read_output_json(output_file))
+        construct_result(result, read_report_json)
       end
     end
 

--- a/lib/runners/processor/ktlint.rb
+++ b/lib/runners/processor/ktlint.rb
@@ -87,7 +87,7 @@ module Runners
 
       output_file = gradle_config[:output]
       output = if output_file
-                 read_output_file(current_dir / output_file)
+                 read_report_file current_dir.join(output_file).to_path
                else
                  stdout
                end
@@ -102,7 +102,7 @@ module Runners
       capture3("mvn", maven_config[:goal], *mvn_options)
 
       output_file = maven_config[:output]
-      output = read_output_file(current_dir / output_file)
+      output = read_report_file current_dir.join(output_file).to_path
 
       construct_result(maven_config[:reporter], output)
     end

--- a/lib/runners/processor/misspell.rb
+++ b/lib/runners/processor/misspell.rb
@@ -45,7 +45,7 @@ module Runners
       capture3!(analyzer_bin, *cli_args, '--', *analysis_targets)
 
       Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
-        read_output_file(report_file).each_line do |line|
+        read_report_file.each_line do |line|
           match = line.match(/^(?<file>.+):(?<line>\d+):(?<col>\d+): (?<message>"(?<incorrect>.+)" is a misspelling of "(?<correct>.+)")$/)
           lineno = Integer(match[:line])
           col = Integer(match[:col])
@@ -71,10 +71,6 @@ module Runners
 
     def cli_args
       ["-o", report_file, *locale, *ignore]
-    end
-
-    def report_file
-      @report_file ||= Tempfile.create(["misspell-report-", ".txt"]).path
     end
 
     def locale

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -79,8 +79,6 @@ module Runners
     end
 
     def run_analyzer(changes, targets, rule, options)
-      report_file = Tempfile.create(["phpmd-", ".xml"]).path
-
       # PHPMD exits 1 when some violations are found.
       # The `--ignore-violation-on-exit` will exit with a zero code, even if any violations are found.
       # See https://phpmd.org/documentation/index.html
@@ -103,7 +101,7 @@ module Runners
       end
 
       begin
-        xml_doc = read_output_xml(report_file)
+        xml_doc = read_report_xml
       rescue REXML::ParseException => exn
         trace_writer.error exn.message
         return Results::Failure.new(guid: guid, analyzer: analyzer,

--- a/lib/runners/processor/pmd_java.rb
+++ b/lib/runners/processor/pmd_java.rb
@@ -36,7 +36,7 @@ module Runners
 
     private
 
-    def cli_args(report_file)
+    def cli_args
       [].tap do |args|
         args << "-language" << "java"
         args << "-threads" << "2"
@@ -50,9 +50,7 @@ module Runners
     end
 
     def run_analyzer
-      report_file = Tempfile.create(["pmd-report-", ".xml"]).path
-
-      _, stderr, status = capture3(analyzer_bin, *cli_args(report_file))
+      _, stderr, status = capture3(analyzer_bin, *cli_args)
 
       if status.success? || status.exitstatus == 4
         stderr.each_line do |line|
@@ -65,7 +63,7 @@ module Runners
         end
 
         Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
-          xml = read_output_xml(report_file)
+          xml = read_report_xml
           construct_result(xml) { result.add_issue _1 }
         end
       else

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -169,13 +169,11 @@ module Runners
     end
 
     def run_analyzer(options)
-      output_file = Tempfile.create(["rubocop-", ".json"]).path
-
       # NOTE: `--out` option must be after `--format` option.
       #
       # @see https://docs.rubocop.org/en/stable/formatters
       options << "--format=json"
-      options << "--out=#{output_file}"
+      options << "--out=#{report_file}"
 
       _, stderr, status = capture3(*ruby_analyzer_bin, *options)
       check_rubocop_yml_warning(stderr)
@@ -191,7 +189,7 @@ module Runners
         return Results::Failure.new(guid: guid, message: error_message, analyzer: analyzer)
       end
 
-      output_json = read_output_json(output_file) { nil }
+      output_json = read_report_json { nil }
 
       Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
         break result unless output_json # No offenses

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -83,6 +83,7 @@ end
 extension File (Polyfill)
   def self.basename: (String | Pathname, ?String) -> String
   def self.write: (String, String, ?perm: Integer) -> Integer
+  def self.file?: (String) -> bool
 end
 
 class Digest

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -151,9 +151,11 @@ class Runners::Processor
   def root_dir: -> Pathname
   def directory_traversal_attack?: (String) -> bool
   def show_runtime_versions: -> void
-  def read_output_file: (_ToS) -> String
-  def read_output_xml: (_ToS) -> REXML::Document
-  def read_output_json: <'x> (_ToS) { () -> 'x } -> (Hash<Symbol, any> | 'x)
+  def report_file: -> String
+  def report_file_exist?: -> bool
+  def read_report_file: (?String) -> String
+  def read_report_xml: (?String) -> REXML::Document
+  def read_report_json: <'x> (?String) { () -> 'x } -> (Hash<Symbol, any> | 'x)
 end
 
 type capture3_options = bool | Proc


### PR DESCRIPTION
This change aims to reduce duplication of each `Processor` subclass by adding a new method `Processor#report_file`.
Also, this renames `read_output_*` methods to `read_report_*` to reduce the confusion of developers.

See also https://github.com/sider/runners/pull/1050#issuecomment-625085601