### PR TITLE
Add comment about #find_patch_by_file

### DIFF
--- a/lib/runners/changes.rb
+++ b/lib/runners/changes.rb
@@ -35,6 +35,7 @@ module Runners
       if gdp
         location = issue.location
         # NOTE: #find_patch_by_file omits just renamed files.
+        # @see https://github.com/packsaddle/ruby-git_diff_parser/issues/272
         patch = gdp.find_patch_by_file(issue.path.to_s)
         if patch && location
           patch.changed_lines.one? { |line| location.start_line == line.number }

--- a/lib/runners/changes.rb
+++ b/lib/runners/changes.rb
@@ -34,6 +34,7 @@ module Runners
       gdp = patches # NOTE: This assignment is required for typecheck by Steep
       if gdp
         location = issue.location
+        # NOTE: #find_patch_by_file omits just renamed files.
         patch = gdp.find_patch_by_file(issue.path.to_s)
         if patch && location
           patch.changed_lines.one? { |line| location.start_line == line.number }


### PR DESCRIPTION
Our implementation depends on [git_diff_parser](https://github.com/packsaddle/ruby-git_diff_parser), so I left comments about the behavior.