### PR TITLE
[GolangCI-Lint] Explicitly set `--timeout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.24.0...HEAD)
 
 - Fix "No space left" error on Git workspace [#1112](https://github.com/sider/runners/pull/1112)
+- **GolangCI-Lint** Explicitly set `--timeout` [#1117](https://github.com/sider/runners/pull/1117)
 
 ## 0.24.0
 

--- a/lib/runners/processor/golangci_lint.rb
+++ b/lib/runners/processor/golangci_lint.rb
@@ -75,12 +75,20 @@ module Runners
     def analyzer_options
       [].tap do |opts|
         analysis_targets.each { |target| opts << target }
+
+        # NOTE: Always override the value in `.golangci.yml`
         opts << "--out-format=json"
         opts << "--print-issued-lines"
         opts << "--print-linter-name"
         opts << "--issues-exit-code=0"
         opts << "--color=never"
         opts << "--concurrency=2"
+
+        # NOTE: The value should be less than the top-level timeout value.
+        #
+        # @see https://github.com/sider/runners/blob/1231de0ca047c7a23449ab1a7bb0751f39f16643/images/Dockerfile.end.erb#L11
+        opts << "--timeout=15m"
+
         opts << "--tests=#{config_linter[:tests]}" unless config_linter[:tests].nil?
         opts << "--config=#{path_to_config}" if path_to_config
         Array(config_linter[:disable]).each { |disable| opts << "--disable=#{disable}" }

--- a/lib/runners/processor/golangci_lint.rb
+++ b/lib/runners/processor/golangci_lint.rb
@@ -108,7 +108,7 @@ module Runners
     def path_to_config
       return config_linter[:config] if config_linter[:config]
 
-      # @see https://github.com/golangci/golangci-lint#config-file
+      # @see https://golangci-lint.run/usage/configuration/#config-file
       default_config_file_is_found = %w[.golangci.yml .golangci.toml .golangci.json].find { |f| (current_dir / f).exist? }
       return if default_config_file_is_found
 


### PR DESCRIPTION
If the `--timeout` option is not set on the command-line, users can change the value they want via `.golangci.yml`.
This change aims to prevent the change by users.

Also, we need to consider the top-level timeout value:

https://github.com/sider/runners/blob/1231de0ca047c7a23449ab1a7bb0751f39f16643/images/Dockerfile.end.erb#L11

Note: The GolangCI-Lint's default value is `1m`. It's too little.
https://golangci-lint.run/usage/configuration/#command-line-options