### PR TITLE
Bump Steep from 0.14.0 to 0.15.0

### DIFF
--- a/Gemfile.steep
+++ b/Gemfile.steep
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'steep', '= 0.14.0'
+gem 'steep', '= 0.15.0'
 gem 'rake'

--- a/Gemfile.steep.lock
+++ b/Gemfile.steep.lock
@@ -1,12 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.2.1)
+    activesupport (6.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
+      zeitwerk (~> 2.2, >= 2.2.2)
     ast (2.4.0)
     ast_utils (0.3.0)
       parser (~> 2.4)
@@ -22,17 +22,17 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     method_source (0.9.2)
     minitest (5.14.0)
-    parser (2.7.0.4)
+    parser (2.7.1.2)
       ast (~> 2.4.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rainbow (3.0.0)
     rake (13.0.1)
-    rb-fsevent (0.10.3)
+    rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    steep (0.14.0)
+    steep (0.15.0)
       activesupport (>= 5.1)
       ast_utils (~> 0.3.0)
       language_server-protocol (~> 3.14.0.1)
@@ -42,7 +42,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
     thor (1.0.1)
     thread_safe (0.3.6)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     zeitwerk (2.3.0)
 
@@ -51,7 +51,7 @@ PLATFORMS
 
 DEPENDENCIES
   rake
-  steep (= 0.14.0)
+  steep (= 0.15.0)
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
- https://github.com/soutaro/steep/releases/tag/v0.15.0
- https://github.com/soutaro/steep/compare/v0.14.0...v0.15.0

