### PR TITLE
[ESLint] Stop using `~/.eslintrc.*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Updated tools:
 Misc:
 
 - **Cppcheck** Add `bug-hunting` option [#1166](https://github.com/sider/runners/pull/1166)
+- **ESLint** Stop using `~/.eslintrc.*` [#1201](https://github.com/sider/runners/pull/1201)
 - Drop deprecated Golint, Govet, and GoMetaLinter [#1164](https://github.com/sider/runners/pull/1164)
 - Improve error and warning messages [#1195](https://github.com/sider/runners/pull/1195)
 

--- a/images/eslint/Dockerfile
+++ b/images/eslint/Dockerfile
@@ -30,11 +30,8 @@ ENV PATH ${RUNNER_USER_HOME}/eslint/node_modules/.bin:${PATH}
 # See https://nodejs.org/api/cli.html#cli_node_path_path
 ENV NODE_PATH ${RUNNER_USER_HOME}/eslint/node_modules:${NODE_PATH}
 
-# NOTE: ESLint uses a configuration file in the home directory if no other configuration files are found.
-#       See https://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy
-COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/eslint/sider_eslintrc.yml ${RUNNER_USER_HOME}/.eslintrc.yml
-
-COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/eslint/custom-eslint-json-formatter.js ${RUNNER_USER_HOME}/
+COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/eslint/sider_eslintrc.yml ${RUNNER_USER_HOME}/eslint/
+COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/eslint/custom-eslint-json-formatter.js ${RUNNER_USER_HOME}/eslint/
 
 
 # Copy the main source code

--- a/images/eslint/Dockerfile.erb
+++ b/images/eslint/Dockerfile.erb
@@ -3,10 +3,7 @@ FROM sider/devon_rex_npm:master
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.npm.erb' %>
 
-# NOTE: ESLint uses a configuration file in the home directory if no other configuration files are found.
-#       See https://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy
-COPY --chown=<%= chown %> images/eslint/sider_eslintrc.yml ${RUNNER_USER_HOME}/.eslintrc.yml
-
-COPY --chown=<%= chown %> images/eslint/custom-eslint-json-formatter.js ${RUNNER_USER_HOME}/
+COPY --chown=<%= chown %> images/<%= analyzer %>/sider_eslintrc.yml ${RUNNER_USER_HOME}/<%= analyzer %>/
+COPY --chown=<%= chown %> images/<%= analyzer %>/custom-eslint-json-formatter.js ${RUNNER_USER_HOME}/<%= analyzer %>/
 
 <%= render_erb 'images/Dockerfile.end.erb' %>

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -28,6 +28,40 @@ s.add_test(
   analyzer: { name: "ESLint", version: default_version }
 )
 
+s.add_test(
+  "no_config_v5",
+  type: "success",
+  issues: [
+    {
+      path: "index.js",
+      location: { start_line: 1, start_column: 1, end_line: 1, end_column: 12 },
+      id: "no-console",
+      message: "Unexpected console statement.",
+      links: [],
+      object: { severity: "error", category: nil, recommended: nil },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ESLint", version: "5.0.0" }
+)
+
+s.add_test(
+  "no_config_v6",
+  type: "success",
+  issues: [
+    {
+      path: "index.js",
+      location: { start_line: 1, start_column: 5, end_line: 1, end_column: 11 },
+      id: "no-constant-condition",
+      message: "Unexpected constant condition.",
+      links: %w[https://eslint.org/docs/rules/no-constant-condition],
+      object: { severity: "error", category: "Possible Errors", recommended: true },
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "ESLint", version: "6.0.0" }
+)
+
 # This test case's .eslintrc includes ESLint plugin, thus Sider fails because of the plugin unavailable.
 s.add_test(
   "only_eslintrc",

--- a/test/smokes/eslint/no_config_v5/index.js
+++ b/test/smokes/eslint/no_config_v5/index.js
@@ -1,0 +1,1 @@
+console.log("Hi.")

--- a/test/smokes/eslint/no_config_v5/package.json
+++ b/test/smokes/eslint/no_config_v5/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "eslint": "5.0.0"
+  }
+}

--- a/test/smokes/eslint/no_config_v6/index.js
+++ b/test/smokes/eslint/no_config_v6/index.js
@@ -1,0 +1,1 @@
+if (1 == 1) console.log("Hi.")

--- a/test/smokes/eslint/no_config_v6/package.json
+++ b/test/smokes/eslint/no_config_v6/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "eslint": "6.0.0"
+  }
+}


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Summary:

- Before: Copy `sider_eslintrc.yml` to `~/.eslintrc.yml`, which is used automatically by ESLint.
- After: Specify the CLI option `--config sider_eslintrc.yml` explicitly if no config files.

It is hard to find ESLint configuration files in a project because:

- ESLint does not provide a way to find config files.
- ESLint supports different format for config files, e.g. `.eslintrc`, `.eslintrc.yml`, `package.json` and so on.
- ESLint tries to use config files in sub-directories, e.g. `sub_dir/.eslintrc.json`.

So, this change tries running the `eslint` command **two times** if no config files.
And, it parses the error message to know whether no config files, e.g. `ESLint couldn't ...`.

I think the influence for execution time is small because ESLint raises an error soon when no config files.

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

Fix #1073

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
