### PR TITLE
Fix ignoring non ASCII filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.25.4...HEAD)
 
+- Fix ignoring non ASCII filename [#1153](https://github.com/sider/runners/pull/1153)
+
 ## 0.25.4
 
 [Full diff](https://github.com/sider/runners/compare/0.25.3...0.25.4)

--- a/lib/runners/ignoring.rb
+++ b/lib/runners/ignoring.rb
@@ -40,16 +40,19 @@ module Runners
         shell.capture3! "git", "init"
         shell.capture3! "git", "add", "."
 
+        # @see https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath
+        shell.capture3! "git", "config", "core.quotePath", "false"
+
         # @see https://git-scm.com/docs/git-ls-files
-        stdout, = shell.capture3!(
+        ignored_files, = shell.capture3!(
           "git", "ls-files", "--ignored", "--exclude-from", gitignore,
           trace_command_line: true,
           trace_stdout: false,
         )
 
-        stdout.each_line(chomp: true) do |line|
-          block.call line.delete_prefix('"').delete_suffix('"')
-        end
+        shell.capture3! "git", "config", "--unset", "core.quotePath" # restore
+
+        ignored_files.each_line(chomp: true, &block)
       end
     end
   end

--- a/lib/runners/ignoring.rb
+++ b/lib/runners/ignoring.rb
@@ -46,7 +46,10 @@ module Runners
           trace_command_line: true,
           trace_stdout: false,
         )
-        stdout.each_line(chomp: true, &block)
+
+        stdout.each_line(chomp: true) do |line|
+          block.call line.delete_prefix('"').delete_suffix('"')
+        end
       end
     end
   end

--- a/test/ignoring_test.rb
+++ b/test/ignoring_test.rb
@@ -45,6 +45,7 @@ class IgnoringTest < Minitest::Test
       new_file dir / "npm.log"
       new_file dir / "yarn.log"
       new_file dir / "npm.log.bak"
+      new_file dir / "\343\201\223\343\202\223\343\201\253\343\201\241\343\201\257.sjis.log"
 
       subject = Ignoring.new(working_dir: dir, trace_writer: trace_writer, config: config)
       assert_equal [
@@ -72,6 +73,7 @@ class IgnoringTest < Minitest::Test
       refute_path_exists dir / "npm.log"
       refute_path_exists dir / "yarn.log"
       assert_path_exists dir / "npm.log.bak"
+      refute_path_exists dir / "\343\201\223\343\202\223\343\201\253\343\201\241\343\201\257.sjis.log"
     end
   end
 

--- a/test/ignoring_test.rb
+++ b/test/ignoring_test.rb
@@ -45,7 +45,7 @@ class IgnoringTest < Minitest::Test
       new_file dir / "npm.log"
       new_file dir / "yarn.log"
       new_file dir / "npm.log.bak"
-      new_file dir / "\343\201\223\343\202\223\343\201\253\343\201\241\343\201\257.sjis.log"
+      new_file dir / "てすと.log"
 
       subject = Ignoring.new(working_dir: dir, trace_writer: trace_writer, config: config)
       assert_equal [
@@ -58,6 +58,7 @@ class IgnoringTest < Minitest::Test
         "test/b/outB/index.html",
         "test/c/out.txt",
         "yarn.log",
+        "てすと.log",
       ], subject.delete_ignored_files!
 
       refute_path_exists dir / "examples/foo/out/index.html"
@@ -73,7 +74,7 @@ class IgnoringTest < Minitest::Test
       refute_path_exists dir / "npm.log"
       refute_path_exists dir / "yarn.log"
       assert_path_exists dir / "npm.log.bak"
-      refute_path_exists dir / "\343\201\223\343\202\223\343\201\253\343\201\241\343\201\257.sjis.log"
+      refute_path_exists dir / "てすと.log"
     end
   end
 


### PR DESCRIPTION
https://sider.review/gh/repos/202486306/pulls/1122/logs/95757ae5-ccd2-446c-8cfa-1b6a1312c3f3#L34

> No such file or directory @ dir_s_rmdir - /tmp/d20200528-6-ju02nt/"test/smokes/pmd_cpd/option_encoding_error/\343\201\223\343\202\223\343\201\253\343\201\241\343\201\257.sjis.cs" (Errno::ENOENT)

An example of git-ls-files output (double-quotes included):

```
test/smokes/pmd_cpd/broken_sider_yml/sider.yml
test/smokes/pmd_cpd/broken_sider_yml/src/Main.java
test/smokes/pmd_cpd/expectations.rb
test/smokes/pmd_cpd/no_files/placeholder
test/smokes/pmd_cpd/no_issues/app.java
test/smokes/pmd_cpd/no_issues/sider.yml
test/smokes/pmd_cpd/option_encoding_error/hello.eucjp.cs
test/smokes/pmd_cpd/option_encoding_error/sider.yml
"test/smokes/pmd_cpd/option_encoding_error/\343\201\223\343\202\223\343\201\253\343\201\241\343\201\257.sjis.cs"
"test/smokes/pmd_cpd/option_encoding_success/bar/baz/\343\201\223\343\202\223\343\201\253\343\201\241\343\201\257.sjis.cs"
test/smokes/pmd_cpd/option_encoding_success/bar/hello.eucjp.cs
"test/smokes/pmd_cpd/option_encoding_success/foo/\343\201\223\343\202\223\343\201\253\343\201\241\343\201\257.sjis.cs"
```

See also #1122