### PR TITLE
Fix unstable `CLITest#test_processor_class`

### DIFF
--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -141,10 +141,10 @@ class CLITest < Minitest::Test
   def test_processor_class
     with_runners_options_env(source: { head: 'http://example.com/head' }) do
       cli = CLI.new(argv: %w[--analyzer=rubocop test-guid], stdout: stdout, stderr: stderr)
-      assert_equal Runners::Processor::RuboCop, cli.processor_class
+      assert_equal 'Runners::Processor::RuboCop', cli.processor_class.name
 
       cli = CLI.new(argv: %w[--analyzer=scss_lint test-guid], stdout: stdout, stderr: stderr)
-      assert_equal Runners::Processor::ScssLint, cli.processor_class
+      assert_equal 'Runners::Processor::ScssLint', cli.processor_class.name
 
       error = assert_raises { CLI.new(argv: %w[--analyzer=foo test-guid], stdout: stdout, stderr: stderr) }
       assert_equal "Not found processor class with 'foo'", error.message


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

`CLITest#test_processor_class` sometimes fails on CI. (Never failed on local)

```
CLITest#test_processor_class [/home/runner/work/runners/runners/test/cli_test.rb:144]:
--- expected
+++ actual
@@ -1 +1 @@
-Runners::Processor::RuboCop
+#<Class:#<Runners::Processor::RuboCop:0xXXXXXX>>
```

https://github.com/sider/runners/runs/802525935#step:5:245

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- [x] ~~Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.~~
  → Not notable change.
