### PR TITLE
[Refactor] Rename `push_dir` to `chdir`

### DIFF
--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -42,7 +42,7 @@ module Runners
             root_dir_not_found = processor.check_root_dir_exist
             return root_dir_not_found if root_dir_not_found
 
-            processor.push_root_dir do
+            processor.in_root_dir do
               trace_writer.header "Setting up analyzer"
               processor.show_runtime_versions
               result = processor.setup do

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -8,7 +8,7 @@ module Runners
     attr_reader :guid, :workspace, :working_dir, :git_ssh_path, :trace_writer, :warnings, :config, :shell
 
     def_delegators :@shell,
-      :push_dir, :current_dir,
+      :chdir, :current_dir,
       :capture3, :capture3!, :capture3_trace, :capture3_with_retry!,
       :env_hash, :push_env_hash
 
@@ -108,8 +108,8 @@ module Runners
       Results::Failure.new(guid: guid, message: message)
     end
 
-    def push_root_dir(&block)
-      push_dir(root_dir, &block)
+    def in_root_dir(&block)
+      chdir(root_dir, &block)
     end
 
     def root_dir

--- a/lib/runners/processor/gometalinter.rb
+++ b/lib/runners/processor/gometalinter.rb
@@ -119,7 +119,7 @@ module Runners
     def push_import_path_dir
       with_import_path do |path|
         if path
-          push_dir path do
+          chdir path do
             yield
           end
         else

--- a/lib/runners/ruby/gem_installer.rb
+++ b/lib/runners/ruby/gem_installer.rb
@@ -30,7 +30,7 @@ module Runners
         trace_writer.header "Installing gems..."
 
         Bundler.with_unbundled_env do
-          shell.push_dir gem_home do
+          shell.chdir gem_home do
             shell.capture3!("bundle", "install")
             shell.capture3!("bundle", "list")
           rescue Shell::ExecError

--- a/lib/runners/shell.rb
+++ b/lib/runners/shell.rb
@@ -36,18 +36,15 @@ module Runners
       end
     end
 
-    # @dynamic trace_writer, env_hash_stack
+    # @dynamic trace_writer, current_dir, env_hash_stack
     attr_reader :trace_writer
+    attr_reader :current_dir
     attr_reader :env_hash_stack
 
     def initialize(current_dir:, trace_writer:, env_hash:)
       @trace_writer = trace_writer
       @current_dir = current_dir
       @env_hash_stack = [env_hash]
-    end
-
-    def current_dir
-      @current_dir
     end
 
     def chdir(dir)

--- a/lib/runners/shell.rb
+++ b/lib/runners/shell.rb
@@ -36,9 +36,8 @@ module Runners
       end
     end
 
-    # @dynamic trace_writer, dir_stack, env_hash_stack
+    # @dynamic trace_writer, env_hash_stack
     attr_reader :trace_writer
-    attr_reader :dir_stack
     attr_reader :env_hash_stack
 
     def initialize(current_dir:, trace_writer:, env_hash:)
@@ -48,14 +47,14 @@ module Runners
     end
 
     def current_dir
-      dir_stack.last or raise "Empty dir stack"
+      @dir_stack.last or raise "Empty dir stack"
     end
 
-    def push_dir(dir)
-      dir_stack.push dir
-      yield
+    def chdir(dir)
+      @dir_stack.push dir
+      yield dir
     ensure
-      dir_stack.pop
+      @dir_stack.pop
     end
 
     def push_env_hash(env)

--- a/lib/runners/shell.rb
+++ b/lib/runners/shell.rb
@@ -52,7 +52,7 @@ module Runners
 
     def chdir(dir)
       backup = @current_dir
-      Dir.chdir(dir) do |path|
+      Dir.chdir(dir.to_path) do |path|
         @current_dir = Pathname(path)
         yield @current_dir
       end

--- a/lib/runners/shell.rb
+++ b/lib/runners/shell.rb
@@ -42,19 +42,22 @@ module Runners
 
     def initialize(current_dir:, trace_writer:, env_hash:)
       @trace_writer = trace_writer
-      @dir_stack = [current_dir]
+      @current_dir = current_dir
       @env_hash_stack = [env_hash]
     end
 
     def current_dir
-      @dir_stack.last or raise "Empty dir stack"
+      @current_dir
     end
 
     def chdir(dir)
-      @dir_stack.push dir
-      yield dir
+      backup = @current_dir
+      Dir.chdir(dir) do |path|
+        @current_dir = Pathname(path)
+        yield @current_dir
+      end
     ensure
-      @dir_stack.pop
+      @current_dir = backup
     end
 
     def push_env_hash(env)

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -29,7 +29,7 @@ module Runners
 
     def git_directory
       @git_directory ||= root_tmp_dir.tap do |path|
