### PR TITLE
Mask sensitive data in `Shell::ExecError`

### DIFF
--- a/lib/runners/shell.rb
+++ b/lib/runners/shell.rb
@@ -126,8 +126,8 @@ module Runners
           if raise_on_failure
             raise ExecError.new(type: method,
                                 args: command_line,
-                                stdout_str: stdout_str,
-                                stderr_str: stderr_str,
+                                stdout_str: trace_writer.filter.mask(stdout_str),
+                                stderr_str: trace_writer.filter.mask(stderr_str),
                                 status: status,
                                 dir: current_dir)
           end

--- a/test/shell_test.rb
+++ b/test/shell_test.rb
@@ -225,4 +225,17 @@ class ShellTest < Minitest::Test
       assert_equal path, error.dir
     end
   end
+
+  def test_masking_senstives_in_exception
+    mktmpdir do |path|
+      shell = Shell.new(current_dir: path, trace_writer: trace_writer, env_hash: {})
+
+      error = assert_raises Shell::ExecError do
+        shell.capture3!("echo '[stdout] user:secret' ; echo '[stderr] user:secret' 1>&2 ; exit 1")
+      end
+
+      assert_equal "[stdout] [FILTERED]\n", error.stdout_str
+      assert_equal "[stderr] [FILTERED]\n", error.stderr_str
+    end
+  end
 end


### PR DESCRIPTION
This change is a safeguard. Actual problems have not occurred.

Related to #1137

