### PR TITLE
Update Smoke.add_test to receive :options

### DIFF
--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -136,27 +136,50 @@ module Runners
       def self.add_test(name, type:, guid: "test-guid", timestamp: :_,
                         issues: nil, message: nil, analyzer: nil,
                         class: nil, backtrace: nil, inspect: nil,
-                        warnings: [], ci_config: :_, version: :_,
-                        options: { offline: false })
+                        warnings: [], ci_config: :_, version: :_)
         return unless only? name
 
+        pattern = build_pattern(type: type, guid: guid, timestamp: timestamp,
+          issues: issues, message: message, analyzer: analyzer,
+          class: binding.local_variable_get(:class), backtrace: backtrace, inspect: inspect,
+          warnings: warnings, ci_config: ci_config, version: version
+        )
+
+        tests << TestSet.new(name: name, pattern: pattern, options: {  offline: false  })
+      end
+
+      def self.add_offline_test(name, type:, guid: "test-guid", timestamp: :_,
+                                issues: nil, message: nil, analyzer: nil,
+                                class: nil, backtrace: nil, inspect: nil,
+                                warnings: [], ci_config: :_, version: :_)
+        return unless only? name
+
+        pattern = build_pattern(
+          type: type, guid: guid, timestamp: timestamp,
+          issues: issues, message: message, analyzer: analyzer,
+          class: binding.local_variable_get(:class), backtrace: backtrace, inspect: inspect,
+          warnings: warnings, ci_config: ci_config, version: version
+        )
+
+        tests << TestSet.new(name: name, pattern: pattern, options: { offline: true })
+      end
+
+      def self.build_pattern(**fields)
         optional = {
-          issues: issues,
-          message: message,
-          analyzer: analyzer,
-          class: binding.local_variable_get(:class),
-          backtrace: backtrace,
-          inspect: inspect,
+          issues: fields.fetch(:issues),
+          message: fields.fetch(:message),
+          analyzer: fields.fetch(:analyzer),
+          class: fields.fetch(:class),
+          backtrace: fields.fetch(:backtrace),
+          inspect: fields.fetch(:inspect),
         }.compact
 
