### PR TITLE
Generated ignoring file sometimes is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.25.3...HEAD)
 
+- Generated ignoring file sometimes is missing [#1150](https://github.com/sider/runners/pull/1150)
+
 ## 0.25.3
 
 [Full diff](https://github.com/sider/runners/compare/0.25.2...0.25.3)

--- a/sig_new/tempfile.rbs
+++ b/sig_new/tempfile.rbs
@@ -1,3 +1,3 @@
 class Tempfile
-  def self.open: [X] (Array[String]) { (File) -> X } -> X
+  def self.create: [X] (String | Array[String]) { (File) -> X } -> X
 end


### PR DESCRIPTION
Related to #1148

Example:

```console
$ git ls-files --ignored --exclude-from /tmp/gitignore-20200527-6-i7ma6c
fatal: cannot use /tmp/gitignore-20200527-6-i7ma6c as an exclude file
```

I recommend [viewing it with hidden whitespaces](https://github.com/sider/runners/pull/1150/files?w=1).