### PR TITLE
Add Querly rule about `.to_i` method

### DIFF
--- a/querly.yml
+++ b/querly.yml
@@ -107,3 +107,5 @@ rules:
           result[:line].to_i
       - after: |
           Integer(result[:line])
+    justification:
+      - When the use of `.to_i` can make the code more simple

--- a/querly.yml
+++ b/querly.yml
@@ -10,9 +10,10 @@ rules:
       If you want to know if it is aborted, consider using also `Process#exited?`.
 
       See also:
-      * https://ruby-doc.org/core-2.7.1/Process/Status.html#method-i-exitstatus
+      * https://ruby-doc.org/core/Process/Status.html#method-i-exitstatus
     justification:
       - When you are not interested in aborted or core-dumped.
+
   - id: sider.runners.trace_writer_status
     pattern:
       - status(_, ...)
@@ -24,6 +25,7 @@ rules:
     examples:
       - before: trace_writer.status(status)
       - before: "trace_writer.status(status, recorded_at: Time.now)"
+
   - id: sider.runners.sh-util-in-rake-tasks
     pattern:
       - sh(_)
@@ -35,7 +37,7 @@ rules:
 
       See also:
       * https://www.rubydoc.info/gems/rake/FileUtils#sh-instance_method
-      * https://ruby-doc.org/core-2.6.5/Kernel.html#method-i-exec
+      * https://ruby-doc.org/core/Kernel.html#method-i-exec
     justification:
       - When required to run the command via the system shell.
       - When the command has no arguments.
@@ -44,6 +46,7 @@ rules:
           sh "echo #{username}"
         after: |
           sh "echo", username
+
   - id: sider.runners.tmpdir
     pattern:
       - Dir.tmpdir
@@ -58,12 +61,14 @@ rules:
           output_file = Pathname(Dir.tmpdir) / "output.json"
       - after: |
           output_file = working_dir / "output.json"
+
   - id: sider.runners.mktmpdir
     pattern: Dir.mktmpdir
     message: The code probably may be more simple if using `Runners::Tmpdir` instead.
     examples:
       - before: Dir.mktmpdir { |dir| puts Pathname(dir) }
         after: mktmpdir { |dir| puts dir }
+
   - id: sider.runners.tempfile_new
     pattern: Tempfile.new
     message: |
@@ -72,9 +77,33 @@ rules:
       `Tempfile.create` does **not** automatically remove the created file.
       On the other hand, since `Tempfile.new` removes automatically the file, smoke tests can sometimes fail.
 
-      See https://ruby-doc.org/stdlib-2.7.0/libdoc/tempfile/rdoc/Tempfile.html
+      See https://ruby-doc.org/stdlib/libdoc/tempfile/rdoc/Tempfile.html
     examples:
       - before: |
           Tempfile.new(["rubocop-", ".json"])
       - after: |
           Tempfile.create(["rubocop-", ".json"])
+
+  - id: sider.runners.to_i
+    pattern: _.to_i
+    message: |
+      Be careful with the `.to_i` method.
+
+      For example, `nil.to_i` or `"".to_i` returns `0`, but this behavior may be unexpected.
+      If you want to just covert String to Integer, the `Integer` method may be suitable in most cases.
+
+      Example:
+      ```ruby
+      Integer("0") #=> 0
+      Integer("") #=> ArgumentError
+      ```
+
+      See also:
+      * https://ruby-doc.org/core/NilClass.html#to_i-method
+      * https://ruby-doc.org/core/String.html#to_i-method
+      * https://ruby-doc.org/core/Kernel.html#Integer-method
+    examples:
+      - before: |
+          result[:line].to_i
+      - after: |
+          Integer(result[:line])


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This added rule aims to call attention to the use of the `.to_i` method.
I think the `Integer` method is more suitable than `.to_i`.

For example:

```console
$ querly check --rule sider.runners.to_i lib/
lib/runners/processor/pmd_cpd.rb:147:14	elem_dupli[:lines].to_i	Be careful with the `.to_i` method. (sider.runners.to_i)
lib/runners/processor/pmd_cpd.rb:148:15	elem_dupli[:tokens].to_i	Be careful with the `.to_i` method. (sider.runners.to_i)
lib/runners/cli.rb:112:22	value.to_i	Be careful with the `.to_i` method. (sider.runners.to_i)
lib/runners/testing/smoke.rb:38:15	ENV["JOBS"]&.to_i	Be careful with the `.to_i` method. (sider.runners.to_i)
lib/runners/processor/flake8.rb:59:11	config_linter[:version]&.to_i	Be careful with the `.to_i` method. (sider.runners.to_i)
lib/runners/processor/flake8.rb:105:22	line.to_i	Be careful with the `.to_i` method. (sider.runners.to_i)
```

See also:
- https://ruby-doc.org/core/NilClass.html#to_i-method
- https://ruby-doc.org/core/String.html#to_i-method
- https://ruby-doc.org/core/Kernel.html#Integer-method

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- [x] ~~Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.~~
  → Not notable change.