### PR TITLE
[Brakeman] Fix warning in Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.28.0...HEAD)
 
+- **Brakeman** Fix warning in Markdown [#1206](https://github.com/sider/runners/pull/1206)
+
 ## 0.28.0
 
 [Full diff](https://github.com/sider/runners/compare/0.27.0...0.28.0)

--- a/lib/runners/processor/brakeman.rb
+++ b/lib/runners/processor/brakeman.rb
@@ -41,10 +41,10 @@ module Runners
           add_warning <<~MSG, file: config.path_name
             #{analyzer_name} is for Rails only. Your repository may not have a Rails application.
             If your Rails is not located in the root directory, configure your `#{config.path_name}` as follows:
-            ---
-            linter:
-              #{analyzer_id}:
-                root_dir: "path/to/your/rails/root"
+
+                linter:
+                  #{analyzer_id}:
+                    root_dir: "path/to/your/rails/root"
           MSG
           return Results::Success.new(guid: guid, analyzer: analyzer)
         else

--- a/test/smokes/brakeman/expectations.rb
+++ b/test/smokes/brakeman/expectations.rb
@@ -100,10 +100,10 @@ s.add_test(
   warnings: [{ message: <<~MSG.strip, file: "sider.yml" }]
     Brakeman is for Rails only. Your repository may not have a Rails application.
     If your Rails is not located in the root directory, configure your `sider.yml` as follows:
-    ---
-    linter:
-      brakeman:
-        root_dir: "path/to/your/rails/root"
+
+        linter:
+          brakeman:
+            root_dir: "path/to/your/rails/root"
   MSG
 )
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This fixes a YAML code block in the warning. 4 spaces indentation expresses a code block.

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
