### PR TITLE
[Rails Best Practices] Fix invalid line number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.29.2...HEAD)
 
+- **Rails Best Practices** Fix invalid line number [#1242](https://github.com/sider/runners/pull/1242)
+
 ## 0.29.2
 
 [Full diff](https://github.com/sider/runners/compare/0.29.1...0.29.2)

--- a/images/rails_best_practices/Gemfile
+++ b/images/rails_best_practices/Gemfile
@@ -7,4 +7,4 @@ gem 'sass', '3.7.4'
 gem 'sassc', '2.4.0'
 
 # HACK: See `Runners::Processor::RailsBestPractices#default_gem_specs`.
-gem 'code_analyzer', git: 'https://github.com/flyerhzm/code_analyzer.git', ref: 'e816d9b4ff9dbd1bb7aa1eef9c78ae9a84f1cae1'
+gem 'code_analyzer', git: 'https://github.com/flyerhzm/code_analyzer.git', tag: 'v0.5.2'

--- a/images/rails_best_practices/Gemfile
+++ b/images/rails_best_practices/Gemfile
@@ -7,4 +7,4 @@ gem 'sass', '3.7.4'
 gem 'sassc', '2.4.0'
 
 # HACK: See `Runners::Processor::RailsBestPractices#default_gem_specs`.
-gem 'code_analyzer', git: 'https://github.com/flyerhzm/code_analyzer.git', ref: 'e31ce438d3858df055bf85334003f29e1bd1673d'
+gem 'code_analyzer', git: 'https://github.com/flyerhzm/code_analyzer.git', ref: 'e816d9b4ff9dbd1bb7aa1eef9c78ae9a84f1cae1'

--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -44,10 +44,10 @@ module Runners
 
     def default_gem_specs
       super.tap do |specs|
-        # HACK: https://github.com/flyerhzm/code_analyzer/pull/13 is not released yet.
+        # HACK: The new version of `code_analyzer` is not released yet to Rubygems.
         source = GemInstaller::Source.create(git: {
           repo: "https://github.com/flyerhzm/code_analyzer.git",
-          ref: "e816d9b4ff9dbd1bb7aa1eef9c78ae9a84f1cae1",
+          tag: "v0.5.2",
         })
         specs << GemInstaller::Spec.new(name: "code_analyzer", version: [], source: source)
       end

--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -47,7 +47,7 @@ module Runners
         # HACK: https://github.com/flyerhzm/code_analyzer/pull/13 is not released yet.
         source = GemInstaller::Source.create(git: {
           repo: "https://github.com/flyerhzm/code_analyzer.git",
-          ref: "e31ce438d3858df055bf85334003f29e1bd1673d",
+          ref: "e816d9b4ff9dbd1bb7aa1eef9c78ae9a84f1cae1",
         })
         specs << GemInstaller::Spec.new(name: "code_analyzer", version: [], source: source)
       end

--- a/test/smokes/rails_best_practices/expectations.rb
+++ b/test/smokes/rails_best_practices/expectations.rb
@@ -298,6 +298,24 @@ s.add_test(
       location: { start_line: 5 },
       object: nil,
       git_blame_info: nil
+    },
+    {
+      message: "move code into model (post use_count > 2)",
+      links: %w[https://rails-bestpractices.com/posts/2010/07/24/move-code-into-model/],
+      id: "RailsBestPractices::Reviews::MoveCodeIntoModelReview",
+      path: "app/views/articles/show.html.erb",
+      location: { start_line: 9 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "move code into model (Time use_count > 2)",
+      links: %w[https://rails-bestpractices.com/posts/2010/07/24/move-code-into-model/],
+      id: "RailsBestPractices::Reviews::MoveCodeIntoModelReview",
+      path: "app/views/articles/show.html.erb",
+      location: { start_line: 13 },
+      object: nil,
+      git_blame_info: nil
     }
   ]
 )

--- a/test/smokes/rails_best_practices/invalid_line_number/app/views/articles/show.html.erb
+++ b/test/smokes/rails_best_practices/invalid_line_number/app/views/articles/show.html.erb
@@ -5,3 +5,9 @@
 <% unless (allowed? :some, "extra") || article.exists? || article.started_at.nil? || article.published_at <= Time.current %>
   <p>...</p>
 <% end %>
+
+<% if ::PostScanner.search(:some, "extra") || post.exists? || post.started_at.nil? || post.published_at <= Time.current %>
+  <p>...</p>
+<% end %>
+
+<%= (Time.zone.parse('2020-01-01')..Time.zone.parse('2020-01-05')).cover?(Time.current) ? 'on' : 'off' %>


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change updates the `code_analyzer` gem's commit in `Gemfile`.
(Sadly, the gem's new version is not published yet.)

https://github.com/flyerhzm/code_analyzer/compare/e31ce438d3858df055bf85334003f29e1bd1673d...e816d9b4ff9dbd1bb7aa1eef9c78ae9a84f1cae1

Unless this fix, the smoke test outputs the following warnings:

```ruby
[
  {
    message: "Invalid `line_number` is output: \"@const\". The line location in `app/views/articles/show.html.erb` is lost.",
    file: "app/views/articles/show.html.erb"
  },
  {
    message: "Invalid `line_number` is output: \"method_add_arg\". The line location in `app/views/articles/show.html.erb` is lost.",
    file: "app/views/articles/show.html.erb"
  }
]
```

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

Related to #1232 #1240

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
