### PR TITLE
Migrate Prettier to RuboCop with `--safe-auto-correct`

### DIFF
--- a/.rubocop-formatter.yml
+++ b/.rubocop-formatter.yml
@@ -1,0 +1,11 @@
+AllCops:
+  DefaultFormatter: quiet
+
+Layout/LineLength:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -20,5 +20,5 @@ group :development, :test do
   gem 'steep', "0.11.1", require: false
   gem 'aufgaben', git: 'https://github.com/ybiquitous/aufgaben.git', tag: '0.5.0', require: false
   gem 'lefthook', require: false
-  gem 'prettier', require: false
+  gem 'rubocop', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,6 @@ GEM
     parallel (1.19.1)
     parser (2.7.1.1)
       ast (~> 2.4.0)
-    prettier (0.18.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -68,6 +67,14 @@ GEM
     retryable (3.0.5)
     rexml (3.2.4)
     rr (1.2.1)
+    rubocop (0.83.0)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rexml
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    ruby-progressbar (1.10.1)
     steep (0.11.1)
       activesupport (>= 5.1)
       ast_utils (~> 0.3.0)
@@ -81,6 +88,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    unicode-display_width (1.7.0)
     unification_assertion (0.0.1)
       minitest (~> 5)
     zeitwerk (2.3.0)
@@ -100,11 +108,11 @@ DEPENDENCIES
   locale
   minitest
   parallel
-  prettier
   rake
   retryable
   rexml (>= 3.2, < 4.0)
   rr
+  rubocop
   steep (= 0.11.1)
   strong_json (= 2.1.0)
   unification_assertion

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,6 @@
 pre-commit:
   parallel: true
   commands:
-    prettier:
+    format-smoke-tests:
       glob: "test/smokes/**/expectations.rb"
-      run: bundle exec rbprettier --write {staged_files} && git add {staged_files}
+      run: bundle exec rubocop -c .rubocop-formatter.yml --safe-auto-correct {staged_files} && git add {staged_files}

--- a/test/smokes/brakeman/expectations.rb
+++ b/test/smokes/brakeman/expectations.rb
@@ -149,12 +149,12 @@ s.add_test(
   warnings: [
     {
       message: <<~MESSAGE.strip,
-Sider tried to install `brakeman 4.4.0` according to your `Gemfile.lock`, but it installs `4.3.1` instead.
-Because `4.4.0` does not satisfy the Sider constraints [\">= 4.0.0\", \"< 4.4.0\"].
+        Sider tried to install `brakeman 4.4.0` according to your `Gemfile.lock`, but it installs `4.3.1` instead.
+        Because `4.4.0` does not satisfy the Sider constraints [\">= 4.0.0\", \"< 4.4.0\"].
 
-If you want to use a different version of `brakeman`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
-See https://help.sider.review/getting-started/custom-configuration#gems-option
-MESSAGE
+        If you want to use a different version of `brakeman`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
+        See https://help.sider.review/getting-started/custom-configuration#gems-option
+      MESSAGE
       file: nil
     }
   ]

--- a/test/smokes/code_sniffer/expectations.rb
+++ b/test/smokes/code_sniffer/expectations.rb
@@ -36,11 +36,11 @@ s.add_test(
   analyzer: { name: "PHP_CodeSniffer", version: "3.5.5" },
   warnings: [
     {
-     message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The `$.linter.code_sniffer.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/php/codesniffer ).
-MSG
+      message: <<~MSG.strip,
+        DEPRECATION WARNING!!!
+        The `$.linter.code_sniffer.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/php/codesniffer ).
+      MSG
       file: "sideci.yml"
     }
   ]
@@ -107,7 +107,7 @@ s.add_test(
       path: "src/test.php",
       location: { start_line: 2 },
       id: "Squiz.Functions.GlobalFunction.Found",
-      message: "Consider putting global function \"foo\" in a static class",
+      message: 'Consider putting global function "foo" in a static class',
       links: [],
       object: { type: "WARNING", severity: 5, fixable: false },
       git_blame_info: nil

--- a/test/smokes/code_sniffer/phpcs3/expectations.rb
+++ b/test/smokes/code_sniffer/phpcs3/expectations.rb
@@ -148,7 +148,7 @@ s.add_test(
       path: "app.php",
       location: { start_line: 5 },
       id: "Squiz.Functions.GlobalFunction.Found",
-      message: "Consider putting global function \"test\" in a static class",
+      message: 'Consider putting global function "test" in a static class',
       links: [],
       object: { type: "WARNING", severity: 5, fixable: false },
       git_blame_info: nil
@@ -157,7 +157,7 @@ s.add_test(
       path: "app.php",
       location: { start_line: 14 },
       id: "Squiz.Functions.GlobalFunction.Found",
-      message: "Consider putting global function \"test\" in a static class",
+      message: 'Consider putting global function "test" in a static class',
       links: [],
       object: { type: "WARNING", severity: 5, fixable: false },
       git_blame_info: nil
@@ -166,7 +166,7 @@ s.add_test(
       path: "app.php",
       location: { start_line: 21 },
       id: "Squiz.Functions.GlobalFunction.Found",
-      message: "Consider putting global function \"testWithCallBack\" in a static class",
+      message: 'Consider putting global function "testWithCallBack" in a static class',
       links: [],
       object: { type: "WARNING", severity: 5, fixable: false },
       git_blame_info: nil

--- a/test/smokes/coffeelint/expectations.rb
+++ b/test/smokes/coffeelint/expectations.rb
@@ -48,10 +48,10 @@ s.add_test(
   warnings: [
     {
       message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The `$.linter.coffeelint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/coffeelint ).
-MSG
+        DEPRECATION WARNING!!!
+        The `$.linter.coffeelint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/coffeelint ).
+      MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/cpplint/expectations.rb
+++ b/test/smokes/cpplint/expectations.rb
@@ -8,7 +8,7 @@ s.add_test(
       id: "legal/copyright",
       path: "src/test.cpp",
       location: nil,
-      message: "No copyright message found.  You should have a line: \"Copyright [year] <Copyright Owner>\"",
+      message: 'No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"',
       links: [],
       object: { confidence: "5" },
       git_blame_info: nil

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -38,8 +38,8 @@ s.add_test(
   "pinned_old_eslint",
   type: "failure",
   message: <<~MSG.strip,
-Your `eslint` settings could not satisfy the required constraints. Please check your `package.json` again.
-If you want to analyze via the Sider default settings, please configure your `sideci.yml`. For details, see the documentation.
+    Your `eslint` settings could not satisfy the required constraints. Please check your `package.json` again.
+    If you want to analyze via the Sider default settings, please configure your `sideci.yml`. For details, see the documentation.
   MSG
   analyzer: :_
 )
@@ -132,10 +132,10 @@ s.add_test(
   warnings: [
     {
       message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The `$.linter.eslint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/eslint ).
-MSG
+        DEPRECATION WARNING!!!
+        The `$.linter.eslint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/eslint ).
+      MSG
       file: "sideci.yml"
     }
   ]
@@ -278,15 +278,15 @@ s.add_test(
   issues: [
     {
       message: <<~MESSAGE.strip,
-Parsing error: Unexpected token, expected ";"
-
-  1 | function bar() {
-> 2 |   var x = foo:
-    |              ^
-  3 |   for (;;) {
-  4 |     break x;
-  5 |   }
-MESSAGE
+        Parsing error: Unexpected token, expected ";"
+        
+          1 | function bar() {
+        > 2 |   var x = foo:
+            |              ^
+          3 |   for (;;) {
+          4 |     break x;
+          5 |   }
+      MESSAGE
       links: [],
       id: "d91b54561db04524f183f5f8dee752dcf1d4fcb0",
       path: "index.js",

--- a/test/smokes/flake8/expectations.rb
+++ b/test/smokes/flake8/expectations.rb
@@ -125,7 +125,7 @@ s.add_test(
       path: "foo.py",
       location: { start_line: 2 },
       id: "A001",
-      message: "\"id\" is a python builtin and is being shadowed, consider renaming the variable",
+      message: '"id" is a python builtin and is being shadowed, consider renaming the variable',
       links: [],
       object: nil,
       git_blame_info: nil

--- a/test/smokes/go_vet/expectations.rb
+++ b/test/smokes/go_vet/expectations.rb
@@ -18,10 +18,10 @@ s.add_test(
   warnings: [
     {
       message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The support for go vet is deprecated. Sider will drop these versions on May 31, 2020.
-Please consider using an alternative tool GolangCI-Lint. See https://help.sider.review/tools/go/govet
-MSG
+        DEPRECATION WARNING!!!
+        The support for go vet is deprecated. Sider will drop these versions on May 31, 2020.
+        Please consider using an alternative tool GolangCI-Lint. See https://help.sider.review/tools/go/govet
+      MSG
       file: "sider.yml"
     }
   ]

--- a/test/smokes/golint/expectations.rb
+++ b/test/smokes/golint/expectations.rb
@@ -18,10 +18,10 @@ s.add_test(
   warnings: [
     {
       message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The support for Golint is deprecated. Sider will drop these versions on May 31, 2020.
-Please consider using an alternative tool GolangCI-Lint. See https://help.sider.review/tools/go/golint
-MSG
+        DEPRECATION WARNING!!!
+        The support for Golint is deprecated. Sider will drop these versions on May 31, 2020.
+        Please consider using an alternative tool GolangCI-Lint. See https://help.sider.review/tools/go/golint
+      MSG
       file: "sider.yml"
     }
   ]

--- a/test/smokes/gometalinter/expectations.rb
+++ b/test/smokes/gometalinter/expectations.rb
@@ -8,10 +8,10 @@ s.add_test(
   warnings: [
     {
       message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The support for Go Meta Linter is deprecated. Sider will drop these versions on May 31, 2020.
-Please consider using an alternative tool GolangCI-Lint. See https://github.com/alecthomas/gometalinter/issues/590
-MSG
+        DEPRECATION WARNING!!!
+        The support for Go Meta Linter is deprecated. Sider will drop these versions on May 31, 2020.
+        Please consider using an alternative tool GolangCI-Lint. See https://github.com/alecthomas/gometalinter/issues/590
+      MSG
       file: "sider.yml"
     }
   ]
@@ -49,7 +49,7 @@ s.add_test(
       git_blame_info: nil
     },
     {
-      message: "[golint] comment on exported const Id should be of the form \"Id ...\"",
+      message: '[golint] comment on exported const Id should be of the form "Id ..."',
       links: [],
       id: "5058a11cfd937cc5547f20ededd3629ff875a2ca",
       path: "main.go",
@@ -58,7 +58,7 @@ s.add_test(
       git_blame_info: nil
     },
     {
-      message: "[golint] comment on exported function NoDocFunc should be of the form \"NoDocFunc ...\"",
+      message: '[golint] comment on exported function NoDocFunc should be of the form "NoDocFunc ..."',
       links: [],
       id: "54b8e33e5e4f35fef5654c7280e6e3b24be91de0",
       path: "main.go",
@@ -67,7 +67,7 @@ s.add_test(
       git_blame_info: nil
     },
     {
-      message: Regexp.new(Regexp.escape("[gotype] could not import os/exec (type-checking package \"os/exec\" failed")),
+      message: Regexp.new(Regexp.escape('[gotype] could not import os/exec (type-checking package "os/exec" failed')),
       links: [],
       id: "6a64372708d696ef4a6634706e74b3d9b69a813c",
       path: "main.go",
@@ -76,7 +76,7 @@ s.add_test(
       git_blame_info: nil
     },
     {
-      message: Regexp.new(Regexp.escape("[gotype] could not import fmt (type-checking package \"fmt\" failed")),
+      message: Regexp.new(Regexp.escape('[gotype] could not import fmt (type-checking package "fmt" failed')),
       links: [],
       id: "873e123509f57e9ea64859ad99cf4aa3688949cb",
       path: "main.go",

--- a/test/smokes/goodcheck/expectations.rb
+++ b/test/smokes/goodcheck/expectations.rb
@@ -42,12 +42,12 @@ s.add_offline_test(
   warnings: [
     {
       message: <<~MESSAGE.strip,
-Sider cannot find the required configuration file `goodcheck.yml`.
-Please set up Goodcheck by following the instructions, or you can disable it in the repository settings.
-
-- https://github.com/sider/goodcheck
-- https://help.sider.review/tools/others/goodcheck
-MESSAGE
+        Sider cannot find the required configuration file `goodcheck.yml`.
+        Please set up Goodcheck by following the instructions, or you can disable it in the repository settings.
+        
+        - https://github.com/sider/goodcheck
+        - https://help.sider.review/tools/others/goodcheck
+      MESSAGE
       file: nil
     }
   ]
@@ -56,7 +56,7 @@ MESSAGE
 s.add_offline_test(
   "invalid_config_file",
   type: "failure",
-  message: "Invalid config: TypeError at $.rules[0]: expected=rule, value=\"id:foo\"",
+  message: 'Invalid config: TypeError at $.rules[0]: expected=rule, value="id:foo"',
   analyzer: { name: "Goodcheck", version: "2.5.1" }
 )
 

--- a/test/smokes/haml_lint/expectations.rb
+++ b/test/smokes/haml_lint/expectations.rb
@@ -35,10 +35,10 @@ s.add_test(
   warnings: [
     {
       message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The `$.linter.haml_lint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/haml-lint ).
-MSG
+        DEPRECATION WARNING!!!
+        The `$.linter.haml_lint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/haml-lint ).
+      MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/jshint/expectations.rb
+++ b/test/smokes/jshint/expectations.rb
@@ -25,7 +25,7 @@ s.add_test(
       path: "index.js",
       location: { start_line: 1 },
       id: "jshint.W097",
-      message: "Use the function form of \"use strict\".",
+      message: 'Use the function form of "use strict".',
       links: [],
       object: nil,
       git_blame_info: nil
@@ -94,10 +94,10 @@ s.add_test(
   warnings: [
     {
       message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The `$.linter.jshint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/jshint ).
-MSG
+        DEPRECATION WARNING!!!
+        The `$.linter.jshint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/javascript/jshint ).
+      MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/languagetool/expectations.rb
+++ b/test/smokes/languagetool/expectations.rb
@@ -68,7 +68,7 @@ s.add_test(
       id: "DOUSI_KOTOGADEKIRU",
       path: "sample.txt",
       location: { start_line: 1 },
-      message: "省略が可能です。暮\"らせる\"",
+      message: '省略が可能です。暮"らせる"',
       links: [],
       object: {
         sentence: "これわ文章を入力して'CheckText'をクリックすると、誤記を探すことができる。",
@@ -82,7 +82,7 @@ s.add_test(
       id: "KOREWA",
       path: "sample.txt",
       location: { start_line: 1 },
-      message: "文法ミスがあります。\"これは\"の間違いです。",
+      message: '文法ミスがあります。"これは"の間違いです。',
       links: [],
       object: {
         sentence: "これわ文章を入力して'CheckText'をクリックすると、誤記を探すことができる。",
@@ -121,10 +121,10 @@ s.add_test(
       id: "EN_QUOTES",
       path: "target.html",
       location: { start_line: 3 },
-      message: "Use a smart closing quote here: \"”\".",
+      message: 'Use a smart closing quote here: "”".',
       links: [],
       object: {
-        sentence: "<p class=\"normal\">This is a sample <em>HTML</em> file.</p>",
+        sentence: '<p class="normal">This is a sample <em>HTML</em> file.</p>',
         type: "typographical",
         category: "TYPOGRAPHY",
         replacements: %w[”]
@@ -135,10 +135,10 @@ s.add_test(
       id: "EN_QUOTES",
       path: "target.html",
       location: { start_line: 3 },
-      message: "Use a smart closing quote here: \"”\".",
+      message: 'Use a smart closing quote here: "”".',
       links: [],
       object: {
-        sentence: "<p class=\"normal\">This is a sample <em>HTML</em> file.</p>",
+        sentence: '<p class="normal">This is a sample <em>HTML</em> file.</p>',
         type: "typographical",
         category: "TYPOGRAPHY",
         replacements: %w[”]
@@ -188,7 +188,7 @@ s.add_test(
       id: "KOREWA",
       path: "sample.txt",
       location: { start_line: 1 },
-      message: "文法ミスがあります。\"これは\"の間違いです。",
+      message: '文法ミスがあります。"これは"の間違いです。',
       links: [],
       object: { sentence: "これわペンです。", type: "uncategorized", category: "CAT1", replacements: %w[これは] },
       git_blame_info: nil

--- a/test/smokes/misspell/expectations.rb
+++ b/test/smokes/misspell/expectations.rb
@@ -5,7 +5,7 @@ s.add_offline_test(
   type: "success",
   issues: [
     {
-      message: "\"infomation\" is a misspelling of \"information\"",
+      message: '"infomation" is a misspelling of "information"',
       links: [],
       id: "information",
       path: "badspell.rb",
@@ -22,7 +22,7 @@ s.add_offline_test(
   type: "success",
   issues: [
     {
-      message: "\"infomation\" is a misspelling of \"information\"",
+      message: '"infomation" is a misspelling of "information"',
       links: [],
       id: "information",
       path: "badspell.rb",
@@ -31,7 +31,7 @@ s.add_offline_test(
       git_blame_info: nil
     },
     {
-      message: "\"offense\" is a misspelling of \"offence\"",
+      message: '"offense" is a misspelling of "offence"',
       links: [],
       id: "offence",
       path: "badspell.rb",
@@ -44,10 +44,10 @@ s.add_offline_test(
   warnings: [
     {
       message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
-MSG
+        DEPRECATION WARNING!!!
+        The `$.linter.misspell.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/others/misspell ).
+      MSG
       file: "sideci.yml"
     }
   ]
@@ -58,7 +58,7 @@ s.add_offline_test(
   type: "success",
   issues: [
     {
-      message: "\"recieve\" is a misspelling of \"receive\"",
+      message: '"recieve" is a misspelling of "receive"',
       links: [],
       id: "receive",
       path: "badspell.rb",
@@ -75,7 +75,7 @@ s.add_offline_test(
   type: "success",
   issues: [
     {
-      message: "\"acknowleges\" is a misspelling of \"acknowledges\"",
+      message: '"acknowleges" is a misspelling of "acknowledges"',
       links: [],
       id: "acknowledges",
       path: "target_dir/bar.rb",
@@ -84,7 +84,7 @@ s.add_offline_test(
       git_blame_info: nil
     },
     {
-      message: "\"comminucation\" is a misspelling of \"communications\"",
+      message: '"comminucation" is a misspelling of "communications"',
       links: [],
       id: "communications",
       path: "target_dir/foo.rb",
@@ -93,7 +93,7 @@ s.add_offline_test(
       git_blame_info: nil
     },
     {
-      message: "\"comminucation\" is a misspelling of \"communications\"",
+      message: '"comminucation" is a misspelling of "communications"',
       links: [],
       id: "communications",
       path: "target_file.rb",
@@ -102,7 +102,7 @@ s.add_offline_test(
       git_blame_info: nil
     },
     {
-      message: "\"infomation\" is a misspelling of \"information\"",
+      message: '"infomation" is a misspelling of "information"',
       links: [],
       id: "information",
       path: "target_dir/bar.rb",
@@ -111,7 +111,7 @@ s.add_offline_test(
       git_blame_info: nil
     },
     {
-      message: "\"recieve\" is a misspelling of \"receive\"",
+      message: '"recieve" is a misspelling of "receive"',
       links: [],
       id: "receive",
       path: "target_dir/foo.rb",
@@ -120,7 +120,7 @@ s.add_offline_test(
       git_blame_info: nil
     },
     {
-      message: "\"recieve\" is a misspelling of \"receive\"",
+      message: '"recieve" is a misspelling of "receive"',
       links: [],
       id: "receive",
       path: "target_file.rb",
@@ -138,7 +138,7 @@ s.add_offline_test(
   type: "success",
   issues: [
     {
-      message: "\"acknowleges\" is a misspelling of \"acknowledges\"",
+      message: '"acknowleges" is a misspelling of "acknowledges"',
       links: [],
       id: "acknowledges",
       path: "target.rb",
@@ -147,7 +147,7 @@ s.add_offline_test(
       git_blame_info: nil
     },
     {
-      message: "\"communiaction\" is a misspelling of \"communications\"",
+      message: '"communiaction" is a misspelling of "communications"',
       links: [],
       id: "communications",
       path: "partial_exclude_dir/target.html",
@@ -156,7 +156,7 @@ s.add_offline_test(
       git_blame_info: nil
     },
     {
-      message: "\"internelized\" is a misspelling of \"internalized\"",
+      message: '"internelized" is a misspelling of "internalized"',
       links: [],
       id: "internalized",
       path: "partial_exclude_dir/bar_dir/target.html",
@@ -165,7 +165,7 @@ s.add_offline_test(
       git_blame_info: nil
     },
     {
-      message: "\"optimizacion\" is a misspelling of \"optimization\"",
+      message: '"optimizacion" is a misspelling of "optimization"',
       links: [],
       id: "optimization",
       path: "partial_exclude_dir/bar_dir/target.js",
@@ -174,7 +174,7 @@ s.add_offline_test(
       git_blame_info: nil
     },
     {
-      message: "\"profissional\" is a misspelling of \"professional\"",
+      message: '"profissional" is a misspelling of "professional"',
       links: [],
       id: "professional",
       path: "foo_dir/target.rb",
@@ -183,7 +183,7 @@ s.add_offline_test(
       git_blame_info: nil
     },
     {
-      message: "\"requeriments\" is a misspelling of \"requirements\"",
+      message: '"requeriments" is a misspelling of "requirements"',
       links: [],
       id: "requirements",
       path: "foo_dir/another_dir/target.html",
@@ -192,7 +192,7 @@ s.add_offline_test(
       git_blame_info: nil
     },
     {
-      message: "\"scholarhsips\" is a misspelling of \"scholarships\"",
+      message: '"scholarhsips" is a misspelling of "scholarships"',
       links: [],
       id: "scholarships",
       path: "foo_dir/another_dir/target.rb",
@@ -201,7 +201,7 @@ s.add_offline_test(
       git_blame_info: nil
     },
     {
-      message: "\"trasnmission\" is a misspelling of \"transmissions\"",
+      message: '"trasnmission" is a misspelling of "transmissions"',
       links: [],
       id: "transmissions",
       path: "partial_exclude_dir/foo_dir/target.py",
@@ -226,7 +226,7 @@ s.add_offline_test(
   type: "success",
   issues: [
     {
-      message: "\"infomation\" is a misspelling of \"information\"",
+      message: '"infomation" is a misspelling of "information"',
       links: [],
       id: "information",
       path: "dir1/file.rb",
@@ -235,7 +235,7 @@ s.add_offline_test(
       git_blame_info: nil
     },
     {
-      message: "\"infomation\" is a misspelling of \"information\"",
+      message: '"infomation" is a misspelling of "information"',
       links: [],
       id: "information",
       path: "file1.rb",

--- a/test/smokes/phinder/expectations.rb
+++ b/test/smokes/phinder/expectations.rb
@@ -82,12 +82,12 @@ s.add_test(
   warnings: [
     {
       message: <<~MESSAGE.strip,
-Phinder configuration validation failed.
-Check the following output by `phinder test` command.
-
-`in_array(2, $arr, false)` does not match the rule sample.in_array_without_3rd_param but should match that rule.
-`in_array(4, $arr)` matches the rule sample.in_array_without_3rd_param but should not match that rule.
-MESSAGE
+        Phinder configuration validation failed.
+        Check the following output by `phinder test` command.
+        
+        `in_array(2, $arr, false)` does not match the rule sample.in_array_without_3rd_param but should match that rule.
+        `in_array(4, $arr)` matches the rule sample.in_array_without_3rd_param but should not match that rule.
+      MESSAGE
       file: "phinder.yml"
     }
   ]
@@ -97,10 +97,10 @@ s.add_test(
   "analyzer_failed",
   type: "failure",
   message: <<~MESSAGE,
-1 error(s) occurred:
-
-InvalidRule: Invalid id value found in 1st rule in phinder.yml
-MESSAGE
+    1 error(s) occurred:
+    
+    InvalidRule: Invalid id value found in 1st rule in phinder.yml
+  MESSAGE
   analyzer: { name: "Phinder", version: "0.9.2" }
 )
 
@@ -140,12 +140,12 @@ s.add_test(
   warnings: [
     {
       message: <<~MESSAGE.strip,
-Sider cannot find the required configuration file(s): `phinder.yml`.
-Please set up Phinder by following the instructions, or you can disable it in the repository settings.
-
-- https://github.com/sider/phinder
-- https://help.sider.review/tools/php/phinder
-MESSAGE
+        Sider cannot find the required configuration file(s): `phinder.yml`.
+        Please set up Phinder by following the instructions, or you can disable it in the repository settings.
+        
+        - https://github.com/sider/phinder
+        - https://help.sider.review/tools/php/phinder
+      MESSAGE
       file: "phinder.yml"
     }
   ]

--- a/test/smokes/phpmd/expectations.rb
+++ b/test/smokes/phpmd/expectations.rb
@@ -19,7 +19,7 @@ s.add_test(
 
 s.add_test(
   "invalid_rule",
-  type: "failure", message: "Invalid rule: \"invalid_rule\"", analyzer: { name: "PHPMD", version: "2.8.1" }
+  type: "failure", message: 'Invalid rule: "invalid_rule"', analyzer: { name: "PHPMD", version: "2.8.1" }
 )
 
 s.add_test(
@@ -59,10 +59,10 @@ s.add_test(
   warnings: [
     {
       message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The `$.linter.phpmd.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/php/phpmd ).
-MSG
+        DEPRECATION WARNING!!!
+        The `$.linter.phpmd.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/php/phpmd ).
+      MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/pmd_java/expectations.rb
+++ b/test/smokes/pmd_java/expectations.rb
@@ -239,7 +239,7 @@ s.add_test(
   analyzer: { name: "PMD Java", version: "6.23.0" },
   issues: [
     {
-      message: "The String literal \"Howdy\" appears 4 times in this file; the first occurrence is on line 3",
+      message: 'The String literal "Howdy" appears 4 times in this file; the first occurrence is on line 3',
       links: %w[https://pmd.github.io/pmd-6.23.0/pmd_rules_java_errorprone.html#avoidduplicateliterals],
       id: "AvoidDuplicateLiterals",
       path: "AvoidDupliatedLiterals.java",

--- a/test/smokes/querly/expectations.rb
+++ b/test/smokes/querly/expectations.rb
@@ -29,7 +29,7 @@ s.add_test(
         id: "com.test.pathname",
         messages: ["Use Pathname method instead"],
         justifications: ["Want to write this code."],
-        examples: [{ before: "Pathname.new(\"path\")", after: "Pathname(\"path\")" }]
+        examples: [{ before: 'Pathname.new("path")', after: 'Pathname("path")' }]
       },
       git_blame_info: nil
     }
@@ -45,12 +45,12 @@ s.add_test(
   warnings: [
     {
       message: <<~MESSAGE.strip,
-Sider cannot find the required configuration file `querly.yml`.
-Please set up Querly by following the instructions, or you can disable it in the repository settings.
-
-- https://github.com/soutaro/querly
-- https://help.sider.review/tools/ruby/querly
-MESSAGE
+        Sider cannot find the required configuration file `querly.yml`.
+        Please set up Querly by following the instructions, or you can disable it in the repository settings.
+        
+        - https://github.com/soutaro/querly
+        - https://help.sider.review/tools/ruby/querly
+      MESSAGE
       file: nil
     }
   ]
@@ -122,7 +122,7 @@ s.add_test(
         id: "com.test.pathname",
         messages: ["Use Pathname method instead"],
         justifications: ["Want to write this code."],
-        examples: [{ before: "Pathname.new(\"path\")", after: "Pathname(\"path\")" }]
+        examples: [{ before: 'Pathname.new("path")', after: 'Pathname("path")' }]
       },
       git_blame_info: nil
     }

--- a/test/smokes/rails_best_practices/expectations.rb
+++ b/test/smokes/rails_best_practices/expectations.rb
@@ -70,10 +70,10 @@ s.add_test(
   warnings: [
     {
       message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The `$.linter.rails_best_practices.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rails-bestpractices ).
-MSG
+        DEPRECATION WARNING!!!
+        The `$.linter.rails_best_practices.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rails-bestpractices ).
+      MSG
       file: "sideci.yml"
     }
   ]
@@ -192,12 +192,12 @@ s.add_test(
   warnings: [
     {
       message: <<~MESSAGE.strip,
-Sider tried to install `rails_best_practices 1.16.0` according to your `Gemfile.lock`, but it installs `1.19.4` instead.
-Because `1.16.0` does not satisfy the Sider constraints [">= 1.19.1", "< 2.0"].
-
-If you want to use a different version of `rails_best_practices`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
-See https://help.sider.review/getting-started/custom-configuration#gems-option
-MESSAGE
+        Sider tried to install `rails_best_practices 1.16.0` according to your `Gemfile.lock`, but it installs `1.19.4` instead.
+        Because `1.16.0` does not satisfy the Sider constraints [">= 1.19.1", "< 2.0"].
+        
+        If you want to use a different version of `rails_best_practices`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
+        See https://help.sider.review/getting-started/custom-configuration#gems-option
+      MESSAGE
       file: nil
     }
   ]

--- a/test/smokes/reek/expectations.rb
+++ b/test/smokes/reek/expectations.rb
@@ -166,12 +166,12 @@ s.add_test(
   warnings: [
     {
       message: <<~MESSAGE.strip,
-Sider tried to install `reek 4.0.0` according to your `Gemfile.lock`, but it installs `6.0.0` instead.
-Because `4.0.0` does not satisfy the Sider constraints [\">= 4.4.0\", \"< 7.0.0\"].
-
-If you want to use a different version of `reek`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
-See https://help.sider.review/getting-started/custom-configuration#gems-option
-MESSAGE
+        Sider tried to install `reek 4.0.0` according to your `Gemfile.lock`, but it installs `6.0.0` instead.
+        Because `4.0.0` does not satisfy the Sider constraints [\">= 4.4.0\", \"< 7.0.0\"].
+        
+        If you want to use a different version of `reek`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
+        See https://help.sider.review/getting-started/custom-configuration#gems-option
+      MESSAGE
       file: nil
     }
   ]

--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -225,10 +225,10 @@ s.add_test(
   warnings: [
     {
       message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The `$.linter.rubocop.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rubocop ).
-MSG
+        DEPRECATION WARNING!!!
+        The `$.linter.rubocop.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/ruby/rubocop ).
+      MSG
       file: "sideci.yml"
     },
     { message: "Metrics/LineLength has the wrong namespace - should be Layout", file: "my.rubocop.yml" }
@@ -256,10 +256,10 @@ s.add_test(
   warnings: [
     {
       message: <<~WARNING.strip,
-Rails cops will be removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
-https://github.com/rubocop-hq/rubocop/blob/master/manual/migrate_rails_cops.md
-https://help.sider.review/getting-started/custom-configuration#gems-option
-WARNING
+        Rails cops will be removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
+        https://github.com/rubocop-hq/rubocop/blob/master/manual/migrate_rails_cops.md
+        https://help.sider.review/getting-started/custom-configuration#gems-option
+      WARNING
       file: :_
     }
   ]
@@ -306,9 +306,9 @@ s.add_test(
   warnings: [
     {
       message: <<~WARNING.strip,
-`rails` option is ignored because the option was removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
-See https://help.sider.review/getting-started/custom-configuration#gems-option
-WARNING
+        `rails` option is ignored because the option was removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
+        See https://help.sider.review/getting-started/custom-configuration#gems-option
+      WARNING
       file: "sideci.yml"
     }
   ]
@@ -390,10 +390,10 @@ s.add_test(
   "install_from_sideci.yml_when_installing_old_version_gems",
   type: "failure",
   message: <<~MSG.strip,
-Failed to install gems. Sider automatically installs gems according to `sideci.yml` and `Gemfile.lock`.
-You can select the version of gems you want to install via `sideci.yml`.
-See https://help.sider.review/getting-started/custom-configuration#gems-option
-MSG
+    Failed to install gems. Sider automatically installs gems according to `sideci.yml` and `Gemfile.lock`.
+    You can select the version of gems you want to install via `sideci.yml`.
+    See https://help.sider.review/getting-started/custom-configuration#gems-option
+  MSG
   analyzer: :_
 )
 
@@ -405,12 +405,12 @@ s.add_test(
   warnings: [
     {
       message: <<~MSG.strip,
-Sider tried to install `rubocop 0.60.0` according to your `Gemfile.lock`, but it installs `0.83.0` instead.
-Because `0.60.0` does not satisfy the Sider constraints [\">= 0.61.0\", \"< 1.0.0\"].
-
-If you want to use a different version of `rubocop`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
-See https://help.sider.review/getting-started/custom-configuration#gems-option
-MSG
+        Sider tried to install `rubocop 0.60.0` according to your `Gemfile.lock`, but it installs `0.83.0` instead.
+        Because `0.60.0` does not satisfy the Sider constraints [\">= 0.61.0\", \"< 1.0.0\"].
+        
+        If you want to use a different version of `rubocop`, update your `Gemfile.lock` to satisfy the constraint or specify the gem version in your `sider.yml`.
+        See https://help.sider.review/getting-started/custom-configuration#gems-option
+      MSG
       file: nil
     }
   ]

--- a/test/smokes/scss_lint/expectations.rb
+++ b/test/smokes/scss_lint/expectations.rb
@@ -46,10 +46,10 @@ s.add_test(
   warnings: [
     {
       message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The support for SCSS-Lint is deprecated. Sider will drop these versions in the near future.
-Please consider using an alternative tool stylelint. See https://github.com/sds/scss-lint/blob/master/README.md#notice-consider-other-tools-before-adopting-scss-lint
-MSG
+        DEPRECATION WARNING!!!
+        The support for SCSS-Lint is deprecated. Sider will drop these versions in the near future.
+        Please consider using an alternative tool stylelint. See https://github.com/sds/scss-lint/blob/master/README.md#notice-consider-other-tools-before-adopting-scss-lint
+      MSG
       file: "sider.yml"
     }
   ]
@@ -108,7 +108,7 @@ s.add_test(
   type: "success",
   issues: [
     {
-      message: "Syntax Error: Invalid CSS after \"  color: black;\": expected \"}\", was \"\"",
+      message: 'Syntax Error: Invalid CSS after "  color: black;": expected "}", was ""',
       links: [],
       id: "Syntax",
       path: "err.scss",

--- a/test/smokes/shellcheck/expectations.rb
+++ b/test/smokes/shellcheck/expectations.rb
@@ -76,7 +76,7 @@ s.add_test(
               endColumn: 5,
               precedence: 12,
               insertionPoint: "afterEnd",
-              replacement: "\""
+              replacement: '"'
             },
             {
               line: 5,
@@ -85,7 +85,7 @@ s.add_test(
               endColumn: 12,
               precedence: 12,
               insertionPoint: "beforeStart",
-              replacement: "\""
+              replacement: '"'
             }
           ]
         }

--- a/test/smokes/stylelint/expectations.rb
+++ b/test/smokes/stylelint/expectations.rb
@@ -9,7 +9,7 @@ s.add_test(
       path: "test.sss",
       location: { start_line: 2 },
       id: "block-closing-brace-newline-before",
-      message: "Expected newline before \"}\" of a multi-line block",
+      message: 'Expected newline before "}" of a multi-line block',
       object: { severity: "error" },
       git_blame_info: nil,
       links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/block-closing-brace-newline-before]
@@ -18,7 +18,7 @@ s.add_test(
       path: "test.sss",
       location: { start_line: 1 },
       id: "block-opening-brace-space-before",
-      message: "Expected single space before \"{\"",
+      message: 'Expected single space before "{"',
       object: { severity: "error" },
       git_blame_info: nil,
       links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/block-opening-brace-space-before]
@@ -72,7 +72,7 @@ s.add_test(
       path: "test.css",
       location: { start_line: 2 },
       id: "property-no-unknown",
-      message: "Unexpected unknown property \"someattr\"",
+      message: 'Unexpected unknown property "someattr"',
       object: { severity: "error" },
       git_blame_info: nil,
       links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/property-no-unknown]
@@ -81,7 +81,7 @@ s.add_test(
       path: "test.scss",
       location: { start_line: 6 },
       id: "property-no-unknown",
-      message: "Unexpected unknown property \"font-color\"",
+      message: 'Unexpected unknown property "font-color"',
       object: { severity: "error" },
       git_blame_info: nil,
       links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/property-no-unknown]
@@ -117,7 +117,7 @@ s.add_test(
       path: "test.less",
       location: { start_line: 13 },
       id: "selector-type-no-unknown",
-      message: "Unexpected unknown type selector \"hoge\"",
+      message: 'Unexpected unknown type selector "hoge"',
       object: { severity: "error" },
       git_blame_info: nil,
       links: %w[https://github.com/stylelint/stylelint/tree/10.0.1/lib/rules/selector-type-no-unknown]
@@ -134,7 +134,7 @@ s.add_test(
       path: "test.css",
       location: { start_line: 2 },
       id: "color-no-invalid-hex",
-      message: "Unexpected invalid hex color \"#100000000\"",
+      message: 'Unexpected invalid hex color "#100000000"',
       links: %w[https://github.com/stylelint/stylelint/tree/13.4.1/lib/rules/color-no-invalid-hex],
       object: { severity: "error" },
       git_blame_info: nil
@@ -143,7 +143,7 @@ s.add_test(
       path: "test.css",
       location: { start_line: 1 },
       id: "selector-type-no-unknown",
-      message: "Unexpected unknown type selector \"foo\"",
+      message: 'Unexpected unknown type selector "foo"',
       links: %w[https://github.com/stylelint/stylelint/tree/13.4.1/lib/rules/selector-type-no-unknown],
       object: { severity: "error" },
       git_blame_info: nil
@@ -177,7 +177,7 @@ s.add_test(
       location: { start_line: 1 }
     },
     {
-      message: "Expected newline before \"}\" of a multi-line block",
+      message: 'Expected newline before "}" of a multi-line block',
       links: %w[https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/block-closing-brace-newline-before],
       id: "block-closing-brace-newline-before",
       path: "test.sss",
@@ -186,7 +186,7 @@ s.add_test(
       location: { start_line: 2 }
     },
     {
-      message: "Expected single space before \"{\"",
+      message: 'Expected single space before "{"',
       links: %w[https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/block-opening-brace-space-before],
       id: "block-opening-brace-space-before",
       path: "test.sss",
@@ -221,7 +221,7 @@ s.add_test(
       location: { start_line: 1 }
     },
     {
-      message: "Unexpected unknown property \"someattr\"",
+      message: 'Unexpected unknown property "someattr"',
       links: %w[https://github.com/stylelint/stylelint/tree/13.4.1/lib/rules/property-no-unknown],
       id: "property-no-unknown",
       path: "ok.css",
@@ -238,7 +238,7 @@ s.add_test(
   type: "success",
   issues: [
     {
-      message: "Unexpected unknown property \"someattr\"",
+      message: 'Unexpected unknown property "someattr"',
       links: %w[https://github.com/stylelint/stylelint/tree/13.4.1/lib/rules/property-no-unknown],
       id: "property-no-unknown",
       path: "test.css",
@@ -247,7 +247,7 @@ s.add_test(
       location: { start_line: 2 }
     },
     {
-      message: "Unexpected unknown property \"font-color\"",
+      message: 'Unexpected unknown property "font-color"',
       links: %w[https://github.com/stylelint/stylelint/tree/13.4.1/lib/rules/property-no-unknown],
       id: "property-no-unknown",
       path: "test.scss",
@@ -256,7 +256,7 @@ s.add_test(
       location: { start_line: 6 }
     },
     {
-      message: "Unexpected unknown type selector \"hoge\"",
+      message: 'Unexpected unknown type selector "hoge"',
       links: %w[https://github.com/stylelint/stylelint/tree/13.4.1/lib/rules/selector-type-no-unknown],
       id: "selector-type-no-unknown",
       path: "test.less",
@@ -351,7 +351,7 @@ s.add_test(
       location: { start_line: 6 }
     },
     {
-      message: "Unexpected unknown property \"someattr\"",
+      message: 'Unexpected unknown property "someattr"',
       links: %w[https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/property-no-unknown],
       id: "property-no-unknown",
       path: "test.css",
@@ -360,7 +360,7 @@ s.add_test(
       location: { start_line: 2 }
     },
     {
-      message: "Unexpected unknown type selector \"hoge\"",
+      message: 'Unexpected unknown type selector "hoge"',
       links: %w[https://github.com/stylelint/stylelint/tree/8.4.0/lib/rules/selector-type-no-unknown],
       id: "selector-type-no-unknown",
       path: "test.less",
@@ -413,7 +413,7 @@ s.add_test(
       location: { start_line: 12 }
     },
     {
-      message: "Unexpected unknown property \"font-color\"",
+      message: 'Unexpected unknown property "font-color"',
       links: %w[https://github.com/stylelint/stylelint/tree/13.4.1/lib/rules/property-no-unknown],
       id: "property-no-unknown",
       path: "test.scss",
@@ -440,7 +440,7 @@ s.add_test(
       location: { start_line: 5 }
     },
     {
-      message: "Unexpected unknown type selector \"hoge\"",
+      message: 'Unexpected unknown type selector "hoge"',
       links: %w[https://github.com/stylelint/stylelint/tree/13.4.1/lib/rules/selector-type-no-unknown],
       id: "selector-type-no-unknown",
       path: "test.less",
@@ -479,10 +479,10 @@ s.add_test(
   warnings: [
     {
       message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The `$.linter.stylelint.options` option(s) in your `sider.yml` are deprecated and will be removed in the near future.
-Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/css/stylelint ).
-MSG
+        DEPRECATION WARNING!!!
+        The `$.linter.stylelint.options` option(s) in your `sider.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/css/stylelint ).
+      MSG
       file: "sider.yml"
     }
   ]
@@ -494,7 +494,7 @@ s.add_test(
   type: "success",
   issues: [
     {
-      message: "Expected newline before \"}\" of a multi-line block",
+      message: 'Expected newline before "}" of a multi-line block',
       links: %w[https://github.com/stylelint/stylelint/tree/9.10.1/lib/rules/block-closing-brace-newline-before],
       id: "block-closing-brace-newline-before",
       path: "test.sss",
@@ -503,7 +503,7 @@ s.add_test(
       location: { start_line: 2 }
     },
     {
-      message: "Expected single space before \"{\"",
+      message: 'Expected single space before "{"',
       links: %w[https://github.com/stylelint/stylelint/tree/9.10.1/lib/rules/block-opening-brace-space-before],
       id: "block-opening-brace-space-before",
       path: "test.sss",

--- a/test/smokes/swiftlint/expectations.rb
+++ b/test/smokes/swiftlint/expectations.rb
@@ -151,10 +151,10 @@ s.add_test(
   warnings: [
     {
       message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The `$.linter.swiftlint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
-Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/swift/swiftlint ).
-MSG
+        DEPRECATION WARNING!!!
+        The `$.linter.swiftlint.options` option(s) in your `sideci.yml` are deprecated and will be removed in the near future.
+        Please update to the new option(s) according to our documentation (see https://help.sider.review/tools/swift/swiftlint ).
+      MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/tslint/expectations.rb
+++ b/test/smokes/tslint/expectations.rb
@@ -130,21 +130,21 @@ s.add_test(
   "raise-deprecated",
   type: "failure",
   message: <<~MESSAGE,
---type-check is deprecated. You only need --project to enable rules which need type information.
-Error at range.ts:2:18: Property 'min' does not exist on type 'string'.
-Error at range.ts:2:31: Property 'middle' does not exist on type 'string'.
-Error at range.ts:2:47: Property 'middle' does not exist on type 'string'.
-Error at range.ts:2:63: Property 'max' does not exist on type 'string'.
-Error at range.ts:11:24: Argument of type '{ min: number; middle: number; max: number; }' is not assignable to parameter of type 'string'.
-MESSAGE
+    --type-check is deprecated. You only need --project to enable rules which need type information.
+    Error at range.ts:2:18: Property 'min' does not exist on type 'string'.
+    Error at range.ts:2:31: Property 'middle' does not exist on type 'string'.
+    Error at range.ts:2:47: Property 'middle' does not exist on type 'string'.
+    Error at range.ts:2:63: Property 'max' does not exist on type 'string'.
+    Error at range.ts:11:24: Argument of type '{ min: number; middle: number; max: number; }' is not assignable to parameter of type 'string'.
+  MESSAGE
   analyzer: { name: "TSLint", version: "6.1.2" },
   warnings: [
     {
       message: <<~MSG.strip,
-DEPRECATION WARNING!!!
-The support for TSLint is deprecated. Sider will drop these versions on December 1, 2020.
-Please consider using an alternative tool ESLint. See https://github.com/palantir/tslint/issues/4534
-MSG
+        DEPRECATION WARNING!!!
+        The support for TSLint is deprecated. Sider will drop these versions on December 1, 2020.
+        Please consider using an alternative tool ESLint. See https://github.com/palantir/tslint/issues/4534
+      MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/tyscan/expectations.rb
+++ b/test/smokes/tyscan/expectations.rb
@@ -28,11 +28,11 @@ s.add_test(
   warnings: [
     {
       message: <<~MESSAGE.strip,
-`tyscan.yml` does not exist in your repository.
-
-To start performing analysis, `tyscan.yml` is required.
-See also: https://help.sider.review/tools/javascript/tyscan
-MESSAGE
+        `tyscan.yml` does not exist in your repository.
+        
+        To start performing analysis, `tyscan.yml` is required.
+        See also: https://help.sider.review/tools/javascript/tyscan
+      MESSAGE
       file: nil
     }
   ]


### PR DESCRIPTION
Prettier has a [bug](https://github.com/prettier/plugin-ruby/issues/316) to cause syntax errors about heredoc.
It's painful, so this tries using RuboCop instead with the `--safe-auto-correct` option.
See also the [RuboCop documentation](https://docs.rubocop.org/).

I determine the configuration in order to reduce diffs as possible.

See also https://github.com/sider/runners/pull/989#issuecomment-617087873

I recommend seeing [diffs ignoring whitespaces](https://github.com/sider/runners/pull/1114/files?w=1).
