### PR TITLE
[Rails Best Practices] Remove `code_analyzer` hack

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -214,7 +214,7 @@ updates:
   - package-ecosystem: bundler
     directory: "/images/rails_best_practices"
     schedule:
-      interval: daily # NOTE: See the `code_analyzer` gem issue. We need to revert this to `weekly` in the future.
+      interval: weekly
       time: "09:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10

--- a/images/rails_best_practices/Gemfile
+++ b/images/rails_best_practices/Gemfile
@@ -5,6 +5,3 @@ gem 'slim', '4.1.0'
 gem 'haml', '5.1.2'
 gem 'sass', '3.7.4'
 gem 'sassc', '2.4.0'
-
-# HACK: See `Runners::Processor::RailsBestPractices#default_gem_specs`.
-gem 'code_analyzer', git: 'https://github.com/flyerhzm/code_analyzer.git', tag: 'v0.5.2'

--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -42,17 +42,6 @@ module Runners
       "rails_best_practices" => [">= 1.19.1", "< 2.0"]
     }.freeze
 
-    def default_gem_specs
-      super.tap do |specs|
-        # HACK: The new version of `code_analyzer` is not released yet to Rubygems.
-        source = GemInstaller::Source.create(git: {
-          repo: "https://github.com/flyerhzm/code_analyzer.git",
-          tag: "v0.5.2",
-        })
-        specs << GemInstaller::Spec.new(name: "code_analyzer", version: [], source: source)
-      end
-    end
-
     def setup
       add_warning_if_deprecated_options([:options])
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The new version 0.5.2 of the `code_analyzer` gem has been published to Rubygems.
We no longer need the hacks about the gem, so this change removes them.

We can confirm that `code_analyzer 0.5.2` is successfully installed into the Docker image:

```console
$ rake docker:shell ANALYZER=rails_best_practices
docker run -it --rm --entrypoint=bash --volume=/Users/masafumi.koba/git/sider/runners:/work --workdir=/work sider/runner_rails_best_practices:dev
analyzer_runner@20533dd5caab:/work$ gem list code_analyzer

*** LOCAL GEMS ***

code_analyzer (0.5.2)
```

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

Fix #1243
Fix #1247

> Check the following items.

- [x] ~~Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.~~
  → This is an internal change.
