### PR TITLE
Improve interface of `Results::Success`

### DIFF
--- a/lib/runners/results.rb
+++ b/lib/runners/results.rb
@@ -29,9 +29,9 @@ module Runners
       attr_reader :issues
       attr_reader :analyzer
 
-      def initialize(guid:, analyzer:)
+      def initialize(guid:, analyzer:, issues: [])
         super(guid: guid)
-        @issues = []
+        @issues = issues
         @analyzer = analyzer
       end
 
@@ -57,8 +57,8 @@ module Runners
         super && analyzer&.valid?
       end
 
-      def add_issue(issue)
-        issues << issue
+      def add_issue(*issue)
+        issues.push(*issue)
       end
 
       def filter_issues(changes)

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -62,8 +62,8 @@ class Runners::Results::Success < Runners::Results::Base
   attr_reader issues: Array<Runners::Issue>
   attr_reader analyzer: Analyzer
 
-  def initialize: (guid: String, analyzer: Analyzer) -> any
-  def add_issue: (Runners::Issue) -> void
+  def initialize: (guid: String, analyzer: Analyzer, ?issues: Array<Runners::Issue>) -> any
+  def add_issue: (*Runners::Issue) -> void
   def filter_issues: (Changes) -> void
   def add_git_blame_info: (Workspace) -> void
 end

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -191,6 +191,24 @@ class ResultTest < Minitest::Test
 
   end
 
+  def test_success_initializing_issues
+    analyzer = Analyzer.new(name: "RuboCop", version: "1.0.0")
+    issues = [
+      Issue.new(path: Pathname("foo.rb"), location: nil, id: "aaa", message: "bbb"),
+      Issue.new(path: Pathname("foo.rb"), location: nil, id: "xxx", message: "yyy"),
+    ]
+    result = Results::Success.new(guid: SecureRandom.uuid, analyzer: analyzer, issues: issues)
+    assert_equal issues, result.issues
+  end
+
+  def test_success_add_multiple_issues
+    result = Results::Success.new(guid: SecureRandom.uuid, analyzer: Analyzer.new(name: "RuboCop", version: "1.0.0"))
+    issue1 = Issue.new(path: Pathname("foo.rb"), location: nil, id: "aaa", message: "bbb")
+    issue2 = Issue.new(path: Pathname("foo.rb"), location: nil, id: "xxx", message: "yyy")
+    result.add_issue(issue1, issue2)
+    assert_equal [issue1, issue2], result.issues
+  end
+
   def test_add_git_blame_info
     result = Results::Success.new(guid: SecureRandom.uuid, analyzer: Analyzer.new(name: "RuboCop", version: "1.3.2pre"))
     result.add_issue Issue.new(


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to improve the interface of the `Results::Success` and make it more useful:

- Add `issues` argument to `#initialize`.
- Allow `#add_issue` to receive multiple issues.

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable. → Not notable.