-        shell.push_dir(path) do
+        shell.chdir(path) do
           shell.capture3!("git", "init")
           shell.capture3!("git", "config", "gc.auto", "0")
           shell.capture3!("git", "remote", "add", "origin", remote_url.to_s)

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -105,7 +105,7 @@ end
 class Dir
   def self.mktmpdir: <'a> { (String) -> 'a } -> 'a
                    | () -> String
-  def self.chdir: <'a> (String | Pathname) { (String) -> 'a } -> 'a
+  def self.chdir: <'a> (String) { (String) -> 'a } -> 'a
 end
 
 class URI

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -105,6 +105,7 @@ end
 class Dir
   def self.mktmpdir: <'a> { (String) -> 'a } -> 'a
                    | () -> String
+  def self.chdir: <'a> (String | Pathname) { (String) -> 'a } -> 'a
 end
 
 class URI

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -121,10 +121,10 @@ class Runners::Processor
   def analyze: (Changes) -> result
   def config_linter: () -> Hash<Symbol, any>
   def check_root_dir_exist: () -> result?
-  def push_root_dir: <'x> { -> 'x } -> 'x
+  def in_root_dir: <'x> { (Pathname) -> 'x } -> 'x
   def ensure_files: (*Pathname) { (Pathname) -> result } -> result
   def ensure_runner_config_schema: (any) { (any) -> result } -> result
-  def push_dir: <'x> (Pathname) { -> 'x } -> 'x
+  def chdir: <'x> (Pathname) { (Pathname) -> 'x } -> 'x
   def current_dir: () -> Pathname
 
   def self.register_config_schema: (**any) -> void
@@ -165,7 +165,6 @@ type capture3_options = bool | Proc
 class Runners::Shell
   attr_reader trace_writer: TraceWriter
   attr_reader env_hash_stack: Array<Hash<String, String?>>
-  attr_reader dir_stack: Array<Pathname>
 
   def initialize: (current_dir: Pathname, env_hash: Hash<String, String?>, trace_writer: TraceWriter) -> any
 
@@ -174,7 +173,7 @@ class Runners::Shell
   def capture3_with_retry!: (String, *String, ?tries: Integer) -> [String, String]
   def capture3_trace: (String, *String, **capture3_options) -> [String, String, Process::Status]
 
-  def push_dir: <'x> (Pathname) { -> 'x } -> 'x
+  def chdir: <'x> (Pathname) { (Pathname) -> 'x } -> 'x
   def current_dir: () -> Pathname
 
   def push_env_hash: <'x> (Hash<String, String?>) { -> 'x } -> 'x

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -163,7 +163,10 @@ end
 type capture3_options = bool | Proc
 
 class Runners::Shell
+  @current_dir: Pathname
+
   attr_reader trace_writer: TraceWriter
+  attr_reader current_dir: Pathname
   attr_reader env_hash_stack: Array<Hash<String, String?>>
 
   def initialize: (current_dir: Pathname, env_hash: Hash<String, String?>, trace_writer: TraceWriter) -> any
@@ -174,8 +177,6 @@ class Runners::Shell
   def capture3_trace: (String, *String, **capture3_options) -> [String, String, Process::Status]
 
   def chdir: <'x> (Pathname) { (Pathname) -> 'x } -> 'x
-  def current_dir: () -> Pathname
-
   def push_env_hash: <'x> (Hash<String, String?>) { -> 'x } -> 'x
   def env_hash: -> Hash<String, String?>
 end

--- a/sig_new/runners/shell.rbs
+++ b/sig_new/runners/shell.rbs
@@ -1,5 +1,5 @@
 class Runners::Shell
-  @dir_stack: Array[Pathname]
+  @current_dir: Pathname
 
   attr_reader trace_writer: TraceWriter
   attr_reader env_hash_stack: Array[Hash[String, String?]]

--- a/sig_new/runners/shell.rbs
+++ b/sig_new/runners/shell.rbs
@@ -1,4 +1,6 @@
 class Runners::Shell
+  @dir_stack: Array[Pathname]
+
   attr_reader trace_writer: TraceWriter
   attr_reader env_hash_stack: Array[Hash[String, String?]]
 

--- a/sig_new/runners/shell.rbs
+++ b/sig_new/runners/shell.rbs
@@ -2,10 +2,10 @@ class Runners::Shell
   @current_dir: Pathname
 
   attr_reader trace_writer: TraceWriter
+  attr_reader current_dir: Pathname
   attr_reader env_hash_stack: Array[Hash[String, String?]]
 
   def initialize: (current_dir: Pathname, env_hash: Hash[String, String?], trace_writer: TraceWriter) -> untyped