-        pattern = {
-          result: { guid: guid, timestamp: timestamp, type: type, **optional },
-          warnings: warnings,
-          ci_config: ci_config,
-          version: version,
+        {
+          result: { guid: fields.fetch(:guid), timestamp: fields.fetch(:timestamp), type: fields.fetch(:type), **optional },
+          warnings: fields.fetch(:warnings),
+          ci_config: fields.fetch(:ci_config),
+          version: fields.fetch(:version),
         }
-
-        tests << TestSet.new(name: name, pattern: pattern, options: options)
       end
     end
   end

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -104,8 +104,10 @@ module Runners
       def command_line(test_set)
         smoke_target = (expectations.parent / test_set.name).realpath
         runners_options = JSON.dump(source: { head: PROJECT_PATH })
-        commands = %W[docker run --rm --mount type=bind,source=#{smoke_target},target=#{PROJECT_PATH} --env RUNNERS_OPTIONS='#{runners_options}' #{docker_image} test-guid]
+        commands = %W[docker run --rm --mount type=bind,source=#{smoke_target},target=#{PROJECT_PATH} --env RUNNERS_OPTIONS='#{runners_options}']
         commands << "--network=none" if test_set.options[:offline]
+        commands << docker_image
+        commands << test_set.pattern[:guid]
         commands.join(" ")
       end
 

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -13,7 +13,7 @@ module Runners
 
       PROJECT_PATH = "/project".freeze
 
-      TestSet = Struct.new(:name, :pattern, :options, keyword_init: true)
+      TestParams = Struct.new(:name, :pattern, :options, keyword_init: true)
 
       attr_reader :argv
 
@@ -147,7 +147,7 @@ module Runners
           warnings: warnings, ci_config: ci_config, version: version
         )
 
-        tests << TestSet.new(name: name, pattern: pattern, options: {  offline: false  })
+        tests << TestParams.new(name: name, pattern: pattern, options: {  offline: false  })
       end
 
       def self.add_offline_test(name, type:, guid: "test-guid", timestamp: :_,
@@ -163,7 +163,7 @@ module Runners
           warnings: warnings, ci_config: ci_config, version: version
         )
 
-        tests << TestSet.new(name: name, pattern: pattern, options: { offline: true })
+        tests << TestParams.new(name: name, pattern: pattern, options: { offline: true })
       end
 
       def self.build_pattern(**fields)

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -107,7 +107,7 @@ module Runners
         commands = %W[docker run --rm --mount type=bind,source=#{smoke_target},target=#{PROJECT_PATH} --env RUNNERS_OPTIONS='#{runners_options}']
         commands << "--network=none" if test_set.options[:offline]
         commands << docker_image
-        commands << test_set.pattern[:guid]
+        commands << test_set.pattern.dig(:result, :guid)
         commands.join(" ")
       end
 

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -13,7 +13,7 @@ module Runners
 
       PROJECT_PATH = "/project".freeze
 
-      TestParams = Struct.new(:name, :pattern, :options, keyword_init: true)
+      TestParams = Struct.new(:name, :pattern, :offline, keyword_init: true)
 
       attr_reader :argv
 
@@ -105,7 +105,7 @@ module Runners
         smoke_target = (expectations.parent / test_set.name).realpath
         runners_options = JSON.dump(source: { head: PROJECT_PATH })
         commands = %W[docker run --rm --mount type=bind,source=#{smoke_target},target=#{PROJECT_PATH} --env RUNNERS_OPTIONS='#{runners_options}']
-        commands << "--network=none" if test_set.options[:offline]
+        commands << "--network=none" if test_set.offline
         commands << docker_image
         commands << test_set.pattern.dig(:result, :guid)
         commands.join(" ")
@@ -147,7 +147,7 @@ module Runners
           warnings: warnings, ci_config: ci_config, version: version
         )
 
-        tests << TestParams.new(name: name, pattern: pattern, options: {  offline: false  })
+        tests << TestParams.new(name: name, pattern: pattern, offline: false)
       end
 
       def self.add_offline_test(name, type:, guid: "test-guid", timestamp: :_,
@@ -163,7 +163,7 @@ module Runners
           warnings: warnings, ci_config: ci_config, version: version
         )
 
-        tests << TestParams.new(name: name, pattern: pattern, options: { offline: true })
+        tests << TestParams.new(name: name, pattern: pattern, offline: true)
       end
 
       def self.build_pattern(**fields)

--- a/sig/runners/testing.rbi
+++ b/sig/runners/testing.rbi
@@ -53,7 +53,7 @@ Runners::Testing::Smoke::PROJECT_PATH: String
 class Runners::Testing::Smoke::TestParams
   attr_accessor name: String
   attr_accessor pattern: Hash<Symbol, any>
-  attr_accessor options: Hash<Symbol, any>
+  attr_accessor offline: bool
 
-  def initialize: (name: String, pattern: Hash<Symbol, any>, options: Hash<Symbol, any>) -> any
+  def initialize: (name: String, pattern: Hash<Symbol, any>, offline: bool) -> any
 end

--- a/sig/runners/testing.rbi
+++ b/sig/runners/testing.rbi
@@ -12,10 +12,10 @@ class Runners::Testing::Smoke
   def expectations: -> Pathname
   def initialize: (Array<String>) -> any
   def run: () -> void
-  def run_test: (String, any, IO) -> Symbol
+  def run_test: (TestSet, IO) -> Symbol
   def unify_result: (any, any, IO) -> bool
   def with_data_container: <'x> { () -> 'x } -> 'x
-  def command_line: (String) -> String
+  def command_line: (TestSet) -> String
   def system!: (*String) -> void
   def colored_pretty_inspect: (any) -> String
 
@@ -31,8 +31,17 @@ class Runners::Testing::Smoke
                       ?inspect: String | Regexp | Symbol | nil,
                       ?warnings: Array<Hash<Symbol, any>>,
                       ?ci_config: Hash<Symbol, any> | Symbol,
-                      ?version: String | Symbol) -> void
-  def self.tests: -> Hash<String, any>
+                      ?version: String | Symbol,
+                      ?options: Hash<Symbol, any>) -> void
+  def self.tests: -> Array<TestSet>
 end
 
 Runners::Testing::Smoke::PROJECT_PATH: String
+
+class Runners::Testing::Smoke::TestSet
+  attr_accessor name: String
+  attr_accessor pattern: Hash<Symbol, any>
+  attr_accessor options: Hash<Symbol, any>
+
+  def initialize: (name: String, pattern: Hash<Symbol, any>, options: Hash<Symbol, any>) -> any
+end

--- a/sig/runners/testing.rbi
+++ b/sig/runners/testing.rbi
@@ -31,8 +31,20 @@ class Runners::Testing::Smoke
                       ?inspect: String | Regexp | Symbol | nil,
                       ?warnings: Array<Hash<Symbol, any>>,
                       ?ci_config: Hash<Symbol, any> | Symbol,
-                      ?version: String | Symbol,
-                      ?options: Hash<Symbol, any>) -> void
+                      ?version: String | Symbol) -> void
+  def self.add_offline_test: (String, type: String,
+                              ?guid: String | Symbol,
+                              ?timestamp: String | Symbol,
+                              ?issues: Array<Hash<Symbol, any>> | Symbol | nil,
+                              ?message: String | Symbol | Regexp | nil,
+                              ?analyzer: Hash<Symbol, any> | Symbol | nil,
+                              ?class: String | Symbol | nil,
+                              ?backtrace: Array<String> | Symbol | nil,
+                              ?inspect: String | Regexp | Symbol | nil,
+                              ?warnings: Array<Hash<Symbol, any>>,
+                              ?ci_config: Hash<Symbol, any> | Symbol,
+                              ?version: String | Symbol) -> void
+  def self.build_pattern: (**any) -> Hash<Symbol, any>
   def self.tests: -> Array<TestSet>
 end
 

