### PR TITLE
Add exception classes for failed git-fetch and git-checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - **GolangCI-Lint** Explicitly set `--timeout` [#1117](https://github.com/sider/runners/pull/1117)
 - **Cppcheck** Add `addon` option [#1119](https://github.com/sider/runners/pull/1119)
 - **Cppcheck** 1.90 -> 2.0 [#1083](https://github.com/sider/runners/pull/1083)
+- Add exception classes for failed git-fetch and git-checkout [#1139](https://github.com/sider/runners/pull/1139)
 
 ## 0.24.0
 

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -105,4 +105,22 @@ class WorkspaceGitTest < Minitest::Test
         ], info)
     end
   end
+
+  def test_git_fetch_failed
+    with_workspace(**workspace_params.merge(pull_number: 999999999)) do |workspace|
+      error = assert_raises(Runners::Workspace::Git::FetchFailed) do
+        workspace.send(:prepare_head_source, nil)
+      end
+      assert_match %r{\Agit-fetch failed: fatal: couldn't find remote ref refs/pull/999999999/head}, error.message
+    end
+  end
+
+  def test_git_checkout_failed
+    with_workspace(**workspace_params.merge(head: "invalid_commit")) do |workspace|
+      error = assert_raises(Runners::Workspace::Git::CheckoutFailed) do
+        workspace.send(:prepare_head_source, nil)
+      end
+      assert_match %r{\Agit-checkout failed: error: pathspec 'invalid_commit' did not match any file\(s\) known to git}, error.message
+    end
+  end
 end


### PR DESCRIPTION
New classes will be included in the `result.class` field.

https://github.com/sider/runners/blob/e42a34ad50a664293193a31ddc4a66e71d711072/lib/runners/schema/result.rb#L24

Fix #953
