### PR TITLE
Add :use_local not to attempt to fetch gems remotely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.23.3...HEAD)
 
+- Add :use_local not to attempt to fetch gems remotely [#1078](https://github.com/sider/runners/pull/1078)
+
 ## 0.23.3
 
 [Full diff](https://github.com/sider/runners/compare/0.23.2...0.23.3)

--- a/lib/runners/ruby/gem_installer.rb
+++ b/lib/runners/ruby/gem_installer.rb
@@ -5,15 +5,16 @@ module Runners
 
       DEFAULT_SOURCE = "https://rubygems.org"
 
-      attr_reader :gem_home, :specs, :trace_writer, :shell, :constraints, :config_path_name
+      attr_reader :gem_home, :specs, :trace_writer, :shell, :constraints, :config_path_name, :use_local
 
-      def initialize(shell:, home:, config_path_name:, specs:, constraints:, trace_writer:)
+      def initialize(shell:, home:, config_path_name:, specs:, constraints:, trace_writer:, use_local:)
         @gem_home = home
         @specs = specs
         @shell = shell
         @config_path_name = config_path_name
         @constraints = constraints
         @trace_writer = trace_writer
+        @use_local = use_local
       end
 
       def gemfile_path
@@ -31,7 +32,8 @@ module Runners
 
         Bundler.with_unbundled_env do
           shell.push_dir gem_home do
-            shell.capture3!("bundle", "install")
+            install_args = use_local ? %w[--local] : []
+            shell.capture3!("bundle", "install", *install_args)
             shell.capture3!("bundle", "list")
           rescue Shell::ExecError
             raise InstallationFailure.new(<<~MESSAGE.strip)

--- a/sig/runners/ruby.rbi
+++ b/sig/runners/ruby.rbi
@@ -37,7 +37,8 @@ class Runners::Ruby::GemInstaller
                    config_path_name: String,
                    specs: Array<Spec>,
                    constraints: Hash<String, Array<String>>,
-                   trace_writer: TraceWriter) -> void
+                   trace_writer: TraceWriter,
+                   use_local: bool) -> void
   def install!: <'x> { (Hash<String, String>) -> 'x } -> 'x
   def gemfile_path: -> Pathname
   def gemfile_content: -> String

--- a/test/smokes/goodcheck/expectations.rb
+++ b/test/smokes/goodcheck/expectations.rb
@@ -1,6 +1,6 @@
 s = Runners::Testing::Smoke
 
-s.add_test(
+s.add_offline_test(
   "success",
   type: "success",
   issues: [
@@ -17,7 +17,7 @@ s.add_test(
   analyzer: { name: "Goodcheck", version: "2.5.1" }
 )
 
-s.add_test(
+s.add_offline_test(
   "with_ci_config",
   type: "success",
   issues: [
@@ -34,33 +34,33 @@ s.add_test(
   analyzer: { name: "Goodcheck", version: "2.5.1" }
 )
 
-s.add_test(
+s.add_offline_test(
   "no_config_file",
   type: "success",
   issues: [],
   analyzer: { name: "Goodcheck", version: "2.5.1" },
   warnings: [
     {
-      message: <<~MESSAGE.strip,
-Sider cannot find the required configuration file `goodcheck.yml`.
+      message: <<~MESSAGE.strip
+      Sider cannot find the required configuration file `goodcheck.yml`.
 Please set up Goodcheck by following the instructions, or you can disable it in the repository settings.
 
 - https://github.com/sider/goodcheck
 - https://help.sider.review/tools/others/goodcheck
-MESSAGE
+MESSAGE,
       file: nil
     }
   ]
 )
 
-s.add_test(
+s.add_offline_test(
   "invalid_config_file",
   type: "failure",
   message: "Invalid config: TypeError at $.rules[0]: expected=rule, value=\"id:foo\"",
   analyzer: { name: "Goodcheck", version: "2.5.1" }
 )
 
-s.add_test(
+s.add_offline_test(
   "with_invalid_ci_config",
   type: "failure",
   message:
@@ -68,7 +68,7 @@ s.add_test(
   analyzer: :_
 )
 
-s.add_test(
+s.add_offline_test(
   "warning_config_file",
   type: "success",
   issues: [],
@@ -82,7 +82,7 @@ s.add_test(
   ]
 )
 
-s.add_test(
+s.add_offline_test(
   "deprecated-options",
   type: "success",
   issues: [],
@@ -107,7 +107,7 @@ s.add_test(
   analyzer: { name: "Goodcheck", version: "1.0.0" }
 )
 
-s.add_test(
+s.add_offline_test(
   "detect_there_is_no_content",
   type: "success",
   issues: [
@@ -124,7 +124,7 @@ s.add_test(
   analyzer: { name: "Goodcheck", version: "2.5.1" }
 )
 
-s.add_test(
+s.add_offline_test(
   "rules_without_pattern",
   type: "success",
   issues: [

--- a/test/smokes/goodcheck/expectations.rb
+++ b/test/smokes/goodcheck/expectations.rb
@@ -41,13 +41,13 @@ s.add_offline_test(
   analyzer: { name: "Goodcheck", version: "2.5.1" },
   warnings: [
     {
-      message: <<~MESSAGE.strip
-      Sider cannot find the required configuration file `goodcheck.yml`.
+      message: <<~MESSAGE.strip,
+Sider cannot find the required configuration file `goodcheck.yml`.
 Please set up Goodcheck by following the instructions, or you can disable it in the repository settings.
 
 - https://github.com/sider/goodcheck
 - https://help.sider.review/tools/others/goodcheck
-MESSAGE,
+MESSAGE
       file: nil
     }
   ]


### PR DESCRIPTION
If the repository does not include `Gemfile`, `Gemfile.lock`,
`*.gemspec`, and the `gems` section in `sider.yml`, Runners do not have
to access the internet. So, I made Runners not to fetch gems remotely
with the `--local` option of `bundle install`.

Close #1074