--- a/sig/runners/testing.rbi
+++ b/sig/runners/testing.rbi
@@ -12,10 +12,10 @@ class Runners::Testing::Smoke
   def expectations: -> Pathname
   def initialize: (Array<String>) -> any
   def run: () -> void
-  def run_test: (TestSet, IO) -> Symbol
+  def run_test: (TestParams, IO) -> Symbol
   def unify_result: (any, any, IO) -> bool
   def with_data_container: <'x> { () -> 'x } -> 'x
-  def command_line: (TestSet) -> String
+  def command_line: (TestParams) -> String
   def system!: (*String) -> void
   def colored_pretty_inspect: (any) -> String
 
@@ -45,12 +45,12 @@ class Runners::Testing::Smoke
                               ?ci_config: Hash<Symbol, any> | Symbol,
                               ?version: String | Symbol) -> void
   def self.build_pattern: (**any) -> Hash<Symbol, any>
-  def self.tests: -> Array<TestSet>
+  def self.tests: -> Array<TestParams>
 end
 
 Runners::Testing::Smoke::PROJECT_PATH: String
 
-class Runners::Testing::Smoke::TestSet
+class Runners::Testing::Smoke::TestParams
   attr_accessor name: String
   attr_accessor pattern: Hash<Symbol, any>
   attr_accessor options: Hash<Symbol, any>

--- a/test/smokes/misspell/expectations.rb
+++ b/test/smokes/misspell/expectations.rb
@@ -44,11 +44,11 @@ s.add_test(
   analyzer: { name: "Misspell", version: "0.3.4" },
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
-      MSG
+      message: <<~MSG.strip
+      DEPRECATION WARNING!!!
+The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
+MSG,
       file: "sideci.yml"
     }
   ],

