### PR TITLE
Add `analyzer` field to `Results::Error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - **SwiftLint** Improve error handling [#1063](https://github.com/sider/runners/pull/1063)
 - Log issues count [#1064](https://github.com/sider/runners/pull/1064)
 - Ensure `Processor#analyzer` initialization [#1067](https://github.com/sider/runners/pull/1067)
+- Add `analyzer` field to `Results::Error` [#1068](https://github.com/sider/runners/pull/1068)
 
 ## 0.23.0
 

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -25,6 +25,7 @@ module Runners
       @working_dir = working_dir
       @trace_writer = trace_writer
       @warnings = []
+      @analyzer = nil
     end
 
     def run
@@ -46,7 +47,7 @@ module Runners
               processor.show_runtime_versions
               result = processor.setup do
                 trace_writer.header "Running analyzer"
-                processor.analyzer # initialize analyzer
+                @analyzer = processor.analyzer # initialize analyzer
                 processor.analyze(changes)
               end
 
@@ -84,13 +85,13 @@ module Runners
           ---
           #{exn.raw_content}
         MSG
-        Results::Failure.new(guid: guid, message: exn.message)
+        Results::Failure.new(guid: guid, message: exn.message, analyzer: @analyzer)
       rescue UserError => exn
-        Results::Failure.new(guid: guid, message: exn.message)
+        Results::Failure.new(guid: guid, message: exn.message, analyzer: @analyzer)
       rescue => exn
         Bugsnag.notify(exn)
         handle_error(exn)
-        Results::Error.new(guid: guid, exception: exn)
+        Results::Error.new(guid: guid, exception: exn, analyzer: @analyzer)
       end
     end
 

--- a/lib/runners/results.rb
+++ b/lib/runners/results.rb
@@ -127,12 +127,13 @@ module Runners
     # Result to indicate that processor raises an exception.
     # Client programs should not return this result.
     class Error < Base
-      # @dynamic exception
-      attr_reader :exception
+      # @dynamic exception, analyzer
+      attr_reader :exception, :analyzer
 
-      def initialize(guid:, exception:)
+      def initialize(guid:, exception:, analyzer:)
         super(guid: guid)
         @exception = exception
+        @analyzer = analyzer
       end
 
       def as_json
@@ -141,6 +142,7 @@ module Runners
           json[:class] = exception.class.name
           json[:backtrace] = exception.backtrace
           json[:inspect] = exception.inspect
+          json[:analyzer] = analyzer&.as_json
         end
       end
 

--- a/lib/runners/schema/result.rb
+++ b/lib/runners/schema/result.rb
@@ -21,7 +21,7 @@ module Runners
       let :success, object(guid: string, timestamp: string, type: literal("success"), issues: array(Issue.issue), analyzer: analyzer)
       let :failure, object(guid: string, timestamp: string, type: literal("failure"), message: string, analyzer: optional(analyzer))
       let :missing_file_failure, object(guid: string, timestamp: string, type: literal("missing_files"), files: array(string))
-      let :error, object(guid: string, timestamp: string, type: literal("error"), class: string, backtrace: array(string), inspect: string)
+      let :error, object(guid: string, timestamp: string, type: literal("error"), class: string, backtrace: array(string), inspect: string, analyzer: optional(analyzer))
 
       let :envelope, object(
         result: enum(success, failure, missing_file_failure, error),

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -82,7 +82,8 @@ end
 
 class Runners::Results::Error < Runners::Results::Base
   attr_reader exception: Exception
-  def initialize: (guid: String, exception: Exception) -> any
+  attr_reader analyzer: Analyzer?
+  def initialize: (guid: String, exception: Exception, analyzer: Analyzer?) -> any
 end
 
 class Runners::Changes

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -302,7 +302,8 @@ class ResultTest < Minitest::Test
   end
 
   def test_error_result
-    result = Results::Error.new(guid: SecureRandom.uuid, exception: RuntimeError.new("some error!"))
+    result = Results::Error.new(guid: SecureRandom.uuid, exception: RuntimeError.new("some error!"),
+                                analyzer: Analyzer.new(name: "Foo", version: "1.2.3"))
 
     assert result.valid?
 
@@ -313,7 +314,8 @@ class ResultTest < Minitest::Test
                        type: "error",
                        class: "RuntimeError",
                        backtrace: nil,
-                       inspect: "#<RuntimeError: some error!>"
+                       inspect: "#<RuntimeError: some error!>",
+                       analyzer: { name: "Foo", version: "1.2.3" },
                      })
   end
 

--- a/test/smokes/detekt/expectations.rb
+++ b/test/smokes/detekt/expectations.rb
@@ -14,7 +14,11 @@ s.add_test(
 
 s.add_test(
   "with_invalid_sider_option",
-  type: "error", class: "RuntimeError", backtrace: :_, inspect: %r{.*\'non\/exists\/dir\/\' does not exist.*}
+  type: "error",
+  class: "RuntimeError",
+  backtrace: :_,
+  inspect: %r{.*\'non\/exists\/dir\/\' does not exist.*},
+  analyzer: { name: "detekt", version: "1.8.0" }
 )
 
 s.add_test(

--- a/test/smokes/reek/expectations.rb
+++ b/test/smokes/reek/expectations.rb
@@ -96,9 +96,23 @@ s.add_test(
   analyzer: { name: "Reek", version: "6.0.0" }
 )
 
-s.add_test("renamed_rule", type: "error", class: "Runners::Shell::ExecError", backtrace: :_, inspect: :_)
+s.add_test(
+  "renamed_rule",
+  type: "error",
+  class: "Runners::Shell::ExecError",
+  backtrace: :_,
+  inspect: :_,
+  analyzer: { name: "Reek", version: "6.0.0" }
+)
 
-s.add_test("v4_config_style", type: "error", class: "Runners::Shell::ExecError", backtrace: :_, inspect: :_)
+s.add_test(
+  "v4_config_style",
+  type: "error",
+  class: "Runners::Shell::ExecError",
+  backtrace: :_,
+  inspect: :_,
+  analyzer: { name: "Reek", version: "6.0.0" }
+)
 
 s.add_test(
   "v4_config_file_exists",


### PR DESCRIPTION
This change aims to make our debugging easier by getting analyzer versions.

Related to #1067