### PR TITLE
[remark-lint] Fix handling `fatal` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.25.5...HEAD)
 
+- **remark-lint** Fix handling `fatal` output [#1156](https://github.com/sider/runners/pull/1156)
+
 ## 0.25.5
 
 [Full diff](https://github.com/sider/runners/compare/0.25.4...0.25.5)

--- a/test/smokes/remark_lint/expectations.rb
+++ b/test/smokes/remark_lint/expectations.rb
@@ -10,7 +10,7 @@ s.add_test(
       id: "no-undefined-references",
       message: "Found reference to undefined definition",
       links: [],
-      object: nil,
+      object: { severity: "warn" },
       git_blame_info: nil
     },
     {
@@ -19,7 +19,7 @@ s.add_test(
       id: "no-unused-definitions",
       message: "Found unused definition",
       links: [],
-      object: nil,
+      object: { severity: "warn" },
       git_blame_info: nil
     }
   ],
@@ -38,7 +38,7 @@ s.add_test(
       id: "heading-increment",
       message: "Heading levels should increment by one level at a time",
       links: [],
-      object: nil,
+      object: { severity: "warn" },
       git_blame_info: nil
     },
     {
@@ -47,7 +47,7 @@ s.add_test(
       id: "no-auto-link-without-protocol",
       message: "All automatic links must start with a protocol",
       links: [],
-      object: nil,
+      object: { severity: "warn" },
       git_blame_info: nil
     }
   ],
@@ -64,7 +64,7 @@ s.add_test(
       id: "no-auto-link-without-protocol",
       message: "All automatic links must start with a protocol",
       links: [],
-      object: nil,
+      object: { severity: "warn" },
       git_blame_info: nil
     },
     {
@@ -73,7 +73,7 @@ s.add_test(
       id: "no-auto-link-without-protocol",
       message: "All automatic links must start with a protocol",
       links: [],
-      object: nil,
+      object: { severity: "warn" },
       git_blame_info: nil
     }
   ],
@@ -90,7 +90,7 @@ s.add_test(
       id: "no-auto-link-without-protocol",
       message: "All automatic links must start with a protocol",
       links: [],
-      object: nil,
+      object: { severity: "error" },
       git_blame_info: nil
     }
   ],
@@ -107,7 +107,7 @@ s.add_test(
       id: "no-auto-link-without-protocol",
       message: "All automatic links must start with a protocol",
       links: [],
-      object: nil,
+      object: { severity: "warn" },
       git_blame_info: nil
     }
   ],
@@ -124,7 +124,7 @@ s.add_test(
       id: "file-extension",
       message: "Incorrect extension: use `md`",
       links: [],
-      object: nil,
+      object: { severity: "warn" },
       git_blame_info: nil
     },
     {
@@ -133,7 +133,7 @@ s.add_test(
       id: "no-heading-punctuation",
       message: "Don’t add a trailing `:` to headings",
       links: [],
-      object: nil,
+      object: { severity: "warn" },
       git_blame_info: nil
     }
   ],
@@ -150,7 +150,7 @@ s.add_test(
       id: "books-links",
       message: "Missing PDF indication",
       links: [],
-      object: nil,
+      object: { severity: "warn" },
       git_blame_info: nil
     },
     {
@@ -159,7 +159,7 @@ s.add_test(
       id: "books-links",
       message: "Missing a space before author",
       links: [],
-      object: nil,
+      object: { severity: "warn" },
       git_blame_info: nil
     },
     {
@@ -168,7 +168,7 @@ s.add_test(
       id: "books-links",
       message: "Missing PDF indication",
       links: [],
-      object: nil,
+      object: { severity: "warn" },
       git_blame_info: nil
     }
   ],
@@ -202,7 +202,7 @@ s.add_test(
       id: "first-heading-level",
       message: "First heading level should be `1`",
       links: [],
-      object: nil,
+      object: { severity: "warn" },
       git_blame_info: nil
     }
   ],

--- a/test/smokes/remark_lint/option_rc_path/config/.remarkrc
+++ b/test/smokes/remark_lint/option_rc_path/config/.remarkrc
@@ -1,5 +1,5 @@
 {
-  "plugins": [
-    "remark-preset-lint-recommended"
-  ]
+  "plugins": {
+    "remark-lint-no-auto-link-without-protocol": ["error"]
+  }
 }


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.


I thought that `fatal: true` indicated a fatal error.
But actually `fatal: true` can indicate that the severity is `error` (not `warn`).

A true fatal error is reported when `fatal: true` and `stack: non-null`.

See also:

- https://github.com/remarkjs/remark-lint/blob/7.0.0/packages/unified-lint-rule/index.js#L27
- https://github.com/remarkjs/remark-lint/blob/7.0.0/doc/rules.md#configuration

**Note: This change introduces `object.severity` in remark-lint results.**

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
