### PR TITLE
[PHPMD] Support the comma-separated list options as array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Misc:
 
 - Use Docker BuildKit [#1245](https://github.com/sider/runners/pull/1245)
 - Fix Kotlin file extensions [#1252](https://github.com/sider/runners/pull/1252)
+- **PHPMD** Support the comma-separated list options as array [#1253](https://github.com/sider/runners/pull/1253)
 
 ## 0.29.3
 

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -251,7 +251,7 @@ module Runners
     end
 
     def comma_separated_list(value)
-      values = Array(value).map { |s| s.split(",") }
+      values = Array(value).flat_map { |s| s.split(/\s*,\s*/) }
       values.empty? ? nil : values.join(",")
     end
   end

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -249,5 +249,10 @@ module Runners
         JSON.parse(output, symbolize_names: true)
       end
     end
+
+    def comma_separated_list(value)
+      values = Array(value).map { |s| s.split(",") }
+      values.empty? ? nil : values.join(",")
+    end
   end
 end

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -67,7 +67,7 @@ module Runners
 
     def exclude
       exclude = comma_separated_list(config_linter[:exclude] || config_linter.dig(:options, :exclude))
-      exclude ? ["--exclude", "#{exclude}"] : []
+      exclude ? ["--exclude", exclude] : []
     end
 
     def strict

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -52,7 +52,7 @@ module Runners
     end
 
     def target_dirs
-      comma_separated_list(config_linter[:target] || DEFAULT_TARGET)
+      comma_separated_list(config_linter[:target]) || DEFAULT_TARGET
     end
 
     def minimumpriority

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -6,10 +6,10 @@ module Runners
       let :runner_config, Schema::BaseConfig.base.update_fields { |fields|
         fields.merge!({
                         target: enum?(string, array(string)),
-                        rule: string?,
+                        rule: enum?(string, array(string)),
                         minimumpriority: numeric?,
-                        suffixes: string?,
-                        exclude: string?,
+                        suffixes: enum?(string, array(string)),
+                        exclude: enum?(string, array(string)),
                         strict: boolean?,
                         custom_rule_path: array?(string),
                         # DO NOT ADD ANY OPTIONS in `options` option.
@@ -26,6 +26,9 @@ module Runners
 
     register_config_schema(name: :phpmd, schema: Schema.runner_config)
 
+    DEFAULT_TARGET = ".".freeze
+    DEFAULT_CONFIG_FILE = (Pathname(Dir.home) / "sider_config.xml").to_path.freeze
+
     def setup
       add_warning_if_deprecated_options([:options])
       yield
@@ -33,8 +36,7 @@ module Runners
 
     def analyze(changes)
       delete_unchanged_files(changes, only: target_files, except: config_linter[:custom_rule_path] || [])
-      options = [minimumpriority, suffixes, exclude, strict].flatten.compact
-      run_analyzer(changes, target_dirs, rule, options)
+      run_analyzer(changes)
     end
 
     private
@@ -46,50 +48,48 @@ module Runners
 
     def rule
       rules = config_linter[:rule] || config_linter.dig(:options, :rule)
-      if rules
-        rules
-      else
-        # NOTE: It assumes that default config xml is located in $HOME
-        (Pathname(Dir.home) / 'sider_config.xml').realpath.to_s
-      end
+      comma_separated_list(rules) || DEFAULT_CONFIG_FILE
     end
 
     def target_dirs
-      Array(config_linter[:target] || './').flat_map { |target| target.split(',') }.join(',')
+      comma_separated_list(config_linter[:target] || DEFAULT_TARGET)
     end
 
     def minimumpriority
-      min_priority = config_linter[:minimumpriority] || config_linter.dig(:options, :minimumpriority)
-      ["--minimumpriority", "#{min_priority}"] if min_priority
+      priority = config_linter[:minimumpriority] || config_linter.dig(:options, :minimumpriority)
+      priority ? ["--minimumpriority", priority.to_s] : []
     end
 
     def suffixes
-      suffixes = config_linter[:suffixes] || config_linter.dig(:options, :suffixes)
-      ["--suffixes", "#{suffixes}"] if suffixes
+      suffixes = comma_separated_list(config_linter[:suffixes] || config_linter.dig(:options, :suffixes))
+      suffixes ? ["--suffixes", suffixes] : []
     end
 
     def exclude
-      exclude = config_linter[:exclude] || config_linter.dig(:options, :exclude)
-      ["--exclude", "#{exclude}"] if exclude
+      exclude = comma_separated_list(config_linter[:exclude] || config_linter.dig(:options, :exclude))
+      exclude ? ["--exclude", "#{exclude}"] : []
     end
 
     def strict
       strict = config_linter[:strict] || config_linter.dig(:options, :strict)
-      ["--strict"] if strict
+      strict ? ["--strict"] : []
     end
 
-    def run_analyzer(changes, targets, rule, options)
+    def run_analyzer(changes)
       # PHPMD exits 1 when some violations are found.
       # The `--ignore-violation-on-exit` will exit with a zero code, even if any violations are found.
       # See https://phpmd.org/documentation/index.html
       _stdout, stderr, status = capture3(
         analyzer_bin,
-        targets,
+        target_dirs,
         "xml",
         rule,
         "--ignore-violations-on-exit",
         "--report-file", report_file,
-        *options
+        *minimumpriority,
+        *suffixes,
+        *exclude,
+        *strict,
       )
 
       unless status.success?

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -155,6 +155,7 @@ class Runners::Processor
   def read_report_file: (?String) -> String
   def read_report_xml: (?String) -> REXML::Document
   def read_report_json: <'x> (?String) { () -> 'x } -> (Hash<Symbol, any> | 'x)
+  def comma_separated_list: (String | Array<String> | nil) -> String?
 end
 
 # TODO: Keep for the backward compatibility.

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -491,4 +491,18 @@ class ProcessorTest < Minitest::Test
       assert_raises(JSON::ParserError) { processor.read_report_json(file) }
     end
   end
+
+  def test_comma_separated_list
+    with_workspace do |workspace|
+      processor = new_processor(workspace: workspace)
+
+      assert_nil processor.comma_separated_list(nil)
+      assert_nil processor.comma_separated_list([])
+      assert_equal "", processor.comma_separated_list("")
+      assert_equal "a", processor.comma_separated_list("a")
+      assert_equal "a,b", processor.comma_separated_list("a,b")
+      assert_equal "a", processor.comma_separated_list(["a"])
+      assert_equal "a,b", processor.comma_separated_list(["a", "b"])
+    end
+  end
 end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -498,11 +498,14 @@ class ProcessorTest < Minitest::Test
 
       assert_nil processor.comma_separated_list(nil)
       assert_nil processor.comma_separated_list([])
-      assert_equal "", processor.comma_separated_list("")
+      assert_nil processor.comma_separated_list("")
       assert_equal "a", processor.comma_separated_list("a")
       assert_equal "a,b", processor.comma_separated_list("a,b")
+      assert_equal "a,b", processor.comma_separated_list("a , b")
       assert_equal "a", processor.comma_separated_list(["a"])
       assert_equal "a,b", processor.comma_separated_list(["a", "b"])
+      assert_equal "a,b,c", processor.comma_separated_list(["a,b", "c"])
+      assert_equal "a,b,c,d,e", processor.comma_separated_list(["a,b", "c", "d , e"])
     end
   end
 end

--- a/test/smokes/phpmd/array_options/app/Controller/PageController.php
+++ b/test/smokes/phpmd/array_options/app/Controller/PageController.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Static content controller.
+ *
+ * This file will render views from views/pages/
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       app.Controller
+ * @since         CakePHP(tm) v 0.2.9
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+App::uses('AppController', 'Controller');
+
+/**
+ * Static content controller
+ *
+ * Override this controller by placing a copy in controllers directory of an application
+ *
+ * @package       app.Controller
+ * @link http://book.cakephp.org/2.0/en/controllers/pages-controller.html
+ */
+class PagesController extends AppController {
+
+/**
+ * This controller does not use a model
+ *
+ * @var array
+ */
+	public $uses = array();
+	public $uses2 = array();
+	public $uses3 = array();
+
+/**
+ * TooManyMethods
+*/
+public function display1() {
+}
+public function display2() {
+}
+public function display3() {
+}
+public function display4() {
+}
+public function display5() {
+}
+public function display6() {
+}
+public function display7() {
+}
+public function display8() {
+}
+public function display9() {
+}
+public function display10() {
+}
+public function display11() {
+}
+public function display12() {
+}
+public function display13() {
+}
+public function display14() {
+}
+public function display15() {
+}
+public function display16() {
+}
+public function display17() {
+}
+
+/**
+ * Displays a view
+ *
+ * @return void
+ * @throws NotFoundException When the view file could not be found
+ *	or MissingViewException in debug mode.
+ */
+	public function display() {
+    $eeeeeeeeee;
+    $aaaaaaaaaa;
+    $bbbbbbbbbb;
+    $aaaaaaaaaa;
+
+    $cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc;
+		$path = func_get_args();
+
+		$count = count($path);
+		if (!$count) {
+			return $this->redirect('/');
+		}
+		$page = $subpage = $title_for_layout = null;
+
+		if (!empty($path[0])) {
+			$page = $path[0];
+		}
+		if (!empty($path[1])) {
+			$subpage = $path[1];
+		}
+		if (!empty($path[$count - 1])) {
+			$title_for_layout = Inflector::humanize($path[$count - 1]);
+		}
+		$this->set(compact('page', 'subpage', 'title_for_layout'));
+
+		try {
+			$this->render(implode('/', $path));
+		} catch (MissingViewException $e) {
+			if (Configure::read('debug')) {
+				throw $e;
+			}
+			throw new NotFoundException();
+		}
+  }
+
+  private $顧客名;
+
+  function set顧客名($v)
+  {
+    $this->顧客名 = $v;
+    return $this;
+  }
+
+  function get顧客名()
+  {
+    return $this->顧客名;
+  }
+}
+
+/**
+ * CyclomaticComplexity
+ */
+// Cyclomatic Complexity = 12
+class Foo {
+    public function example()  {
+        if ($a == $b)  {
+            if ($a1 == $b1) {
+                fiddle();
+            } else if ($a2 == $b2) {
+                fiddle();
+            }  else {
+                fiddle();
+            }
+        } else if ($c == $d) {
+            while ($c == $d) {
+                fiddle();
+            }
+         } else if ($e == $f) {
+            for ($n = 0; $n < $h; $n++) {
+                fiddle();
+            }
+        } else{
+            switch ($z) {
+                case 1:
+                    fiddle();
+                    break;
+                case 2:
+                    fiddle();
+                    break;
+                case 3:
+                    fiddle();
+                    break;
+                default:
+                    fiddle();
+                    break;
+            }
+        }
+    }
+}

--- a/test/smokes/phpmd/array_options/app/index.php
+++ b/test/smokes/phpmd/array_options/app/index.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       app
+ * @since         CakePHP(tm) v 0.10.0.1076
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+require 'webroot' . DIRECTORY_SEPARATOR . 'index.php';
+
+class Main {
+    function __construct(){
+        $hoge = "hoge";
+    }
+
+    function bar($flag = true) {
+        return $flag;
+    }
+}

--- a/test/smokes/phpmd/array_options/app/webroot/index.php
+++ b/test/smokes/phpmd/array_options/app/webroot/index.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Index
+ *
+ * The Front Controller for handling every request
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       app.webroot
+ * @since         CakePHP(tm) v 0.2.9
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * Use the DS to separate the directories in other defines
+ */
+if (!defined('DS')) {
+	define('DS', DIRECTORY_SEPARATOR);
+}
+
+/**
+ * These defines should only be edited if you have CakePHP installed in
+ * a directory layout other than the way it is distributed.
+ * When using custom settings be sure to use the DS and do not add a trailing DS.
+ */
+
+/**
+ * The full path to the directory which holds "app", WITHOUT a trailing DS.
+ *
+ */
+if (!defined('ROOT')) {
+	define('ROOT', dirname(dirname(dirname(__FILE__))));
+}
+
+/**
+ * The actual directory name for the "app".
+ *
+ */
+if (!defined('APP_DIR')) {
+	define('APP_DIR', basename(dirname(dirname(__FILE__))));
+}
+
+/**
+ * The absolute path to the "cake" directory, WITHOUT a trailing DS.
+ *
+ * Un-comment this line to specify a fixed path to CakePHP.
+ * This should point at the directory containing `Cake`.
+ *
+ * For ease of development CakePHP uses PHP's include_path. If you
+ * cannot modify your include_path set this value.
+ *
+ * Leaving this constant undefined will result in it being defined in Cake/bootstrap.php
+ *
+ * The following line differs from its sibling
+ * /lib/Cake/Console/Templates/skel/webroot/index.php
+ */
+//define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . 'lib');
+
+/**
+ * This auto-detects CakePHP as a composer installed library.
+ * You may remove this if you are not planning to use composer (not recommended, though).
+ */
+$vendorPath = ROOT . DS . APP_DIR . DS . 'Vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib';
+$dispatcher = 'Cake' . DS . 'Console' . DS . 'ShellDispatcher.php';
+if (!defined('CAKE_CORE_INCLUDE_PATH') && file_exists($vendorPath . DS . $dispatcher)) {
+	define('CAKE_CORE_INCLUDE_PATH', $vendorPath);
+}
+
+/**
+ * Editing below this line should NOT be necessary.
+ * Change at your own risk.
+ *
+ */
+if (!defined('WEBROOT_DIR')) {
+	define('WEBROOT_DIR', basename(dirname(__FILE__)));
+}
+if (!defined('WWW_ROOT')) {
+	define('WWW_ROOT', dirname(__FILE__) . DS);
+}
+
+// for built-in server
+if (php_sapi_name() === 'cli-server') {
+	if ($_SERVER['REQUEST_URI'] !== '/' && file_exists(WWW_ROOT . $_SERVER['PHP_SELF'])) {
+		return false;
+	}
+	$_SERVER['PHP_SELF'] = '/' . basename(__FILE__);
+}
+
+if (!defined('CAKE_CORE_INCLUDE_PATH')) {
+	if (function_exists('ini_set')) {
+		ini_set('include_path', ROOT . DS . 'lib' . PATH_SEPARATOR . ini_get('include_path'));
+	}
+	if (!include 'Cake' . DS . 'bootstrap.php') {
+		$failed = true;
+	}
+} else {
+	if (!include CAKE_CORE_INCLUDE_PATH . DS . 'Cake' . DS . 'bootstrap.php') {
+		$failed = true;
+	}
+}
+if (!empty($failed)) {
+	trigger_error("CakePHP core could not be found. Check the value of CAKE_CORE_INCLUDE_PATH in APP/webroot/index.php. It should point to the directory containing your " . DS . "cake core directory and your " . DS . "vendors root directory.", E_USER_ERROR);
+}
+
+App::uses('Dispatcher', 'Routing');
+
+$Dispatcher = new Dispatcher();
+$Dispatcher->dispatch(
+	new CakeRequest(),
+	new CakeResponse()
+);

--- a/test/smokes/phpmd/array_options/foo.phtml
+++ b/test/smokes/phpmd/array_options/foo.phtml
@@ -1,0 +1,9 @@
+<html>
+  <body>
+    <?php
+    function foo() {
+      $var = "bar";
+    }
+    ?>
+  </body>
+</html>

--- a/test/smokes/phpmd/array_options/sider.yml
+++ b/test/smokes/phpmd/array_options/sider.yml
@@ -1,0 +1,11 @@
+linter:
+  phpmd:
+    exclude:
+      - app/Controller/
+      - app/index.php
+    rule:
+      - cleancode,codesize
+      - controversial,design
+      - naming
+      - unusedcode
+    suffixes: [php, phtml]

--- a/test/smokes/phpmd/expectations.rb
+++ b/test/smokes/phpmd/expectations.rb
@@ -1,5 +1,7 @@
 s = Runners::Testing::Smoke
 
+default_version = "2.8.1"
+
 s.add_test(
   "success",
   type: "success",
@@ -14,12 +16,12 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "PHPMD", version: "2.8.1" }
+  analyzer: { name: "PHPMD", version: default_version }
 )
 
 s.add_test(
   "invalid_rule",
-  type: "failure", message: 'Invalid rule: "invalid_rule"', analyzer: { name: "PHPMD", version: "2.8.1" }
+  type: "failure", message: 'Invalid rule: "invalid_rule"', analyzer: { name: "PHPMD", version: default_version }
 )
 
 s.add_test(
@@ -55,7 +57,7 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "PHPMD", version: "2.8.1" },
+  analyzer: { name: "PHPMD", version: default_version },
   warnings: [
     {
       message: <<~MSG.strip,
@@ -71,7 +73,7 @@ s.add_test(
 
 s.add_test(
   "syntax_error",
-  type: "failure", message: /Unexpected end of token stream in file:/, analyzer: { name: "PHPMD", version: "2.8.1" }
+  type: "failure", message: /Unexpected end of token stream in file:/, analyzer: { name: "PHPMD", version: default_version }
 )
 
 s.add_test(
@@ -88,7 +90,7 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "PHPMD", version: "2.8.1" }
+  analyzer: { name: "PHPMD", version: default_version }
 )
 
 s.add_test(
@@ -105,10 +107,10 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "PHPMD", version: "2.8.1" }
+  analyzer: { name: "PHPMD", version: default_version }
 )
 
-s.add_test("with_php_version", type: "success", issues: [], analyzer: { name: "PHPMD", version: "2.8.1" })
+s.add_test("with_php_version", type: "success", issues: [], analyzer: { name: "PHPMD", version: default_version })
 
 s.add_test(
   "broken_sideci_yml",
@@ -150,12 +152,29 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "PHPMD", version: "2.8.1" }
+  analyzer: { name: "PHPMD", version: default_version }
 )
 
 s.add_test(
   "invalid_output_xml",
   type: "failure",
   message: "Invalid XML was output. See the log for details.",
-  analyzer: { name: "PHPMD", version: "2.8.1" }
+  analyzer: { name: "PHPMD", version: default_version }
+)
+
+s.add_test(
+  "array_options",
+  type: "success",
+  issues: [
+    {
+      path: "foo.phtml",
+      location: { start_line: 5, end_line: 5 },
+      id: "UnusedLocalVariable",
+      message: "Avoid unused local variables such as '$var'.",
+      links: %w[https://phpmd.org/rules/unusedcode.html#unusedlocalvariable],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHPMD", version: default_version }
 )


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to increase usability when users configure their `sider.yml`. E.g.

```diff
-rule: "cleancode,codesize,controversial,design"
+rule:
+  - cleancode
+  - codesize
+  - controversial
+  - design
```

Also, this change adds a utility method to handle a comma-separated list to the `Processor` class.

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

Fix #1076

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
