### PR TITLE
[SwiftLint] Add smoke test for `unused_import` rule

### DIFF
--- a/lib/runners/processor/swiftlint.rb
+++ b/lib/runners/processor/swiftlint.rb
@@ -36,7 +36,13 @@ module Runners
     end
 
     def analyze(changes)
+      # NOTE: This makes it impossible using rules like `unused_import`.
+      #       But the `unused_import` rule is for the `swiftlint analyze` command, not `swiftlint lint`.
+      #       So, it seems there should not be a big inconvenience.
+      #
+      # @see https://realm.github.io/SwiftLint/unused_import.html
       delete_unchanged_files changes, only: ["*.swift"]
+
       run_analyzer
     end
 

--- a/test/smokes/swiftlint/expectations.rb
+++ b/test/smokes/swiftlint/expectations.rb
@@ -175,3 +175,8 @@ s.add_test(
   message: "Currently running SwiftLint 0.39.2 but configuration specified version 0.0.0.",
   analyzer: { name: "SwiftLint", version: "0.39.2" }
 )
+
+# NOTE: `unused_import` rule is for `swiftlint analyze` and is not reported with `swiftlint lint`
+#
+# @see https://realm.github.io/SwiftLint/unused_import.html
+s.add_test("unused_import", type: "success", issues: [], analyzer: { name: "SwiftLint", version: "0.39.2" })

--- a/test/smokes/swiftlint/unused_import/.swiftlint.yml
+++ b/test/smokes/swiftlint/unused_import/.swiftlint.yml
@@ -1,0 +1,2 @@
+analyzer_rules:
+  - unused_import

--- a/test/smokes/swiftlint/unused_import/App.swift
+++ b/test/smokes/swiftlint/unused_import/App.swift
@@ -1,0 +1,6 @@
+import Sum
+
+/// App
+public class App {
+    deinit { }
+}

--- a/test/smokes/swiftlint/unused_import/Sum.swift
+++ b/test/smokes/swiftlint/unused_import/Sum.swift
@@ -1,0 +1,4 @@
+/// Sum
+public class Sum {
+    deinit { }
+}

--- a/test/smokes/swiftlint/unused_import/sider.yml
+++ b/test/smokes/swiftlint/unused_import/sider.yml
@@ -1,0 +1,3 @@
+linter:
+  swiftlint:
+    enable-all-rules: true


### PR DESCRIPTION
See https://realm.github.io/SwiftLint/unused_import.html
Related to #1069

