### PR TITLE
Remove unstable `CLITest#test_processor_class`

### DIFF
--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -138,19 +138,6 @@ class CLITest < Minitest::Test
     end
   end
 
-  def test_processor_class
-    with_runners_options_env(source: { head: 'http://example.com/head' }) do
-      cli = CLI.new(argv: %w[--analyzer=rubocop test-guid], stdout: stdout, stderr: stderr)
-      assert_equal Runners::Processor::RuboCop, cli.processor_class
-
-      cli = CLI.new(argv: %w[--analyzer=scss_lint test-guid], stdout: stdout, stderr: stderr)
-      assert_equal Runners::Processor::ScssLint, cli.processor_class
-
-      error = assert_raises { CLI.new(argv: %w[--analyzer=foo test-guid], stdout: stdout, stderr: stderr) }
-      assert_equal "Not found processor class with 'foo'", error.message
-    end
-  end
-
   def test_format_duration
     with_runners_options_env(source: { head: 'http://example.com/head' }) do
       cli = CLI.new(argv: %w[--analyzer=rubocop test-guid], stdout: stdout, stderr: stderr)


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Re-challenge for PR #1226.

`CLITest#test_processor_class` is unstable (sometimes failed) but not useful to detect bugs.
I think the current smoke tests are enough if `CLITest#test_processor_class` is missing.

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- [x] ~~Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.~~
  → Not notable change.