--- a/test/smokes/misspell/expectations.rb
+++ b/test/smokes/misspell/expectations.rb
@@ -44,11 +44,11 @@ s.add_test(
   analyzer: { name: "Misspell", version: "0.3.4" },
   warnings: [
     {
-      message: <<~MSG.strip
-      DEPRECATION WARNING!!!
-The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
-MSG,
+      message: <<~MSG,
+        DEPRECATION WARNING!!!
+        The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
+      MSG
       file: "sideci.yml"
     }
   ],

--- a/test/smokes/misspell/expectations.rb
+++ b/test/smokes/misspell/expectations.rb
@@ -1,6 +1,6 @@
 s = Runners::Testing::Smoke
 
-s.add_test(
+s.add_offline_test(
   "success",
   type: "success",
   issues: [
@@ -17,7 +17,7 @@ s.add_test(
   analyzer: { name: "Misspell", version: "0.3.4" }
 )
 
-s.add_test(
+s.add_offline_test(
   "locale",
   type: "success",
   issues: [
@@ -43,17 +43,17 @@ s.add_test(
   analyzer: { name: "Misspell", version: "0.3.4" },
   warnings: [
     {
-      message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
-MSG
+      message: <<~MSG,
+        DEPRECATION WARNING!!!
+        The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
+      MSG
       file: "sideci.yml"
     }
   ]
 )
 
-s.add_test(
+s.add_offline_test(
   "ignore",
   type: "success",
   issues: [
@@ -70,7 +70,7 @@ s.add_test(
   analyzer: { name: "Misspell", version: "0.3.4" }
 )
 
-s.add_test(
+s.add_offline_test(
   "analyze_specific_targets",
   type: "success",
   issues: [
@@ -133,7 +133,7 @@ s.add_test(
   warnings: [{ message: /DEPRECATION WARNING!!!\nThe `\$\.linter\.misspell\.targets` option/, file: "sideci.yml" }]
 )
 
-s.add_test(
+s.add_offline_test(
   "exclude_targets",
   type: "success",
   issues: [
@@ -213,7 +213,7 @@ s.add_test(
   analyzer: { name: "Misspell", version: "0.3.4" }
 )
 
-s.add_test(
+s.add_offline_test(
   "broken_sideci_yml",
   type: "failure",
   message:
@@ -221,7 +221,7 @@ s.add_test(
   analyzer: :_
 )
 
-s.add_test(
+s.add_offline_test(
   "option_target",
   type: "success",
   issues: [

--- a/test/smokes/misspell/expectations.rb
+++ b/test/smokes/misspell/expectations.rb
@@ -43,11 +43,11 @@ s.add_offline_test(
   analyzer: { name: "Misspell", version: "0.3.4" },
   warnings: [
     {
-      message: <<~MSG,
-        DEPRECATION WARNING!!!
-        The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
-      MSG
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
+The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
+MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/misspell/expectations.rb
+++ b/test/smokes/misspell/expectations.rb
@@ -14,8 +14,7 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Misspell", version: "0.3.4" },
-  options: { offline: true }
+  analyzer: { name: "Misspell", version: "0.3.4" }
 )
 
 s.add_test(
@@ -44,15 +43,14 @@ s.add_test(
   analyzer: { name: "Misspell", version: "0.3.4" },
   warnings: [
     {
-      message: <<~MSG.strip
-      DEPRECATION WARNING!!!
+      message: <<~MSG.strip,
+DEPRECATION WARNING!!!
 The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
 Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
-MSG,
+MSG
       file: "sideci.yml"
     }
-  ],
-  options: { offline: true }
+  ]
 )
 
 s.add_test(
@@ -69,8 +67,7 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Misspell", version: "0.3.4" },
-  options: { offline: true }
+  analyzer: { name: "Misspell", version: "0.3.4" }
 )
 
 s.add_test(
@@ -133,8 +130,7 @@ s.add_test(
     }
   ],
   analyzer: { name: "Misspell", version: "0.3.4" },
-  warnings: [{ message: /DEPRECATION WARNING!!!\nThe `\$\.linter\.misspell\.targets` option/, file: "sideci.yml" }],
-  options: { offline: true }
+  warnings: [{ message: /DEPRECATION WARNING!!!\nThe `\$\.linter\.misspell\.targets` option/, file: "sideci.yml" }]
 )
 
 s.add_test(
@@ -214,8 +210,7 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Misspell", version: "0.3.4" },
-  options: { offline: true }
+  analyzer: { name: "Misspell", version: "0.3.4" }
 )
 
 s.add_test(
@@ -223,8 +218,7 @@ s.add_test(
   type: "failure",
   message:
     "The value of the attribute `$.linter.misspell.locale` in your `sideci.yml` is invalid. Please fix and retry.",
-  analyzer: :_,
-  options: { offline: true }
+  analyzer: :_
 )
 
 s.add_test(
@@ -250,6 +244,5 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Misspell", version: "0.3.4" },
-  options: { offline: true }
+  analyzer: { name: "Misspell", version: "0.3.4" }
 )

--- a/test/smokes/misspell/expectations.rb
+++ b/test/smokes/misspell/expectations.rb
@@ -14,7 +14,8 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Misspell", version: "0.3.4" }
+  analyzer: { name: "Misspell", version: "0.3.4" },
+  options: { offline: true }
 )
 
 s.add_test(
@@ -43,14 +44,15 @@ s.add_test(
   analyzer: { name: "Misspell", version: "0.3.4" },
   warnings: [
     {
-      message: <<~MSG.strip,
-DEPRECATION WARNING!!!
+      message: <<~MSG.strip
+      DEPRECATION WARNING!!!
 The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
 Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
-MSG
+MSG,
       file: "sideci.yml"
     }
-  ]
+  ],
+  options: { offline: true }
 )
 
 s.add_test(
@@ -67,7 +69,8 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Misspell", version: "0.3.4" }
+  analyzer: { name: "Misspell", version: "0.3.4" },
+  options: { offline: true }
 )
 
 s.add_test(
@@ -130,7 +133,8 @@ s.add_test(
     }
   ],
   analyzer: { name: "Misspell", version: "0.3.4" },
-  warnings: [{ message: /DEPRECATION WARNING!!!\nThe `\$\.linter\.misspell\.targets` option/, file: "sideci.yml" }]
+  warnings: [{ message: /DEPRECATION WARNING!!!\nThe `\$\.linter\.misspell\.targets` option/, file: "sideci.yml" }],
+  options: { offline: true }
 )
 
 s.add_test(
@@ -210,7 +214,8 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Misspell", version: "0.3.4" }
+  analyzer: { name: "Misspell", version: "0.3.4" },
+  options: { offline: true }
 )
 
 s.add_test(
@@ -218,7 +223,8 @@ s.add_test(
   type: "failure",
   message:
     "The value of the attribute `$.linter.misspell.locale` in your `sideci.yml` is invalid. Please fix and retry.",
-  analyzer: :_
+  analyzer: :_,
+  options: { offline: true }
 )
 
 s.add_test(
@@ -244,5 +250,6 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Misspell", version: "0.3.4" }
+  analyzer: { name: "Misspell", version: "0.3.4" },
+  options: { offline: true }
 )


### PR DESCRIPTION
I want to change the test behavior via `Smoke.add_test` and want to make
smoke tests without the internet.

This will be used on #1078
https://github.com/sider/runners/pull/1078#pullrequestreview-411525454