### PR TITLE
[Refactor] Remove unused `Changes#untracked_paths` method

### DIFF
--- a/lib/runners/changes.rb
+++ b/lib/runners/changes.rb
@@ -2,13 +2,11 @@ module Runners
   class Changes
     attr_reader :changed_paths
     attr_reader :unchanged_paths
-    attr_reader :untracked_paths
     attr_reader :patches
 
-    def initialize(changed_paths:, unchanged_paths:, untracked_paths:, patches:)
+    def initialize(changed_paths:, unchanged_paths:, patches:)
       @changed_paths = Set.new(changed_paths).freeze
       @unchanged_paths = Set.new(unchanged_paths).freeze
-      @untracked_paths = Set.new(untracked_paths).freeze
       @patches = patches
     end
 
@@ -52,7 +50,6 @@ module Runners
     def self.calculate(base_dir:, head_dir:, working_dir:, patches:)
       changed_paths = []
       unchanged_paths = []
-      untracked_paths = []
 
       Pathname.glob(working_dir + "**/*", File::FNM_DOTMATCH).each do |working_path|
         next unless working_path.file?
@@ -77,17 +74,12 @@ module Runners
             else
               changed_paths << relative_path
             end
-          else
-            untracked_paths << relative_path
           end
-        else
-          untracked_paths << relative_path
         end
       end
 
       new(changed_paths: changed_paths.sort!,
           unchanged_paths: unchanged_paths.sort!,
-          untracked_paths: untracked_paths.sort!,
           patches: patches)
     end
   end

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -89,12 +89,10 @@ end
 class Runners::Changes
   attr_reader changed_paths: Set<Pathname>
   attr_reader unchanged_paths: Set<Pathname>
-  attr_reader untracked_paths: Set<Pathname>
   attr_reader patches: GitDiffParser::Patches | nil
 
   def initialize: (changed_paths: Array<Pathname>,
                    unchanged_paths: Array<Pathname>,
-                   untracked_paths: Array<Pathname>,
                    patches: GitDiffParser::Patches | nil) -> any
   def delete_unchanged: (dir: Pathname, ?except: Array<String>, ?only: Array<String>) -> Array<Pathname>
   def deletable?: (Pathname, Pathname, Array<String>, Array<String>) -> bool

--- a/test/changes_test.rb
+++ b/test/changes_test.rb
@@ -60,7 +60,6 @@ index 740c016..cc737a5 100644
 
           assert_equal Set[Pathname("changed1.rb"), Pathname("changed2.rb")], changes.changed_paths
           assert_equal Set[Pathname("unchanged.rb")], changes.unchanged_paths
-          assert_equal Set[Pathname("built1.rb"), Pathname("built2.rb")], changes.untracked_paths
         end
       end
     end
@@ -91,7 +90,6 @@ index 740c016..cc737a5 100644
 
           assert_equal Set[Pathname("changed1.rb"), Pathname("changed2.rb"), Pathname("unchanged.rb")], changes.changed_paths
           assert_equal Set[], changes.unchanged_paths
-          assert_equal Set[Pathname("built1.rb"), Pathname("built2.rb")], changes.untracked_paths
         end
       end
     end
@@ -103,7 +101,7 @@ index 740c016..cc737a5 100644
       dir.join("file2").write("foo")
       dir.join("file3").write("foo")
 
-      changes = Changes.new(changed_paths: [], unchanged_paths: [Pathname("file1"), Pathname("file2"), Pathname("file3")], untracked_paths: [], patches: nil)
+      changes = Changes.new(changed_paths: [], unchanged_paths: [Pathname("file1"), Pathname("file2"), Pathname("file3")], patches: nil)
 
       changes.delete_unchanged(dir: dir)
 
@@ -128,7 +126,7 @@ index 740c016..cc737a5 100644
         ].each { |f| f.write("") }
       end
 
-      changes = Changes.new(changed_paths: [], unchanged_paths: files, untracked_paths: [], patches: nil)
+      changes = Changes.new(changed_paths: [], unchanged_paths: files, patches: nil)
       changes.delete_unchanged(dir: dir, only: ["file[2-3]", "*.{rb,py}"], except: ["file3", "*.{py,md}"])
 
       assert dir.join("file1").file?
@@ -138,25 +136,6 @@ index 740c016..cc737a5 100644
       assert dir.join("some", "bar.py").file?
       assert dir.join("some", "baz.js").file?
       assert dir.join("some", "xyz.md").file?
-    end
-  end
-
-  def test_symlink
-    mktmpdir do |base_path|
-      mktmpdir do |head_path|
-        mktmpdir do |working_path|
-          working_path.join("dir").mkdir
-          working_path.join("foo").write("bar")
-          working_path.join("baz").make_symlink(Pathname("foo"))
-          working_path.join("link").make_symlink(Pathname("../aaaaa"))
-
-          changes = Changes.calculate(base_dir: base_path, head_dir: head_path, working_dir: working_path, patches: nil)
-
-          assert changes.untracked_paths.include?(Pathname("foo"))
-          assert changes.untracked_paths.include?(Pathname("baz"))
-          refute changes.untracked_paths.include?(Pathname("link"))
-        end
-      end
     end
   end
 

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -84,7 +84,7 @@ class ResultTest < Minitest::Test
       schema: nil
     )
 
-    changes = Changes.new(changed_paths: [Pathname("foo/bar/xxx.rb")], unchanged_paths: [Pathname("foo/bar/baz.rb")], untracked_paths: [], patches: nil)
+    changes = Changes.new(changed_paths: [Pathname("foo/bar/xxx.rb")], unchanged_paths: [Pathname("foo/bar/baz.rb")], patches: nil)
     result.filter_issues(changes)
 
     assert result.valid?
@@ -145,7 +145,7 @@ class ResultTest < Minitest::Test
     )
 
 
-    changes = Changes.new(changed_paths: [Pathname("a.py")], unchanged_paths: [Pathname("b.py")], untracked_paths: [], patches: GitDiffParser.parse(<<~DIFF))
+    changes = Changes.new(changed_paths: [Pathname("a.py")], unchanged_paths: [Pathname("b.py")], patches: GitDiffParser.parse(<<~DIFF))
       diff --git a/a.py b/a.py
       index 23038dd..19bbab7 100644
       --- a/a.py

--- a/test/workspace_test.rb
+++ b/test/workspace_test.rb
@@ -44,7 +44,6 @@ class WorkspaceTest < Minitest::Test
 
         refute changes.changed_paths.empty?
         refute changes.unchanged_paths.empty?
-        assert changes.untracked_paths.empty?
       end
     end
   end
@@ -58,7 +57,6 @@ class WorkspaceTest < Minitest::Test
 
         refute changes.changed_paths.empty?
         refute changes.unchanged_paths.empty?
-        assert changes.untracked_paths.empty?
 
         refute workspace.root_tmp_dir.empty?
       end
@@ -74,7 +72,6 @@ class WorkspaceTest < Minitest::Test
 
         refute changes.changed_paths.empty?
         assert changes.unchanged_paths.empty?
-        assert changes.untracked_paths.empty?
       end
     end
   end


### PR DESCRIPTION
This method seems for symlinks but Sider does not analyze them.

Note: This PR is preparation for the issue #951.