### PR TITLE
Do not remove .git within #with_gitignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.25.1...HEAD)
 
 - Output trace more [#1145](https://github.com/sider/runners/pull/1145)
+- Do not remove .git within #with_gitignore [#1147](https://github.com/sider/runners/pull/1147)
 
 ## 0.25.1
 

--- a/lib/runners/ignoring.rb
+++ b/lib/runners/ignoring.rb
@@ -48,7 +48,6 @@ module Runners
 
       yield stdout.split("\0").map { |f| Pathname(f) }
     ensure
-      FileUtils.rm_rf(working_dir / ".git") # NOTE: working_dir is not a Git directory.
       gitignore.write(backup) if backup
     end
   end

--- a/test/ignoring_test.rb
+++ b/test/ignoring_test.rb
@@ -71,8 +71,6 @@ class IgnoringTest < Minitest::Test
       assert_not_exist dir / "yarn.log"
       assert_exist dir / "npm.log.bak"
 
-      refute((dir / ".git").exist?)
-
       assert_equal "Deleting ignored files...", trace_writer.writer[0][:message]
       assert_equal <<~MSG.chomp, trace_writer.writer[6][:message]
         .idea/workspace.xml


### PR DESCRIPTION
We started to reuse Git directory as a `working_dir` since #1112, so a `working_dir` always includes `.git` directory. However, `Ignoring` class still removes `.git` directory after git-check-ignore(1), then it
causes errors afterward.

Fix #1142
