### PR TITLE
[Rails Best Practices] More info in warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.28.3...HEAD)
 
 - **Rails Best Practices** 1.19.4 -> 1.20.0 [#1228](https://github.com/sider/runners/pull/1228)
+- **Rails Best Practices** More info in warning message [#1230](https://github.com/sider/runners/pull/1230)
 
 ## 0.28.3
 

--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -134,7 +134,8 @@ module Runners
           location = if start_line
                        Location.new(start_line: start_line)
                      else
-                       add_warning "`line_number` is invalid: #{line_number.inspect}. The line location is lost."
+                       file = relative_path(issue.fetch(:filename)).to_path
+                       add_warning "Invalid `line_number` is output: #{line_number.inspect}. The line location in `#{file}` is lost.", file: file
                        nil
                      end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change makes the warning message a bit easier to understand when `line_number` is invalid.

E.g. Invalid `line_number` is output: "call". The line location in `config/routes.rb` is lost.

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
