### PR TITLE
[Rails Best Practices] Add smoke test case for invalid line number

### DIFF
--- a/test/smokes/rails_best_practices/expectations.rb
+++ b/test/smokes/rails_best_practices/expectations.rb
@@ -275,3 +275,23 @@ s.add_test(
     }
   ]
 )
+
+s.add_test(
+  "invalid_line_number",
+  type: "success",
+  analyzer: { name: "Rails Best Practices", version: default_version },
+  issues: [
+    {
+      message: "move code into model (article use_count > 2)",
+      links: %w[https://rails-bestpractices.com/posts/2010/07/24/move-code-into-model/],
+      id: "RailsBestPractices::Reviews::MoveCodeIntoModelReview",
+      path: "app/views/articles/show.html.erb",
+      location: nil,
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  warnings: [
+    { message: "Invalid `line_number` is output: \"call\". The line location in `app/views/articles/show.html.erb` is lost.", file: "app/views/articles/show.html.erb" }
+  ]
+)

--- a/test/smokes/rails_best_practices/invalid_line_number/app/views/articles/show.html.erb
+++ b/test/smokes/rails_best_practices/invalid_line_number/app/views/articles/show.html.erb
@@ -1,0 +1,3 @@
+<% if !article.published? && article.published_from_feed? && !article.user&.feed_admin_publish_permission? %>
+  <%= link_to 'Edit this article', edit_article_url(article) %>
+<% end %>


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

In PR #1216, I could **not** add a smoke test case for invalid line numbers because I could not find a reproduction.
But, I can find it finally in this PR!

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

Related to #1216

> Check the following items.

- [x] ~~Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.~~
  → This change is only for the test.
