### PR TITLE
[Rails Best Practices] Fix invalid `line_number`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.28.2...HEAD)
 
+- **Rails Best Practices** Fix invalid `line_number` [#1216](https://github.com/sider/runners/pull/1216)
+
 ## 0.28.2
 
 [Full diff](https://github.com/sider/runners/compare/0.28.1...0.28.2)

--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -128,9 +128,19 @@ module Runners
         output = read_report_file
         output.gsub!('- !ruby/object:RailsBestPractices::Core::Error', '-')
         YAML.safe_load(output, symbolize_names: true, filename: report_file).each do |issue|
+          # HACK: `line_number` sometimes is not a number.
+          line_number = issue.fetch(:line_number)
+          start_line = Integer(line_number, exception: false)
+          location = if start_line
+                       Location.new(start_line: start_line)
+                     else
+                       add_warning "`line_number` is invalid: #{line_number.inspect}. Ignored."
+                       nil
+                     end
+
           result.add_issue Issue.new(
             path: relative_path(issue.fetch(:filename)),
-            location: Location.new(start_line: issue.fetch(:line_number)),
+            location: location,
             id: issue.fetch(:type),
             message: issue.fetch(:message),
             links: Array(issue[:url]),

--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -134,7 +134,7 @@ module Runners
           location = if start_line
                        Location.new(start_line: start_line)
                      else
-                       add_warning "`line_number` is invalid: #{line_number.inspect}. Ignored."
+                       add_warning "`line_number` is invalid: #{line_number.inspect}. The line location is lost."
                        nil
                      end
 

--- a/test/smokes/rails_best_practices/invalid_line_number/app/views/users/show.html.erb
+++ b/test/smokes/rails_best_practices/invalid_line_number/app/views/users/show.html.erb
@@ -1,0 +1,3 @@
+<% if current_user && (current_user == @post.user || @post.editors.include?(current_user)) %>
+  <%= link_to 'Edit this post', edit_post_url(@post) %>
+<% end %>

--- a/test/smokes/rails_best_practices/invalid_line_number/app/views/users/show.html.erb
+++ b/test/smokes/rails_best_practices/invalid_line_number/app/views/users/show.html.erb
@@ -1,3 +1,0 @@
-<% if current_user && (current_user == @post.user || @post.editors.include?(current_user)) %>
-  <%= link_to 'Edit this post', edit_post_url(@post) %>
-<% end %>


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The following error occurs. This may be a bug of RBP, but Runners keep it as a warning.

```
ArgumentError: invalid value for Integer(): "call"
```

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