-  def current_dir: () -> Pathname
   def chdir: [X] (Pathname) { (Pathname) -> X } -> X
   def push_env_hash: [X] (Hash[String, String?]) { () -> X } -> X
   def env_hash: () -> Hash[String, String?]

--- a/sig_new/runners/shell.rbs
+++ b/sig_new/runners/shell.rbs
@@ -1,11 +1,10 @@
 class Runners::Shell
   attr_reader trace_writer: TraceWriter
   attr_reader env_hash_stack: Array[Hash[String, String?]]
-  attr_reader dir_stack: Array[Pathname]
 
   def initialize: (current_dir: Pathname, env_hash: Hash[String, String?], trace_writer: TraceWriter) -> untyped
   def current_dir: () -> Pathname
-  def push_dir: [X] (Pathname) { () -> X } -> X
+  def chdir: [X] (Pathname) { (Pathname) -> X } -> X
   def push_env_hash: [X] (Hash[String, String?]) { () -> X } -> X
   def env_hash: () -> Hash[String, String?]
   def capture3: (String, *String, **untyped) -> [String, String, Process::Status]

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -121,7 +121,7 @@ class ProcessorTest < Minitest::Test
       assert_equal Pathname("bar/baz"), processor.relative_path((workspace.working_dir / "foo/bar/baz").to_s, from: workspace.working_dir / "foo")
 
       # If relative path is given, interpreted from current_dir
-      processor.push_dir workspace.working_dir / "foo" do
+      processor.chdir workspace.working_dir / "foo" do
         assert_equal Pathname("foo/bar/baz"), processor.relative_path("bar/baz")
       end
     end
@@ -154,7 +154,7 @@ class ProcessorTest < Minitest::Test
     end
   end
 
-  def test_push_root_dir_with_config
+  def test_in_root_dir_with_config
     # when root_dir is given, run is invoked within the dir
     with_workspace do |workspace|
       (workspace.working_dir / "app/bar").mkpath
@@ -165,28 +165,22 @@ class ProcessorTest < Minitest::Test
             root_dir: app/bar
       YAML
 
-      run_path = nil
-      processor.push_root_dir do
-        run_path = processor.current_dir
+      processor.in_root_dir do |dir|
+        assert_equal workspace.working_dir / "app/bar", dir
       end
-
-      assert_equal workspace.working_dir / "app/bar", run_path
     end
   end
 
-  def test_push_root_dir_without_config
+  def test_in_root_dir_without_config
     # when root_dir is not given, run is invoked within the working_dir
     with_workspace do |workspace|
       (workspace.working_dir / "app/bar").mkpath
 
       processor = new_processor(workspace: workspace)
 
-      run_path = nil
-      processor.push_root_dir do
-        run_path = processor.current_dir
+      processor.in_root_dir do |dir|
+        assert_equal workspace.working_dir, dir
       end
-
-      assert_equal workspace.working_dir, run_path
     end
   end
 

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -121,7 +121,8 @@ class ProcessorTest < Minitest::Test
       assert_equal Pathname("bar/baz"), processor.relative_path((workspace.working_dir / "foo/bar/baz").to_s, from: workspace.working_dir / "foo")
 
       # If relative path is given, interpreted from current_dir
-      processor.chdir workspace.working_dir / "foo" do
+      dir = (workspace.working_dir / "foo").tap(&:mkpath)
+      processor.chdir(dir) do
         assert_equal Pathname("foo/bar/baz"), processor.relative_path("bar/baz")
       end
     end

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -224,7 +224,7 @@ gem 'multi_json', git: 'https://github.com/intridea/multi_json.git', tag: 'v1.14
 gem 'rspec-request_describer', git: 'https://github.com/r7kamura/rspec-request_describer.git'
 EOF
 
-      shell.push_dir(path) do
+      shell.chdir(path) do
         Bundler.with_unbundled_env do
           shell.capture3!("bundle", "lock")
         end
@@ -509,7 +509,7 @@ source "https://rubygems.org"
 gem 'meowcop'
 EOF
 
-      shell.push_dir(workspace.working_dir) do
+      shell.chdir(workspace.working_dir) do
         Bundler.with_unbundled_env do
           shell.capture3!("bundle", "lock")
         end
@@ -557,7 +557,7 @@ source "https://rubygems.org"
 gem 'strong_json', '2.1.0'
 EOF
 
-      shell.push_dir(workspace.working_dir) do
+      shell.chdir(workspace.working_dir) do
         Bundler.with_unbundled_env do
           shell.capture3!("bundle", "lock")
         end
@@ -586,7 +586,7 @@ gem 'meowcop'
 gem 'rack'
 EOF
 
-      shell.push_dir(workspace.working_dir) do
+      shell.chdir(workspace.working_dir) do
         Bundler.with_unbundled_env do
           shell.capture3!("bundle", "lock")
         end
