### PR TITLE
Add top-level `Bugsnag.notify`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.23.3...HEAD)
 
 - Add :use_local not to attempt to fetch gems remotely [#1078](https://github.com/sider/runners/pull/1078)
+- Add top-level `Bugsnag.notify` [#1086](https://github.com/sider/runners/pull/1086)
 
 ## 0.23.3
 

--- a/bin/runners
+++ b/bin/runners
@@ -11,7 +11,7 @@ class RunnersTimeoutError < StandardError; end
 
 EXIT_STATUS_FOR_SIGTERM = 126
 
-# @see https://docs.bugsnag.com/platforms/ruby/rails/configuration-options
+# @see https://docs.bugsnag.com/platforms/ruby/configuration-options
 Bugsnag.configure do |config|
   config.app_version = ENV["RUNNERS_VERSION"]
   config.release_stage = ENV["BUGSNAG_RELEASE_STAGE"]
@@ -32,4 +32,9 @@ trap('SIGUSR2') do
   Bugsnag.notify(RunnersTimeoutError.new)
 end
 
-Runners::CLI.new(argv: ARGV.dup, stdout: STDOUT, stderr: STDERR).run
+begin
+  Runners::CLI.new(argv: ARGV.dup, stdout: STDOUT, stderr: STDERR).run
+rescue => exn
+  Bugsnag.notify(exn)
+  raise
+end


### PR DESCRIPTION
Bugsnag automatically registers the `at_exit` hook:

- https://github.com/bugsnag/bugsnag-ruby/blob/0466dd2a654cc1adbd1e1bb2fb7ba128fae3ba85/lib/bugsnag.rb#L129
- https://docs.bugsnag.com/platforms/ruby/other/#reporting-unhandled-exceptions

```ruby
at_exit do
  $! #=> SystemExit is ignored by default.
end
```

But an exception captured in `at_exit` is a `SystemExit` class,
and Bugsnag [ignores it by default](https://docs.bugsnag.com/platforms/ruby/other/configuration-options/#ignore_classes).

So, this change aims to report an expected error to add the top-level `rescue` block.

### Note

Since `Runners::Harness` has already called `Bugsnag.notify`, this addition will not have a big impact:

https://github.com/sider/runners/blob/c6c97a293f72a7c79deb07c78d66f36efa5940de/lib/runners/harness.rb#L92