### PR TITLE
Set `git config advice.detachedHead false` to reduce noises

### DIFF
--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -22,7 +22,7 @@ module Runners
     end
 
     def provision(commit_hash, dest)
-      shell.capture3!("git", "checkout", "--quiet", commit_hash, chdir: git_directory)
+      shell.capture3!("git", "checkout", commit_hash, chdir: git_directory)
       FileUtils.copy_entry(git_directory, dest)
       FileUtils.remove_entry(dest / ".git")
     end
@@ -32,6 +32,7 @@ module Runners
         shell.chdir(path) do
           shell.capture3!("git", "init")
           shell.capture3!("git", "config", "gc.auto", "0")
+          shell.capture3!("git", "config", "advice.detachedHead", "false")
           shell.capture3!("git", "remote", "add", "origin", remote_url.to_s)
           shell.capture3!("git", "fetch", *git_fetch_args)
         end

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -22,7 +22,7 @@ module Runners
     end
 
     def provision(commit_hash, dest)
-      shell.capture3!("git", "checkout", commit_hash, chdir: git_directory)
+      shell.capture3!("git", "checkout", "--quiet", commit_hash, chdir: git_directory)
       FileUtils.copy_entry(git_directory, dest)
       FileUtils.remove_entry(dest / ".git")
     end


### PR DESCRIPTION
~~Without `--quiet`, the following message is output to the trace. It's useless.~~
→ Instead of `--quiet`, this uses `config advice.detachedHead false`.

See <https://git-scm.com/docs/git-checkout#Documentation/git-checkout.txt---quiet>

```
Note: switching to '998bc02a913e3899f3a1cd327e162dd54d489a4b'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 998bc02a [HAML-Lint] Fix incompatiblity with RuboCop
```
