### PR TITLE
[Refactor] Optimize `Changes.calculate` for patches

### DIFF
--- a/lib/runners/changes.rb
+++ b/lib/runners/changes.rb
@@ -48,6 +48,8 @@ module Runners
     end
 
     def self.calculate(base_dir:, head_dir:, working_dir:, patches:)
+      return calculate_by_patches(working_dir, patches) if patches
+
       changed_paths = []
       unchanged_paths = []
 
@@ -80,6 +82,18 @@ module Runners
 
       new(changed_paths: changed_paths.sort!,
           unchanged_paths: unchanged_paths.sort!,
+          patches: patches)
+    end
+
+    def self.calculate_by_patches(working_dir, patches)
+      all_files = working_dir
+        .glob("**/*", File::FNM_DOTMATCH)
+        .filter_map { |f| f.relative_path_from(working_dir) if f.file? }
+
+      changed_paths = patches.files.map { |f| Pathname(f) }
+
+      new(changed_paths: changed_paths.sort!,
+          unchanged_paths: (all_files - changed_paths).sort!,
           patches: patches)
     end
   end

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -78,6 +78,7 @@ extension Array (Polyfill)
   def +: <'x> (Array<'x>) -> Array<'a | 'x>
        | (self) -> self
   def filter: { ('a) -> bool } -> self
+  def filter_map: <'x> { ('a) -> 'x } -> Array<'x>
 end
 
 extension File (Polyfill)

--- a/sig/polyfills/git_diff_parser.rbi
+++ b/sig/polyfills/git_diff_parser.rbi
@@ -1,5 +1,6 @@
 class GitDiffParser::Patches
   def find_patch_by_file: (String) -> GitDiffParser::Patch?
+  def files: () -> Array<String>
 end
 
 class GitDiffParser::Patch

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -98,6 +98,7 @@ class Runners::Changes
   def deletable?: (Pathname, Pathname, Array<String>, Array<String>) -> bool
   def include?: (Issue) -> bool
   def self.calculate: (base_dir: Pathname, head_dir: Pathname, working_dir: Pathname, patches: GitDiffParser::Patches | nil) -> instance
+  def self.calculate_by_patches: (Pathname, GitDiffParser::Patches) -> instance
 end
 
 class Runners::Processor


### PR DESCRIPTION
The `GitDiffParser::Patches#files` method helps this optimization.

Note: This PR is prepartion for #915.