@@ -623,7 +623,7 @@ source "https://rubygems.org"
 gem 'multi_json', '1.12.0'
 EOF
 
-      shell.push_dir(workspace.working_dir) do
+      shell.chdir(workspace.working_dir) do
         Bundler.with_unbundled_env do
           shell.capture3!("bundle", "lock")
         end

--- a/test/shell_test.rb
+++ b/test/shell_test.rb
@@ -21,10 +21,19 @@ class ShellTest < Minitest::Test
       shell = Shell.new(current_dir: path, trace_writer: trace_writer, env_hash: {})
       assert_equal path, shell.current_dir
 
-      another_dir = (path / "foo").tap { |d| d.mkpath }
-      ret = shell.chdir(another_dir) do |dir|
-        assert_equal another_dir, dir
-        assert_equal another_dir, shell.current_dir
+      (path / "foo").tap(&:mkpath)
+      ret = shell.chdir(path / "foo") do |dir|
+        assert_equal(path / "foo", dir)
+        assert_equal(path / "foo", shell.current_dir)
+
+        # Nested
+        (dir / "bar").tap(&:mkpath)
+        shell.chdir(dir / "bar") do |dir2|
+          assert_equal(dir / "bar", dir2)
+          assert_equal(dir / "bar", shell.current_dir)
+        end
+
+        assert_equal(path / "foo", shell.current_dir)
         "Hi."
       end
       assert_equal "Hi.", ret

--- a/test/shell_test.rb
+++ b/test/shell_test.rb
@@ -16,6 +16,20 @@ class ShellTest < Minitest::Test
     assert_equal expected, actual
   end
 
+  def test_chdir
+    shell = Shell.new(current_dir: Pathname("foo"), trace_writer: trace_writer, env_hash: {})
+    assert_equal Pathname("foo"), shell.current_dir
+
+    ret = shell.chdir(Pathname("bar")) do |dir|
+      assert_equal Pathname("bar"), dir
+      assert_equal Pathname("bar"), shell.current_dir
+      "Hi."
+    end
+    assert_equal "Hi.", ret
+
+    assert_equal Pathname("foo"), shell.current_dir
+  end
+
   def test_capture3_trace
     mktmpdir do |path|
       shell = Shell.new(current_dir: path, trace_writer: trace_writer, env_hash: {})

--- a/test/shell_test.rb
+++ b/test/shell_test.rb
@@ -17,17 +17,20 @@ class ShellTest < Minitest::Test
   end
 
   def test_chdir
-    shell = Shell.new(current_dir: Pathname("foo"), trace_writer: trace_writer, env_hash: {})
-    assert_equal Pathname("foo"), shell.current_dir
+    mktmpdir do |path|
+      shell = Shell.new(current_dir: path, trace_writer: trace_writer, env_hash: {})
+      assert_equal path, shell.current_dir
 
-    ret = shell.chdir(Pathname("bar")) do |dir|
-      assert_equal Pathname("bar"), dir
-      assert_equal Pathname("bar"), shell.current_dir
-      "Hi."
+      another_dir = (path / "foo").tap { |d| d.mkpath }
+      ret = shell.chdir(another_dir) do |dir|
+        assert_equal another_dir, dir
+        assert_equal another_dir, shell.current_dir
+        "Hi."
+      end
+      assert_equal "Hi.", ret
+
+      assert_equal path, shell.current_dir
     end
-    assert_equal "Hi.", ret
-
-    assert_equal Pathname("foo"), shell.current_dir
   end
 
   def test_capture3_trace

--- a/test/smokes/goodcheck/expectations.rb
+++ b/test/smokes/goodcheck/expectations.rb
@@ -41,13 +41,13 @@ s.add_offline_test(
   analyzer: { name: "Goodcheck", version: "2.5.1" },
   warnings: [
     {
-      message: <<~MESSAGE.strip
-      Sider cannot find the required configuration file `goodcheck.yml`.
+      message: <<~MESSAGE.strip,
+Sider cannot find the required configuration file `goodcheck.yml`.
 Please set up Goodcheck by following the instructions, or you can disable it in the repository settings.
 
 - https://github.com/sider/goodcheck
 - https://help.sider.review/tools/others/goodcheck
-MESSAGE,
+MESSAGE
       file: nil
     }
   ]


### PR DESCRIPTION
The name `push_dir` is confusing to me because it looks that the word "push" has some side-effect.
(Please consider `Array#push`)

So, I suggest to rename it to `chdir` to improve the readability.
The standard library has the same name:
- [`Dir.chdir`](https://ruby-doc.org/core-2.7.1/Dir.html#method-c-chdir)
- [`Process.spawn`](https://ruby-doc.org/core-2.7.1/Process.html#method-c-spawn)

See also <https://github.com/sider/runners/pull/1084#discussion_r425560235>

