### PR TITLE
Optimize `Workspace::Git#patches`

### DIFF
--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -54,15 +54,17 @@ module Runners
     end
 
     def patches
+      return @patches if defined? @patches
+
       base = git_source.base
       head = git_source.head
-      if base && head
-        # NOTE: We should use `...` (triple-dot) instead of `..` (double-dot). See https://git-scm.com/docs/git-diff
-        stdout, _ = shell.capture3!("git", "diff", "#{base}...#{head}", trace_stdout: false, chdir: git_directory)
-        GitDiffParser.parse(stdout)
-      else
-        nil
-      end
+
+      @patches =
+        if base && head
+          # NOTE: We should use `...` (triple-dot) instead of `..` (double-dot). See https://git-scm.com/docs/git-diff
+          stdout, _ = shell.capture3!("git", "diff", "#{base}...#{head}", trace_stdout: false, chdir: git_directory)
+          GitDiffParser.parse(stdout)
+        end
     end
   end
 end

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -79,6 +79,16 @@ class WorkspaceGitTest < Minitest::Test
     end
   end
 
+  def test_patches_not_calling_git_diff_twice
+    with_workspace(base: "abe1cfc294c8d39de7484954bf8c3d7792fd8ad1", head: "998bc02a913e3899f3a1cd327e162dd54d489a4b",
+                   git_http_url: "https://github.com", owner: "sider", repo: "runners", pull_number: 533) do |workspace|
+      p1 = workspace.send(:patches)
+      p2 = workspace.send(:patches)
+      assert_same p1, p2
+      assert_equal 1, workspace.trace_writer.writer.count { |e| e[:command_line]&.slice(0, 2) == %w[git diff] }
+    end
+  end
+
   def test_git_blame_info
     with_workspace(base: "abe1cfc294c8d39de7484954bf8c3d7792fd8ad1", head: "998bc02a913e3899f3a1cd327e162dd54d489a4b",
                    git_http_url: "https://github.com", owner: "sider", repo: "runners", pull_number: 533) do |workspace|


### PR DESCRIPTION
This change aims to prevent that `git diff` is accidentally called twice.
