### PR TITLE
Ensure `Processor#analyzer` initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 - **SwiftLint** Improve error handling [#1063](https://github.com/sider/runners/pull/1063)
 - Log issues count [#1064](https://github.com/sider/runners/pull/1064)
+- Ensure `Processor#analyzer` initialization [#1067](https://github.com/sider/runners/pull/1067)
 
 ## 0.23.0
 

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -46,6 +46,7 @@ module Runners
               processor.show_runtime_versions
               result = processor.setup do
                 trace_writer.header "Running analyzer"
+                processor.analyzer # initialize analyzer
                 processor.analyze(changes)
               end
 

--- a/lib/runners/processor/brakeman.rb
+++ b/lib/runners/processor/brakeman.rb
@@ -14,7 +14,6 @@ module Runners
 
     def setup
       install_gems default_gem_specs, constraints: CONSTRAINTS do
-        analyzer
         yield
       end
     rescue InstallGemsFailure => exn

--- a/lib/runners/processor/coffeelint.rb
+++ b/lib/runners/processor/coffeelint.rb
@@ -30,7 +30,6 @@ module Runners
         return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
       end
 
-      analyzer # Must initialize after installation
       yield
     end
 

--- a/lib/runners/processor/cppcheck.rb
+++ b/lib/runners/processor/cppcheck.rb
@@ -26,11 +26,6 @@ module Runners
     DEFAULT_TARGET = ".".freeze
     DEFAULT_IGNORE = [].freeze
 
-    def setup
-      analyzer
-      yield
-    end
-
     def analyze(_changes)
       run_analyzer
     end

--- a/lib/runners/processor/eslint.rb
+++ b/lib/runners/processor/eslint.rb
@@ -49,7 +49,7 @@ module Runners
       rescue UserError => exn
         return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
       end
-      analyzer
+
       yield
     end
 

--- a/lib/runners/processor/flake8.rb
+++ b/lib/runners/processor/flake8.rb
@@ -17,13 +17,13 @@ module Runners
 
     def setup
       prepare_config
+      capture3! 'pyenv', 'global', detected_python_version
+      capture3! "python", "--version" # NOTE: `show_runtime_versions` does not work...
+      capture3! "pip", "--version"
       yield
     end
 
     def analyze(changes)
-      capture3! 'pyenv', 'global', detected_python_version
-      capture3! "python", "--version" # NOTE: `show_runtime_versions` does not work...
-      capture3! "pip", "--version"
       prepare_plugins
       run_analyzer
     end

--- a/lib/runners/processor/goodcheck.rb
+++ b/lib/runners/processor/goodcheck.rb
@@ -109,7 +109,6 @@ module Runners
 
     def setup
       ret = install_gems default_gem_specs, constraints: CONSTRAINTS do
-        analyzer
         yield
       end
 

--- a/lib/runners/processor/querly.rb
+++ b/lib/runners/processor/querly.rb
@@ -30,7 +30,6 @@ module Runners
 
     def setup
       ret = install_gems default_gem_specs, optionals: OPTIONAL_GEMS, constraints: CONSTRAINTS do
-        analyzer
         yield
       end
 

--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -47,7 +47,6 @@ module Runners
 
       prepare_config
       install_gems default_gem_specs, optionals: OPTIONAL_GEMS, constraints: CONSTRAINTS do
-        analyzer
         yield
       end
     rescue InstallGemsFailure => exn

--- a/lib/runners/processor/reek.rb
+++ b/lib/runners/processor/reek.rb
@@ -21,7 +21,6 @@ module Runners
 
     def setup
       install_gems default_gem_specs, constraints: CONSTRAINTS do
-        analyzer
         yield
       end
     rescue InstallGemsFailure => exn

--- a/lib/runners/processor/remark_lint.rb
+++ b/lib/runners/processor/remark_lint.rb
@@ -37,7 +37,7 @@ module Runners
       rescue UserError => exn
         return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
       end
-      analyzer # Must initialize after installation
+
       yield
     end
 

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -86,7 +86,6 @@ module Runners
       add_warning_if_deprecated_options([:options])
 
       install_gems default_gem_specs, optionals: OPTIONAL_GEMS, constraints: CONSTRAINTS do
-        analyzer
         yield
       end
     rescue InstallGemsFailure => exn

--- a/lib/runners/processor/stylelint.rb
+++ b/lib/runners/processor/stylelint.rb
@@ -52,7 +52,6 @@ module Runners
 
       # Must do after installation
       prepare_config_file
-      analyzer
 
       yield
     end

--- a/lib/runners/processor/tslint.rb
+++ b/lib/runners/processor/tslint.rb
@@ -40,7 +40,6 @@ module Runners
         return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
       end
 
-      analyzer # Must initialize after installation
       yield
     end
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -53,6 +53,10 @@ class CLITest < Minitest::Test
       "rubocop"
     end
 
+    def analyzer_version
+      "1.2.3"
+    end
+
     def setup
       yield
     end
@@ -63,7 +67,7 @@ class CLITest < Minitest::Test
 
       add_warning('hogehogewarn')
 
-      Runners::Results::Success.new(guid: guid, analyzer: Runners::Analyzer.new(name: "test-analyzer", version: "3.14"))
+      Runners::Results::Success.new(guid: guid, analyzer: analyzer)
     end
   end
 

--- a/test/harness_test.rb
+++ b/test/harness_test.rb
@@ -28,8 +28,16 @@ class HarnessTest < Minitest::Test
       "test"
     end
 
+    def analyzer_name
+      "Test"
+    end
+
+    def analyzer_version
+      "0.1.3"
+    end
+
     def analyze(changes)
-      Results::Success.new(guid: guid, analyzer: Analyzer.new(name: "Test", version: "0.1.3"))
+      Results::Success.new(guid: guid, analyzer: analyzer)
     end
   end
 
@@ -74,8 +82,16 @@ class HarnessTest < Minitest::Test
         'test'
       end
 
+      def analyzer_name
+        "Test"
+      end
+
+      def analyzer_version
+        "0.1.3"
+      end
+
       def analyze(changes)
-        Results::Success.new(guid: guid, analyzer: Analyzer.new(name: "Test", version: "0.1.3")).tap do |result|
+        Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
           result.add_issue Issue.new(
             path: Pathname("test/cli/test_test.rb"),
             location: Location.new(start_line: 0),
@@ -184,6 +200,14 @@ class HarnessTest < Minitest::Test
         'test'
       end
 
+      def analyzer_name
+        'Test'
+      end
+
+      def analyzer_version
+        '0.1.3'
+      end
+
       def setup
         (current_dir + "touch").write("#setup should be called before #analyze")
         yield
@@ -191,7 +215,7 @@ class HarnessTest < Minitest::Test
 
       def analyze(changes)
         (current_dir + "touch").file? or raise
-        Results::Success.new(guid: guid, analyzer: Analyzer.new(name: "Test", version: "0.1.3"))
+        Results::Success.new(guid: guid, analyzer: analyzer)
       end
     end
 


### PR DESCRIPTION
`Processor#analyzer` calls internally its `#analyzer_version` method,
which gets the tool version by running a command (e.g. `eslint --version`).

Each `Processor` subclass has currently this responsibility of calling `#analyzer_version`,
but the method sometimes does not be called on error.

Thus, in order to ensure the call of `#analyzer_version`, this changes that `Harness` calls the method, instead of each subclass.

