### PR TITLE
[Refactor] Use head source directory as `Workspace#working_dir`

### DIFF
--- a/test/workspace_test.rb
+++ b/test/workspace_test.rb
@@ -33,17 +33,18 @@ class WorkspaceTest < Minitest::Test
   end
 
   def test_open
-    with_workspace(base: (Pathname(__dir__) + "data/encrypted.tar.gz").to_s,
+    with_workspace(base: data("encrypted.tar.gz"),
                    base_key: "CfAlFi2Uq3aiS3qSnq3Wq0gQWieTbt3151Z+iFXnE3o=",
-                   head: (Pathname(__dir__) + "data/foo.tgz").to_s,
+                   head: data("foo.tgz"),
                    head_key: nil,
     ) do |workspace|
       workspace.open do |_git_ssh_path, changes|
-        assert (workspace.working_dir + "querly.gemspec").file?
-        refute (workspace.working_dir + "foo.tgz").file?
+        assert_path_exists workspace.working_dir / "querly.gemspec"
+        assert_path_exists workspace.working_dir / "querly.gemspec"
+        refute_path_exists workspace.working_dir / "not_found.rb"
 
-        refute changes.changed_paths.empty?
-        refute changes.unchanged_paths.empty?
+        refute_empty changes.changed_paths
+        refute_empty changes.unchanged_paths
       end
     end
   end
@@ -52,26 +53,26 @@ class WorkspaceTest < Minitest::Test
     with_workspace(head: "998bc02a913e3899f3a1cd327e162dd54d489a4b", base: "abe1cfc294c8d39de7484954bf8c3d7792fd8ad1",
                    git_http_url: "https://github.com", owner: "sider", repo: "runners", pull_number: 533) do |workspace|
       workspace.open do |_git_ssh_path, changes|
-        assert (workspace.working_dir / "README.md").file?
-        refute (workspace.working_dir / ".git").exist?
+        assert_path_exists workspace.working_dir / "README.md"
+        refute_path_exists workspace.working_dir / ".git"
 
-        refute changes.changed_paths.empty?
-        refute changes.unchanged_paths.empty?
+        refute_empty changes.changed_paths
+        refute_empty changes.unchanged_paths
 
-        refute workspace.root_tmp_dir.empty?
+        refute_empty workspace.root_tmp_dir
       end
-      refute workspace.root_tmp_dir.exist?
+      refute_path_exists workspace.root_tmp_dir
     end
   end
 
   def test_open_without_base
     with_workspace(base: nil, base_key: nil) do |workspace|
       workspace.open do |_git_ssh_path, changes|
-        assert (workspace.working_dir + "querly.gemspec").file?
-        refute (workspace.working_dir + "foo.tgz").file?
+        assert_path_exists workspace.working_dir / "querly.gemspec"
+        refute_path_exists workspace.working_dir / "not_found.rb"
 
-        refute changes.changed_paths.empty?
-        assert changes.unchanged_paths.empty?
+        refute_empty changes.changed_paths
+        assert_empty changes.unchanged_paths
       end
     end
   end
@@ -85,7 +86,7 @@ class WorkspaceTest < Minitest::Test
   end
 
   def test_git_ssh_path_is_pathname
-    with_workspace(ssh_key: (Pathname(__dir__) / "data/ssh_key").read) do |workspace|
+    with_workspace(ssh_key: data("ssh_key").read) do |workspace|
       workspace.open do |git_ssh_path|
         refute_nil git_ssh_path
 
@@ -94,7 +95,7 @@ class WorkspaceTest < Minitest::Test
           "git", "clone", "--depth=1", "git@github.com:sider/runners.git",
           { chdir: workspace.working_dir.to_s }
         )
-        assert (workspace.working_dir / "runners/sider.yml").file?
+        assert_path_exists workspace.working_dir / "runners" / "sider.yml"
       end
     end
   end


### PR DESCRIPTION
I don't think we need to create another working directory for a head source code.
This change aims to simplify the code in the `Workspace#open` method.

This also removes extra copying from `head_path` to `working_dir`,
so it probably can improve the performance a bit.

Related to #1104

Note: This PR is preparation for #951.