### PR TITLE
[Refactor] Remove dependency on `Workspace` from `Processor`

### DIFF
--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -37,7 +37,7 @@ module Runners
           Ignoring.new(working_dir: working_dir, trace_writer: trace_writer, config: conf).delete_ignored_files!
 
           begin
-            processor = processor_class.new(guid: guid, workspace: workspace, config: conf, git_ssh_path: git_ssh_path, trace_writer: trace_writer)
+            processor = processor_class.new(guid: guid, working_dir: working_dir, config: conf, git_ssh_path: git_ssh_path, trace_writer: trace_writer)
 
             root_dir_not_found = processor.check_root_dir_exist
             return root_dir_not_found if root_dir_not_found

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -5,7 +5,7 @@ module Runners
 
     class CIConfigBroken < UserError; end
 
-    attr_reader :guid, :workspace, :working_dir, :git_ssh_path, :trace_writer, :warnings, :config, :shell
+    attr_reader :guid, :working_dir, :git_ssh_path, :trace_writer, :warnings, :config, :shell
 
     def_delegators :@shell,
       :chdir, :current_dir,
@@ -16,10 +16,9 @@ module Runners
       Schema::Config.register(**args)
     end
 
-    def initialize(guid:, workspace:, config:, git_ssh_path:, trace_writer:)
+    def initialize(guid:, working_dir:, config:, git_ssh_path:, trace_writer:)
       @guid = guid
-      @workspace = workspace
-      @working_dir = workspace.working_dir
+      @working_dir = working_dir
       @git_ssh_path = git_ssh_path
       @trace_writer = trace_writer
       @warnings = []

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -106,7 +106,6 @@ class Runners::Processor
   include Tmpdir
 
   attr_reader guid: String
-  attr_reader workspace: Workspace
   attr_reader working_dir: Pathname
   attr_reader git_ssh_path: Pathname?
   attr_reader trace_writer: TraceWriter
@@ -114,7 +113,7 @@ class Runners::Processor
   attr_reader warnings: Array<any>
   attr_reader config: Config
 
-  def initialize: (guid: String, workspace: Workspace, config: Config, git_ssh_path: Pathname?, trace_writer: TraceWriter) -> any
+  def initialize: (guid: String, working_dir: Pathname, config: Config, git_ssh_path: Pathname?, trace_writer: TraceWriter) -> any
   def relative_path: (String | Pathname, ?from: Pathname) -> Pathname
   def setup: () { -> result } -> result
   def analyze: (Changes) -> result

--- a/test/nodejs_test.rb
+++ b/test/nodejs_test.rb
@@ -51,7 +51,7 @@ class NodejsTest < Minitest::Test
   def new_processor(workspace:)
     @processor = processor_class.new(
       guid: SecureRandom.uuid,
-      workspace: workspace,
+      working_dir: workspace.working_dir,
       config: config,
       git_ssh_path: nil,
       trace_writer: trace_writer,

--- a/test/processor/phpmd_test.rb
+++ b/test/processor/phpmd_test.rb
@@ -10,7 +10,7 @@ class Runners::Processor::PhpmdTest < Minitest::Test
   end
 
   def subject(workspace, yaml: nil)
-    Phpmd.new(guid: SecureRandom.uuid, workspace: workspace, config: config(yaml), git_ssh_path: nil, trace_writer: trace_writer).tap do |s|
+    Phpmd.new(guid: SecureRandom.uuid, working_dir: workspace.working_dir, config: config(yaml), git_ssh_path: nil, trace_writer: trace_writer).tap do |s|
       stub(s).analyzer_id { "phpmd" }
     end
   end

--- a/test/processor/remark_lint_test.rb
+++ b/test/processor/remark_lint_test.rb
@@ -14,7 +14,7 @@ class Runners::Processor::RemarkLintTest < Minitest::Test
   def setup_subject(workspace)
     @subject = Runners::Processor::RemarkLint.new(
       guid: SecureRandom.uuid,
-      workspace: workspace,
+      working_dir: workspace.working_dir,
       config: config,
       trace_writer: trace_writer,
       git_ssh_path: nil

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -24,7 +24,7 @@ class ProcessorTest < Minitest::Test
   def new_processor(workspace:, git_ssh_path: nil, config_yaml: nil)
     processor_class.new(
       guid: SecureRandom.uuid,
-      workspace: workspace,
+      working_dir: workspace.working_dir,
       config: config(config_yaml),
       git_ssh_path: git_ssh_path,
       trace_writer: trace_writer,

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -33,7 +33,7 @@ class RubyTest < Minitest::Test
   def new_processor(workspace:, git_ssh_path: nil, config_yaml: nil)
     processor_class.new(
       guid: SecureRandom.uuid,
-      workspace: workspace,
+      working_dir: workspace.working_dir,
       config: config(config_yaml),
       git_ssh_path: git_ssh_path,
       trace_writer: trace_writer,


### PR DESCRIPTION
The `Processor` class needs only `working_dir` and does not need the `Workspace` class.

I think the removal of the extra dependency leads to better maintainability.