### PR TITLE
[SwiftLint] Improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.23.0...HEAD)
 
+- **SwiftLint** Improve error handling [#1063](https://github.com/sider/runners/pull/1063)
+
 ## 0.23.0
 
 [Full diff](https://github.com/sider/runners/compare/0.22.4...0.23.0)

--- a/test/smokes/swiftlint/expectations.rb
+++ b/test/smokes/swiftlint/expectations.rb
@@ -146,15 +146,15 @@ s.add_test("no_swift_file", type: "success", issues: [], analyzer: { name: "Swif
 s.add_test(
   "no_config_file",
   type: "failure",
-  message: "SwiftLint unexpectedly failed. Please see the log for details.",
+  message: "Could not read configuration file at path 'not_found.yml'.",
   analyzer: { name: "SwiftLint", version: "0.39.2" },
   warnings: [
     {
-      message: <<~MSG.strip,
-DEPRECATION WARNING!!!
+      message: <<~MSG.strip
+      DEPRECATION WARNING!!!
 The `$.linter.swiftlint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
 Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/swift/swiftlint ).
-MSG
+MSG,
       file: "sideci.yml"
     }
   ]
@@ -172,6 +172,6 @@ s.add_test(
 s.add_test(
   "wrong_swiftlint_version_set",
   type: "failure",
-  message: "SwiftLint unexpectedly failed. Please see the log for details.",
+  message: "Currently running SwiftLint 0.39.2 but configuration specified version 0.0.0.",
   analyzer: { name: "SwiftLint", version: "0.39.2" }
 )

--- a/test/smokes/swiftlint/expectations.rb
+++ b/test/smokes/swiftlint/expectations.rb
@@ -150,11 +150,11 @@ s.add_test(
   analyzer: { name: "SwiftLint", version: "0.39.2" },
   warnings: [
     {
-      message: <<~MSG.strip
-      DEPRECATION WARNING!!!
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
 The `$.linter.swiftlint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
 Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/swift/swiftlint ).
-MSG,
+MSG
       file: "sideci.yml"
     }
   ]


### PR DESCRIPTION
Handling `JSON::ParserError` as a failure makes it hard for us to investigate a failure.
So, this change stops handling `JSON::ParserError`.
After this change, `JSON::ParserError` should be reported as a `Results::Error`.

