### PR TITLE
Set `NewCops: enable` for RuboCop

### DIFF
--- a/.rubocop-formatter.yml
+++ b/.rubocop-formatter.yml
@@ -1,5 +1,6 @@
 AllCops:
   DefaultFormatter: quiet
+  NewCops: enable
 
 Layout/LineLength:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  NewCops: enable
+
 require:
   - rubocop-minitest
   - rubocop-performance

--- a/test/smokes/detekt/expectations.rb
+++ b/test/smokes/detekt/expectations.rb
@@ -17,7 +17,7 @@ s.add_test(
   type: "error",
   class: "RuntimeError",
   backtrace: :_,
-  inspect: %r{.*\'non\/exists\/dir\/\' does not exist.*},
+  inspect: %r{.*'non/exists/dir/' does not exist.*},
   analyzer: { name: "detekt", version: "1.9.1" }
 )
 

--- a/test/smokes/pmd_cpd/expectations.rb
+++ b/test/smokes/pmd_cpd/expectations.rb
@@ -1456,7 +1456,7 @@ s.add_test(
             end_column: 1
           }
         ],
-        codefragment: /fun main\(args\: Array<String>\) \{/
+        codefragment: /fun main\(args: Array<String>\) \{/
       },
       git_blame_info: nil
     },
@@ -1670,7 +1670,7 @@ s.add_test(
             end_column: 6
           }
         ],
-        codefragment: /def main\(\)\:/
+        codefragment: /def main\(\):/
       },
       git_blame_info: nil
     },
@@ -1778,7 +1778,7 @@ s.add_test(
             end_column: 1
           }
         ],
-        codefragment: /fun main\(args\: Array<String>\) \{/
+        codefragment: /fun main\(args: Array<String>\) \{/
       },
       git_blame_info: nil
     },
@@ -1850,7 +1850,7 @@ s.add_test(
             end_column: 6
           }
         ],
-        codefragment: /def main\(\)\:/
+        codefragment: /def main\(\):/
       },
       git_blame_info: nil
     },
@@ -2075,7 +2075,7 @@ s.add_test(
             end_column: 6
           }
         ],
-        codefragment: /def main\(\)\:/
+        codefragment: /def main\(\):/
       },
       git_blame_info: nil
     },
@@ -2111,7 +2111,7 @@ s.add_test(
             end_column: 6
           }
         ],
-        codefragment: /def main\(\)\:/
+        codefragment: /def main\(\):/
       },
       git_blame_info: nil
     },


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to prevent the following warning:

```
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Layout/EmptyLinesAroundAttributeAccessor (0.83)
 - Layout/SpaceAroundMethodCallOperator (0.82)
 - Lint/DeprecatedOpenSSLConstant (0.84)
 - Lint/MixedRegexpCaptureTypes (0.85)
 - Lint/RaiseException (0.81)
 - Lint/StructNewOverride (0.81)
 - Style/RedundantFetchBlock (0.86)
 - Style/RedundantRegexpCharacterClass (0.85)
 - Style/RedundantRegexpEscape (0.85)
 - Style/SlicingWithRange (0.83)
For more information: https://docs.rubocop.org/rubocop/versioning.html
```

Also, this change re-formats the following Ruby files:

```console
$ bundle exec rubocop -c .rubocop-formatter.yml --safe-auto-correct test/smokes/**/expectations.rb
```

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- [x] ~~Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.~~
  → Not notable change.
