### PR TITLE
[GolangCI-Lint] Add monorepo test case

### DIFF
--- a/test/smokes/golangci_lint/expectations.rb
+++ b/test/smokes/golangci_lint/expectations.rb
@@ -317,3 +317,12 @@ s.add_test(
   ],
   analyzer: { name: "GolangCI-Lint", version: "1.27.0" }
 )
+
+# NOTE: Monorepo is unsupported by GolangCI-Lint.
+#       See https://github.com/golangci/golangci-lint/issues/828
+s.add_test(
+  "monorepo",
+  type: "failure",
+  message: "Analysis failed. See the log for details.",
+  analyzer: { name: "GolangCI-Lint", version: "1.27.0" }
+)

--- a/test/smokes/golangci_lint/monorepo/mod1/go.mod
+++ b/test/smokes/golangci_lint/monorepo/mod1/go.mod
@@ -1,0 +1,5 @@
+module example.com/mod1
+
+go 1.14
+
+require rsc.io/quote v1.5.2

--- a/test/smokes/golangci_lint/monorepo/mod1/hello.go
+++ b/test/smokes/golangci_lint/monorepo/mod1/hello.go
@@ -1,0 +1,7 @@
+package hello
+
+import "rsc.io/quote"
+
+func Hello() string {
+    return quote.Hello()
+}

--- a/test/smokes/golangci_lint/monorepo/mod2/go.mod
+++ b/test/smokes/golangci_lint/monorepo/mod2/go.mod
@@ -1,0 +1,5 @@
+module example.com/mod2
+
+go 1.14
+
+require rsc.io/quote v1.5.2

--- a/test/smokes/golangci_lint/monorepo/mod2/hello.go
+++ b/test/smokes/golangci_lint/monorepo/mod2/hello.go
@@ -1,0 +1,7 @@
+package hello
+
+import "rsc.io/quote"
+
+func Hello() string {
+    return quote.Hello()
+}


### PR DESCRIPTION
Currently, monorepo is unsupported. 😢 

About Go Modules, see https://blog.golang.org/using-go-modules
