### PR TITLE
[RuboCop] Fix broken document link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.28.0...HEAD)
 
 - **Brakeman** Fix warning in Markdown [#1206](https://github.com/sider/runners/pull/1206)
+- **RuboCop** Fix broken document link [#1207](https://github.com/sider/runners/pull/1207)
 
 ## 0.28.0
 

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -238,7 +238,7 @@ module Runners
     end
 
     def department_to_gem_name
-      @rubocop_gem_names ||= {
+      @department_to_gem_name ||= {
         # rubocop
         "Bundler" => "rubocop",
         "Gemspec" => "rubocop",

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -223,34 +223,47 @@ module Runners
     end
 
     def build_cop_links(cop_name)
-      department, cop = cop_name.split("/").map(&:downcase)
+      department, cop = cop_name.split("/")
 
       if department && cop
-        fragment = "#{department}#{cop}"
-        case
-        when core_departments.include?(department)
-          return ["https://github.com/rubocop-hq/rubocop/blob/v#{analyzer_version}/manual/cops_#{department}.md##{fragment}"]
-        when ["rails", "performance"].include?(department)
-          version = rubocop_plugin_version("rubocop-#{department}")
-          if version
-            return ["https://github.com/rubocop-hq/rubocop-#{department}/blob/v#{version}/manual/cops_#{department}.md##{fragment}"]
-          end
+        gem_name = department_to_gem_name[department]
+        if gem_name
+          department.downcase!
+          cop.downcase!
+          return ["https://docs.rubocop.org/#{gem_name}/cops_#{department}.html##{department}#{cop}"]
         end
       end
 
       []
     end
 
-    def core_departments
-      @core_departments ||= %w[style layout lint metrics naming security bundler gemspec].tap do |list|
-        list << "rails" unless rails_cops_removed?
-        list << "performance" unless performance_cops_removed?
-      end
-    end
+    def department_to_gem_name
+      @rubocop_gem_names ||= {
+        # rubocop
+        "Bundler" => "rubocop",
+        "Gemspec" => "rubocop",
+        "Layout" => "rubocop",
+        "Lint" => "rubocop",
+        "Metrics" => "rubocop",
+        "Migration" => "rubocop",
+        "Naming" => "rubocop",
+        "Security" => "rubocop",
+        "Style" => "rubocop",
 
-    def rubocop_plugin_version(gem_name)
-      @rubocop_plugin_versions ||= installed_gem_versions("rubocop-rails", "rubocop-performance", exception: false)
-      @rubocop_plugin_versions[gem_name]&.first
+        # rubocop-rails
+        "Rails" => "rubocop-rails",
+
+        # rubocop-rspec
+        "Capybara" => "rubocop-rspec",
+        "FactoryBot" => "rubocop-rspec",
+        "RSpec" => "rubocop-rspec",
+
+        # rubocop-minitest
+        "Minitest" => "rubocop-minitest",
+
+        # rubocop-performance
+        "Performance" => "rubocop-performance",
+      }.freeze
     end
 
     def normalize_message(original_message, links, cop_name)
@@ -260,11 +273,6 @@ module Runners
     # @see https://github.com/rubocop-hq/rubocop/blob/v0.72.0/CHANGELOG.md
     def rails_cops_removed?
       Gem::Version.create(analyzer_version) >= Gem::Version.create("0.72.0")
-    end
-
-    # @see https://github.com/rubocop-hq/rubocop/blob/v0.68.0/CHANGELOG.md
-    def performance_cops_removed?
-      Gem::Version.create(analyzer_version) >= Gem::Version.create("0.68.0")
     end
   end
 end

--- a/test/processor/rubocop_test.rb
+++ b/test/processor/rubocop_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class Runners::Processor::RuboCopTest < Minitest::Test
+  include TestHelper
+
+  def trace_writer
+    @trace_writer ||= new_trace_writer
+  end
+
+  def subject
+    @subject
+  end
+
+  def setup_subject(workspace)
+    @subject = Runners::Processor::RuboCop.new(
+      guid: SecureRandom.uuid,
+      working_dir: workspace.working_dir,
+      config: config,
+      trace_writer: trace_writer,
+      git_ssh_path: nil
+    ).tap do |s|
+      stub(s).analyzer_id { "rubocop" }
+    end
+  end
+
+  def test_build_cop_links
+    with_workspace do |workspace|
+      setup_subject(workspace)
+
+      assert_links = ->(expected, actual) {
+        assert_equal expected, subject.send(:build_cop_links, actual)
+        expected.each do |url|
+          assert_equal "200", Net::HTTP.get_response(URI(url)).code
+        end
+      }
+
+      # core
+      assert_links.call %w[https://docs.rubocop.org/rubocop/cops_bundler.html#bundlerduplicatedgem], "Bundler/DuplicatedGem"
+      assert_links.call %w[https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecduplicatedassignment], "Gemspec/DuplicatedAssignment"
+      assert_links.call %w[https://docs.rubocop.org/rubocop/cops_layout.html#layoutemptylines], "Layout/EmptyLines"
+      assert_links.call %w[https://docs.rubocop.org/rubocop/cops_lint.html#lintdebugger], "Lint/Debugger"
+      assert_links.call %w[https://docs.rubocop.org/rubocop/cops_metrics.html#metricsabcsize], "Metrics/AbcSize"
+      assert_links.call %w[https://docs.rubocop.org/rubocop/cops_migration.html#migrationdepartmentname], "Migration/DepartmentName"
+      assert_links.call %w[https://docs.rubocop.org/rubocop/cops_naming.html#namingaccessormethodname], "Naming/AccessorMethodName"
+      assert_links.call %w[https://docs.rubocop.org/rubocop/cops_security.html#securityeval], "Security/Eval"
+      assert_links.call %w[https://docs.rubocop.org/rubocop/cops_style.html#stylealias], "Style/Alias"
+
+      # rails
+      assert_links.call %w[https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsactionfilter], "Rails/ActionFilter"
+
+      # rspec
+      assert_links.call %w[https://docs.rubocop.org/rubocop-rspec/cops_capybara.html#capybarafeaturemethods], "Capybara/FeatureMethods"
+      assert_links.call %w[https://docs.rubocop.org/rubocop-rspec/cops_factorybot.html#factorybotcreatelist], "FactoryBot/CreateList"
+      assert_links.call %w[https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecbe], "RSpec/Be"
+
+      # minitest
+      assert_links.call %w[https://docs.rubocop.org/rubocop-minitest/cops_minitest.html#minitestassertempty], "Minitest/AssertEmpty"
+
+      # performance
+      assert_links.call %w[https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancecaller], "Performance/Caller"
+
+      # unknown
+      assert_links.call [], "Foo"
+      assert_links.call [], "Foo/Bar"
+    end
+  end
+end

--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -8,7 +8,7 @@ s.add_test(
   issues: [
     {
       message: "Literal `true` appeared as a condition.",
-      links: %W[https://github.com/rubocop-hq/rubocop/blob/v#{default_version}/manual/cops_lint.md#lintliteralascondition],
+      links: %w[https://docs.rubocop.org/rubocop/cops_lint.html#lintliteralascondition],
       id: "Lint/LiteralAsCondition",
       path: "app/controllers/users_controller.rb",
       object: { severity: "warning", corrected: false },
@@ -17,7 +17,7 @@ s.add_test(
     },
     {
       message: "Shadowing outer local variable - `v`.",
-      links: %W[https://github.com/rubocop-hq/rubocop/blob/v#{default_version}/manual/cops_lint.md#lintshadowingouterlocalvariable],
+      links: %w[https://docs.rubocop.org/rubocop/cops_lint.html#lintshadowingouterlocalvariable],
       id: "Lint/ShadowingOuterLocalVariable",
       path: "app/controllers/users_controller.rb",
       object: { severity: "warning", corrected: false },
@@ -26,9 +26,9 @@ s.add_test(
     },
     {
       message: "Useless assignment to variable - `v`.",
-      links: %W[
+      links: %w[
         https://rubystyle.guide#underscore-unused-vars
-        https://github.com/rubocop-hq/rubocop/blob/v#{default_version}/manual/cops_lint.md#lintuselessassignment
+        https://docs.rubocop.org/rubocop/cops_lint.html#lintuselessassignment
       ],
       id: "Lint/UselessAssignment",
       path: "app/controllers/users_controller.rb",
@@ -38,9 +38,9 @@ s.add_test(
     },
     {
       message: "Prefer symbols instead of strings as hash keys.",
-      links: %W[
+      links: %w[
         https://rubystyle.guide#symbols-as-keys
-        https://github.com/rubocop-hq/rubocop/blob/v#{default_version}/manual/cops_style.md#stylestringhashkeys
+        https://docs.rubocop.org/rubocop/cops_style.html#stylestringhashkeys
       ],
       id: "Style/StringHashKeys",
       path: "config/environments/development.rb",
@@ -50,9 +50,9 @@ s.add_test(
     },
     {
       message: "Prefer symbols instead of strings as hash keys.",
-      links: %W[
+      links: %w[
         https://rubystyle.guide#symbols-as-keys
-        https://github.com/rubocop-hq/rubocop/blob/v#{default_version}/manual/cops_style.md#stylestringhashkeys
+        https://docs.rubocop.org/rubocop/cops_style.html#stylestringhashkeys
       ],
       id: "Style/StringHashKeys",
       path: "config/environments/test.rb",
@@ -70,7 +70,7 @@ s.add_test(
   issues: [
     {
       "message": "Missing top-level class documentation comment.",
-      "links": %W[https://github.com/rubocop-hq/rubocop/blob/v#{default_version}/manual/cops_style.md#styledocumentation],
+      "links": %w[https://docs.rubocop.org/rubocop/cops_style.html#styledocumentation],
       "id": "Style/Documentation",
       "path": "app.rb",
       "location": { "start_line": 3, "start_column": 1, "end_line": 3, "end_column": 5 },
@@ -79,9 +79,9 @@ s.add_test(
     },
     {
       "message": "Put empty method definitions on a single line.",
-      "links": %W[
+      "links": %w[
         https://rubystyle.guide#no-single-line-methods
-        https://github.com/rubocop-hq/rubocop/blob/v#{default_version}/manual/cops_style.md#styleemptymethod
+        https://docs.rubocop.org/rubocop/cops_style.html#styleemptymethod
       ],
       "id": "Style/EmptyMethod",
       "path": "app.rb",
@@ -101,7 +101,7 @@ s.add_test(
       message: "Use 2 (not 1) spaces for indentation.",
       links: %w[
         https://rubystyle.guide#spaces-indentation
-        https://github.com/rubocop-hq/rubocop/blob/v0.79.0/manual/cops_layout.md#layoutindentationwidth
+        https://docs.rubocop.org/rubocop/cops_layout.html#layoutindentationwidth
       ],
       id: "Layout/IndentationWidth",
       path: "test.rb",
@@ -113,7 +113,7 @@ s.add_test(
       message: "Tab detected.",
       links: %w[
         https://rubystyle.guide#spaces-indentation
-        https://github.com/rubocop-hq/rubocop/blob/v0.79.0/manual/cops_layout.md#layouttab
+        https://docs.rubocop.org/rubocop/cops_layout.html#layouttab
       ],
       id: "Layout/Tab",
       path: "test.rb",
@@ -126,9 +126,7 @@ s.add_test(
       location: { start_line: 1, start_column: 1, end_line: 1, end_column: 1 },
       id: "Style/FrozenStringLiteralComment",
       message: "Missing magic comment `# frozen_string_literal: true`.",
-      links: %w[
-        https://github.com/rubocop-hq/rubocop/blob/v0.79.0/manual/cops_style.md#stylefrozenstringliteralcomment
-      ],
+      links: %w[https://docs.rubocop.org/rubocop/cops_style.html#stylefrozenstringliteralcomment],
       object: { severity: "convention", corrected: false },
       git_blame_info: nil
     },
@@ -137,9 +135,7 @@ s.add_test(
       location: { start_line: 1, start_column: 1, end_line: 1, end_column: 1 },
       id: "Style/FrozenStringLiteralComment",
       message: "Missing magic comment `# frozen_string_literal: true`.",
-      links: %w[
-        https://github.com/rubocop-hq/rubocop/blob/v0.79.0/manual/cops_style.md#stylefrozenstringliteralcomment
-      ],
+      links: %w[https://docs.rubocop.org/rubocop/cops_style.html#stylefrozenstringliteralcomment],
       object: { severity: "convention", corrected: false },
       git_blame_info: nil
     }
@@ -156,7 +152,7 @@ s.add_test(
       message: "Line is too long. [218/200]",
       links: %w[
         https://rubystyle.guide#80-character-limits
-        https://github.com/rubocop-hq/rubocop/blob/v0.79.0/manual/cops_layout.md#layoutlinelength
+        https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinelength
       ],
       id: "Layout/LineLength",
       path: "cat.rb",
@@ -174,7 +170,7 @@ s.add_test(
   issues: [
     {
       message: "Use the `&&` operator to compare multiple values.",
-      links: %W[https://github.com/rubocop-hq/rubocop/blob/v#{default_version}/manual/cops_lint.md#lintmultiplecomparison],
+      links: %w[https://docs.rubocop.org/rubocop/cops_lint.html#lintmultiplecomparison],
       id: "Lint/MultipleComparison",
       path: "test.rb",
       object: { severity: "warning", corrected: false },
@@ -206,7 +202,7 @@ s.add_test(
   issues: [
     {
       message: "Empty `ensure` block detected.",
-      links: %W[https://github.com/rubocop-hq/rubocop/blob/v#{default_version}/manual/cops_lint.md#lintemptyensure],
+      links: %w[https://docs.rubocop.org/rubocop/cops_lint.html#lintemptyensure],
       id: "Lint/EmptyEnsure",
       path: "drink.rb",
       location: { start_line: 12, start_column: 3, end_line: 12, end_column: 8 },
@@ -215,7 +211,7 @@ s.add_test(
     },
     {
       message: "Do not chain ordinary method call after safe navigation operator.",
-      links: %W[https://github.com/rubocop-hq/rubocop/blob/v#{default_version}/manual/cops_lint.md#lintsafenavigationchain],
+      links: %w[https://docs.rubocop.org/rubocop/cops_lint.html#lintsafenavigationchain],
       id: "Lint/SafeNavigationChain",
       path: "drink.rb",
       location: { start_line: 18, start_column: 21, end_line: 18, end_column: 27 },
@@ -246,7 +242,7 @@ s.add_test(
       message: "Line is too long. [218/200]",
       links: %w[
         https://github.com/rubocop-hq/ruby-style-guide#80-character-limits
-        https://github.com/rubocop-hq/rubocop/blob/v0.71.0/manual/cops_metrics.md#metricslinelength
+        https://docs.rubocop.org/rubocop/cops_metrics.html#metricslinelength
       ],
       id: "Metrics/LineLength",
       path: "cat.rb",
@@ -272,7 +268,7 @@ s.add_test(
       message: "Line is too long. [218/200]",
       links: %w[
         https://rubystyle.guide#80-character-limits
-        https://github.com/rubocop-hq/rubocop/blob/v0.72.0/manual/cops_metrics.md#metricslinelength
+        https://docs.rubocop.org/rubocop/cops_metrics.html#metricslinelength
       ],
       id: "Metrics/LineLength",
       path: "cat.rb",
@@ -292,7 +288,7 @@ s.add_test(
       message: "Line is too long. [218/200]",
       links: %w[
         https://rubystyle.guide#80-character-limits
-        https://github.com/rubocop-hq/rubocop/blob/v0.72.0/manual/cops_metrics.md#metricslinelength
+        https://docs.rubocop.org/rubocop/cops_metrics.html#metricslinelength
       ],
       id: "Metrics/LineLength",
       path: "cat.rb",
@@ -319,9 +315,7 @@ s.add_test(
   issues: [
     {
       message: "Use `caller(2..2).first` instead of `caller[1]`.",
-      links: %w[
-        https://github.com/rubocop-hq/rubocop-performance/blob/v1.5.0/manual/cops_performance.md#performancecaller
-      ],
+      links: %w[https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancecaller],
       id: "Performance/Caller",
       path: "app/foo.rb",
       location: { start_line: 1, start_column: 1, end_line: 1, end_column: 9 },
@@ -330,7 +324,7 @@ s.add_test(
     },
     {
       message: "Do not use `exit` in Rails applications.",
-      links: %w[https://github.com/rubocop-hq/rubocop-rails/blob/v2.3.2/manual/cops_rails.md#railsexit],
+      links: %w[https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsexit],
       id: "Rails/Exit",
       path: "app/foo.rb",
       location: { start_line: 3, start_column: 1, end_line: 3, end_column: 4 },
@@ -339,7 +333,7 @@ s.add_test(
     },
     {
       message: "Please use `Rails.root.join('path', 'to')` instead.",
-      links: %w[https://github.com/rubocop-hq/rubocop-rails/blob/v2.3.2/manual/cops_rails.md#railsfilepath],
+      links: %w[https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsfilepath],
       id: "Rails/FilePath",
       path: "app/foo.rb",
       location: { start_line: 2, start_column: 1, end_line: 2, end_column: 33 },
@@ -356,7 +350,7 @@ s.add_test(
   issues: [
     {
       message: "Use `caller(2..2).first` instead of `caller[1]`.",
-      links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.67.0/manual/cops_performance.md#performancecaller],
+      links: %w[https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancecaller],
       id: "Performance/Caller",
       path: "app/foo.rb",
       location: { start_line: 1, start_column: 1, end_line: 1, end_column: 9 },
@@ -365,7 +359,7 @@ s.add_test(
     },
     {
       message: "Do not use `exit` in Rails applications.",
-      links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.67.0/manual/cops_rails.md#railsexit],
+      links: %w[https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsexit],
       id: "Rails/Exit",
       path: "app/foo.rb",
       location: { start_line: 3, start_column: 1, end_line: 3, end_column: 4 },
@@ -374,7 +368,7 @@ s.add_test(
     },
     {
       message: "Please use `Rails.root.join('path', 'to')` instead.",
-      links: %w[https://github.com/rubocop-hq/rubocop/blob/v0.67.0/manual/cops_rails.md#railsfilepath],
+      links: %w[https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsfilepath],
       id: "Rails/FilePath",
       path: "app/foo.rb",
       location: { start_line: 2, start_column: 1, end_line: 2, end_column: 33 },


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Since RuboCop 0.85, https://docs.rubocop.org has been published.
This change fixes all the document link to the new website.

Note that supporting only core and official plugin cops, and removing a version from the document URLs.

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

Fix #1205

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
