### PR TITLE
Revert "Bump strong_json from 2.1.0 to 2.1.1"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'strong_json', '2.1.1'
+gem 'strong_json', '2.1.0'
 gem 'jsonseq'
 gem 'retryable'
 gem 'bundler', '>= 1.12', '< 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       parser (~> 2.4)
       pry (~> 0.12.2)
       rainbow (>= 2.2.2, < 4.0)
-    strong_json (2.1.1)
+    strong_json (2.1.0)
     thor (1.0.1)
     thread_safe (0.3.6)
     tzinfo (1.2.7)
@@ -117,7 +117,7 @@ DEPENDENCIES
   rr
   rubocop
   steep (= 0.11.1)
-  strong_json (= 2.1.1)
+  strong_json (= 2.1.0)
   unification_assertion
 
 BUNDLED WITH


### PR DESCRIPTION
Reverts sider/runners#1126

Steep failed due to this update. We need to ignore this version for a while.