### PR TITLE
[SwiftLint] Delete unchanged files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.23.0...0.23.1)
 
 - **SwiftLint** Improve error handling [#1063](https://github.com/sider/runners/pull/1063)
+- **SwiftLint** Delete unchanged files [#1069](https://github.com/sider/runners/pull/1069)
 - Log issues count [#1064](https://github.com/sider/runners/pull/1064)
 - Ensure `Processor#analyzer` initialization [#1067](https://github.com/sider/runners/pull/1067)
 

--- a/lib/runners/processor/swiftlint.rb
+++ b/lib/runners/processor/swiftlint.rb
@@ -35,7 +35,8 @@ module Runners
       yield
     end
 
-    def analyze(_changes)
+    def analyze(changes)
+      delete_unchanged_files changes, only: ["*.swift"]
       run_analyzer
     end
 


### PR DESCRIPTION
Since Runners 0.23.0, SwiftLint errors have increased.
This change tries to reduce them.
