### PR TITLE
Fix "No space left" error on Git workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.24.0...HEAD)
 
+- Fix "No space left" error on Git workspace [#1112](https://github.com/sider/runners/pull/1112)
+
 ## 0.24.0
 
 [Full diff](https://github.com/sider/runners/compare/0.23.3...0.24.0)

--- a/lib/runners/workspace.rb
+++ b/lib/runners/workspace.rb
@@ -56,12 +56,6 @@ module Runners
           yield git_ssh_path, changes
         end
       end
-    ensure
-      FileUtils.remove_entry root_tmp_dir
-    end
-
-    def root_tmp_dir
-      @root_tmp_dir ||= mktmpdir_as_pathname
     end
 
     def range_git_blame_info(path_string, start_line, end_line)

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -2,41 +2,23 @@ module Runners
   class Workspace::Git < Workspace
     def range_git_blame_info(path_string, start_line, end_line)
       stdout, _ = shell.capture3!("git", "blame", "-p", "-L", "#{start_line},#{end_line}", git_source.head, "--", path_string,
-                                  trace_stdout: false, trace_stderr: true, chdir: git_directory)
+                                  trace_stdout: false, trace_stderr: true)
       GitBlameInfo.parse(stdout)
     end
 
     private
 
-    def prepare_base_source(dest)
-      base = git_source.base
-      if base
-        provision(base, dest)
-      else
-        raise ArgumentError, "base must not be nil"
-      end
+    def prepare_base_source(_dest)
+      # noop
     end
 
-    def prepare_head_source(dest)
-      provision(git_source.head, dest)
-    end
-
-    def provision(commit_hash, dest)
-      shell.capture3!("git", "checkout", commit_hash, chdir: git_directory)
-      FileUtils.copy_entry(git_directory, dest)
-      FileUtils.remove_entry(dest / ".git")
-    end
-
-    def git_directory
-      @git_directory ||= root_tmp_dir.tap do |path|
-        shell.chdir(path) do
-          shell.capture3!("git", "init")
-          shell.capture3!("git", "config", "gc.auto", "0")
-          shell.capture3!("git", "config", "advice.detachedHead", "false")
-          shell.capture3!("git", "remote", "add", "origin", remote_url.to_s)
-          shell.capture3!("git", "fetch", *git_fetch_args)
-        end
-      end
+    def prepare_head_source(_dest)
+      shell.capture3!("git", "init")
+      shell.capture3!("git", "config", "gc.auto", "0")
+      shell.capture3!("git", "config", "advice.detachedHead", "false")
+      shell.capture3!("git", "remote", "add", "origin", remote_url.to_s)
+      shell.capture3!("git", "fetch", *git_fetch_args)
+      shell.capture3!("git", "checkout", git_source.head)
     end
 
     def remote_url
@@ -47,9 +29,11 @@ module Runners
     end
 
     def git_fetch_args
-      @git_fetch_args ||= %w[--quiet --no-tags --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/*].tap do |command|
-        pull_number = git_source.pull_number
-        command << "+refs/pull/#{pull_number}/head:refs/remotes/pull/#{pull_number}/head" if pull_number
+      @git_fetch_args ||= %w[--quiet --no-tags --no-recurse-submodules origin].tap do |command|
+        command << "+refs/heads/*:refs/remotes/origin/*"
+
+        num = git_source.pull_number
+        command << "+refs/pull/#{num}/head:refs/remotes/pull/#{num}/head" if num
       end
     end
 
@@ -62,7 +46,7 @@ module Runners
       @patches =
         if base && head
           # NOTE: We should use `...` (triple-dot) instead of `..` (double-dot). See https://git-scm.com/docs/git-diff
-          stdout, _ = shell.capture3!("git", "diff", "#{base}...#{head}", trace_stdout: false, chdir: git_directory)
+          stdout, _ = shell.capture3!("git", "diff", "#{base}...#{head}", trace_stdout: false)
           GitDiffParser.parse(stdout)
         end
     end

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -22,6 +22,9 @@ class Pathname
   def fnmatch?: (String, Integer) -> bool
   def delete: -> void
   def to_path: -> String
+  def rename: (Pathname) -> 0
+  def parent: -> Pathname
+  def rmdir: -> 0
 end
 
 extension Object (Polyfill)

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -191,6 +191,8 @@ class Runners::Shell::ExecError < Runners::SystemError
 end
 
 class Runners::Harness
+  include Tmpdir
+
   attr_reader guid: String
   attr_reader processor_class: Processor.class constructor
   attr_reader options: Options
@@ -203,6 +205,7 @@ class Runners::Harness
   def run: () -> result
   def ensure_result: { -> result } -> result
   def handle_error: (Exception) -> void
+  def exclude_special_dirs: <'x> { -> 'x } -> 'x
 end
 
 class Runners::Harness::InvalidResult < StandardError

--- a/sig/runners/workspace.rbi
+++ b/sig/runners/workspace.rbi
@@ -17,7 +17,6 @@ class Runners::Workspace
   def extract: (Pathname, Pathname) -> void
   def archive_source: () -> Options::ArchiveSource
   def git_source: () -> Options::GitSource
-  def root_tmp_dir: () -> Pathname
   def patches: () -> GitDiffParser::Patches?
   def range_git_blame_info: (String, Integer, Integer) -> Array<GitBlameInfo>
 end
@@ -40,8 +39,6 @@ end
 class Runners::Workspace::Git < Workspace
   def prepare_base_source: (Pathname) -> void
   def prepare_head_source: (Pathname) -> void
-  def provision: (String, Pathname) -> void
-  def git_directory: () -> Pathname
   def remote_url: () -> URI
   def git_fetch_args: () -> Array<String>
 end

--- a/sig_new/runners/harness.rbs
+++ b/sig_new/runners/harness.rbs
@@ -1,4 +1,6 @@
 class Runners::Harness
+  include Tmpdir
+
   attr_reader guid: String
   attr_reader processor_class: Class
   attr_reader options: Options
@@ -15,4 +17,5 @@ class Runners::Harness
   def run: () -> untyped
   def ensure_result: () { () -> untyped } -> untyped
   def handle_error: (Exception exn) -> void
+  def exclude_special_dirs: [X] { () -> X } -> X
 end

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -5,83 +5,86 @@ class WorkspaceGitTest < Minitest::Test
 
   GitBlameInfo = Runners::GitBlameInfo
 
-  def test_prepare_head_source
-    with_workspace(head: "998bc02a913e3899f3a1cd327e162dd54d489a4b",
-                   git_http_url: "https://github.com", owner: "sider", repo: "runners", pull_number: 533) do |workspace|
+  def workspace_params
+    {
+      head: "998bc02a913e3899f3a1cd327e162dd54d489a4b",
+      git_http_url: "https://github.com",
+      owner: "sider",
+      repo: "runners",
+      pull_number: 533,
+    }
+  end
+
+  def workspace_params_with_base
+    workspace_params.merge(base: "abe1cfc294c8d39de7484954bf8c3d7792fd8ad1")
+  end
+
+  def test_instance_class
+    with_workspace(**workspace_params) do |workspace|
       assert_instance_of Runners::Workspace::Git, workspace
-      mktmpdir do |dest|
-        workspace.send(:prepare_head_source, dest)
-        refute_empty dest.children
-        assert (dest / "README.md").file?
-        refute (dest / ".git").exist?
-      end
     end
   end
 
-  def test_prepare_base_source_raise_if_base_is_nil
-    with_workspace(head: "998bc02a913e3899f3a1cd327e162dd54d489a4b",
-                   git_http_url: "https://github.com", owner: "sider", repo: "runners", pull_number: 533) do |workspace|
-      assert_instance_of Runners::Workspace::Git, workspace
-      mktmpdir do |dest|
-        assert_raises(ArgumentError) do
-          workspace.send(:prepare_base_source, dest)
-        end
-      end
+  def test_prepare_head_source
+    with_workspace(**workspace_params) do |workspace|
+      workspace.send(:prepare_head_source, nil)
+
+      dest = workspace.working_dir
+      refute_empty dest.children
+      assert_path_exists dest / "README.md"
+      assert_path_exists dest / ".git"
     end
   end
 
   def test_remote_url
-    with_workspace(head: "commit",
-                   git_http_url: "https://github.example.com", owner: "foo", repo: "bar") do |workspace|
-      assert_instance_of Runners::Workspace::Git, workspace
-      assert_equal URI("https://github.example.com/foo/bar"), workspace.send(:remote_url)
+    with_workspace(**workspace_params) do |workspace|
+      assert_equal URI("https://github.com/sider/runners"), workspace.send(:remote_url)
     end
   end
 
   def test_remote_url_with_token
-    with_workspace(head: "commit",
-                   git_http_url: "https://github.com", owner: "foo", repo: "bar",
-                   git_http_userinfo: "x-access-token:v1.aaabbbcccdddeeefffgggbc06400127f248a82ac") do |workspace|
-      assert_instance_of Runners::Workspace::Git, workspace
-      assert_equal URI("https://x-access-token:v1.aaabbbcccdddeeefffgggbc06400127f248a82ac@github.com/foo/bar"), workspace.send(:remote_url)
+    params = workspace_params.merge(git_http_userinfo: "x-access-token:v1.aaabbbcccdddeeefffgggbc06400127f248a82ac")
+    with_workspace(**params) do |workspace|
+      assert_equal URI("https://x-access-token:v1.aaabbbcccdddeeefffgggbc06400127f248a82ac@github.com/sider/runners"), workspace.send(:remote_url)
     end
   end
 
   def test_git_fetch_args
-    with_workspace(head: "998bc02a913e3899f3a1cd327e162dd54d489a4b",
-                   git_http_url: "https://github.com", owner: "sider", repo: "runners", pull_number: 533) do |workspace|
-      assert_instance_of Runners::Workspace::Git, workspace
-      assert_equal %w[--quiet --no-tags --no-recurse-submodules origin
-                          +refs/heads/*:refs/remotes/origin/* +refs/pull/533/head:refs/remotes/pull/533/head], workspace.send(:git_fetch_args)
+    with_workspace(**workspace_params) do |workspace|
+      assert_equal %w[
+        --quiet --no-tags --no-recurse-submodules origin
+        +refs/heads/*:refs/remotes/origin/*
+        +refs/pull/533/head:refs/remotes/pull/533/head
+      ], workspace.send(:git_fetch_args)
     end
+  end
 
-    with_workspace(head: "998bc02a913e3899f3a1cd327e162dd54d489a4b",
-                   git_http_url: "https://github.com", owner: "sider", repo: "runners") do |workspace|
-      assert_instance_of Runners::Workspace::Git, workspace
-      assert_equal %w[--quiet --no-tags --no-recurse-submodules origin
-                          +refs/heads/*:refs/remotes/origin/*], workspace.send(:git_fetch_args)
+  def test_git_fetch_args_without_pull_number
+    params = workspace_params.tap { |p| p.delete(:pull_number) }
+    with_workspace(**params) do |workspace|
+      assert_equal %w[
+        --quiet --no-tags --no-recurse-submodules origin
+        +refs/heads/*:refs/remotes/origin/*
+      ], workspace.send(:git_fetch_args)
     end
   end
 
   def test_patches_returns_nil_because_base_is_nil
-    with_workspace(head: "998bc02a913e3899f3a1cd327e162dd54d489a4b",
-                   git_http_url: "https://github.com", owner: "sider", repo: "runners", pull_number: 533) do |workspace|
-      assert_instance_of Runners::Workspace::Git, workspace
+    with_workspace(**workspace_params) do |workspace|
       assert_nil workspace.send(:patches)
     end
   end
 
   def test_patches_returns_patches
-    with_workspace(base: "abe1cfc294c8d39de7484954bf8c3d7792fd8ad1", head: "998bc02a913e3899f3a1cd327e162dd54d489a4b",
-                   git_http_url: "https://github.com", owner: "sider", repo: "runners", pull_number: 533) do |workspace|
-      assert_instance_of Runners::Workspace::Git, workspace
+    with_workspace(**workspace_params_with_base) do |workspace|
+      workspace.send(:prepare_head_source, nil)
       assert_instance_of GitDiffParser::Patches, workspace.send(:patches)
     end
   end
 
   def test_patches_not_calling_git_diff_twice
-    with_workspace(base: "abe1cfc294c8d39de7484954bf8c3d7792fd8ad1", head: "998bc02a913e3899f3a1cd327e162dd54d489a4b",
-                   git_http_url: "https://github.com", owner: "sider", repo: "runners", pull_number: 533) do |workspace|
+    with_workspace(**workspace_params_with_base) do |workspace|
+      workspace.send(:prepare_head_source, nil)
       p1 = workspace.send(:patches)
       p2 = workspace.send(:patches)
       assert_same p1, p2
@@ -90,8 +93,8 @@ class WorkspaceGitTest < Minitest::Test
   end
 
   def test_git_blame_info
-    with_workspace(base: "abe1cfc294c8d39de7484954bf8c3d7792fd8ad1", head: "998bc02a913e3899f3a1cd327e162dd54d489a4b",
-                   git_http_url: "https://github.com", owner: "sider", repo: "runners", pull_number: 533) do |workspace|
+    with_workspace(**workspace_params_with_base) do |workspace|
+      workspace.send(:prepare_head_source, nil)
       info = workspace.range_git_blame_info('test/smokes/haml_lint/expectations.rb', 137, 140)
       assert_equal(
         [

--- a/test/workspace_test.rb
+++ b/test/workspace_test.rb
@@ -54,14 +54,11 @@ class WorkspaceTest < Minitest::Test
                    git_http_url: "https://github.com", owner: "sider", repo: "runners", pull_number: 533) do |workspace|
       workspace.open do |_git_ssh_path, changes|
         assert_path_exists workspace.working_dir / "README.md"
-        refute_path_exists workspace.working_dir / ".git"
+        assert_path_exists workspace.working_dir / ".git"
 
         refute_empty changes.changed_paths
         refute_empty changes.unchanged_paths
-
-        refute_empty workspace.root_tmp_dir
       end
-      refute_path_exists workspace.root_tmp_dir
     end
   end
 


### PR DESCRIPTION
This change aims to prevent the "No space left on device" error by stopping a copy of the entire working directory.

https://github.com/sider/runners/blob/48e04a96ee7e477394deb6a836edda3ded5e5c3b/lib/runners/workspace/git.rb#L26

This removal makes the `Workspace::Git` code more simple.

Fix #951

