### PR TITLE
Bump rails_best_practices from 1.19.4 to 1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.28.3...HEAD)
 
+- **Rails Best Practices** 1.19.4 -> 1.20.0 [#1228](https://github.com/sider/runners/pull/1228)
+
 ## 0.28.3
 
 [Full diff](https://github.com/sider/runners/compare/0.28.2...0.28.3)

--- a/images/rails_best_practices/Gemfile
+++ b/images/rails_best_practices/Gemfile
@@ -1,8 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'rails_best_practices', '1.19.4'
+gem 'rails_best_practices', '1.20.0'
 gem 'slim', '4.1.0'
 gem 'haml', '5.1.2'
 gem 'sass', '3.7.4'
 gem 'sassc', '2.4.0'
-gem 'require_all', '2.0.0'

--- a/test/smokes/rails_best_practices/expectations.rb
+++ b/test/smokes/rails_best_practices/expectations.rb
@@ -1,5 +1,7 @@
 s = Runners::Testing::Smoke
 
+default_version = "1.20.0"
+
 s.add_test(
   "sandbox_rails",
   type: "success",
@@ -41,7 +43,7 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Rails Best Practices", version: "1.19.4" }
+  analyzer: { name: "Rails Best Practices", version: default_version }
 )
 
 s.add_test(
@@ -55,7 +57,7 @@ s.add_test(
 s.add_test(
   "valid_sideci_yml",
   type: "success",
-  analyzer: { name: "Rails Best Practices", version: "1.19.4" },
+  analyzer: { name: "Rails Best Practices", version: default_version },
   issues: [
     {
       message: "Don't rescue Exception",
@@ -178,7 +180,7 @@ s.add_test(
 s.add_test(
   "unsupported",
   type: "success",
-  analyzer: { name: "Rails Best Practices", version: "1.19.4" },
+  analyzer: { name: "Rails Best Practices", version: default_version },
   issues: [
     {
       message: "Don't rescue Exception",
@@ -193,7 +195,7 @@ s.add_test(
   warnings: [
     {
       message: <<~MESSAGE.strip,
-        `rails_best_practices 1.19.4` is installed instead of `1.16.0` in your `Gemfile.lock`.
+        `rails_best_practices #{default_version}` is installed instead of `1.16.0` in your `Gemfile.lock`.
         Because `1.16.0` does not satisfy our constraints `>= 1.19.1, < 2.0`.
 
         If you want to use a different version of `rails_best_practices`, please do either:
@@ -208,7 +210,7 @@ s.add_test(
 s.add_test(
   "include_dirs_by_default",
   type: "success",
-  analyzer: { name: "Rails Best Practices", version: "1.19.4" },
+  analyzer: { name: "Rails Best Practices", version: default_version },
   issues: [
     {
       message: "Don't rescue Exception",
@@ -225,7 +227,7 @@ s.add_test(
 s.add_test(
   "include_dirs_with_config",
   type: "success",
-  analyzer: { name: "Rails Best Practices", version: "1.19.4" },
+  analyzer: { name: "Rails Best Practices", version: default_version },
   issues: [
     {
       message: "Don't rescue Exception",
@@ -260,7 +262,7 @@ s.add_test(
 s.add_test(
   "exclude_multiple",
   type: "success",
-  analyzer: { name: "Rails Best Practices", version: "1.19.4" },
+  analyzer: { name: "Rails Best Practices", version: default_version },
   issues: [
     {
       message: "Don't rescue Exception",


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- https://github.com/flyerhzm/rails_best_practices/blob/master/CHANGELOG.md#1200-2020-02-29
- https://github.com/flyerhzm/rails_best_practices/compare/v1.19.4...v1.20.0

Also, this removes `require_all` from `Gemfile`.
Because `rails_best_practices` has a dependency on `require_all`.
See https://rubygems.org/gems/rails_best_practices/versions/1.20.0

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

Maybe related to #1218

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
