### PR TITLE
[Misspell] Support `ignore` option as array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Misc:
 - Use Docker BuildKit [#1245](https://github.com/sider/runners/pull/1245)
 - Fix Kotlin file extensions [#1252](https://github.com/sider/runners/pull/1252)
 - **PHPMD** Support the comma-separated list options as array [#1253](https://github.com/sider/runners/pull/1253)
+- **Misspell** Support `ignore` option as array [#1255](https://github.com/sider/runners/pull/1255)
 
 ## 0.29.3
 

--- a/lib/runners/processor/misspell.rb
+++ b/lib/runners/processor/misspell.rb
@@ -80,13 +80,6 @@ module Runners
       locale ? ["-locale", "#{locale}"] : []
     end
 
-    # TODO: Please this method when PR #1253 will be merged.
-    # @see https://github.com/sider/runners/pull/1253/files#diff-d96aa2fcf642c90a48d541348afe8949
-    def comma_separated_list(value)
-      values = Array(value).flat_map { |s| s.split(/\s*,\s*/) }
-      values.empty? ? nil : values.join(",")
-    end
-
     def ignore
       # The option requires comma separated with string when user would like to set ignore multiple targets.
       ignore = comma_separated_list(config_linter[:ignore] || config_linter.dig(:options, :ignore))

--- a/test/smokes/misspell/expectations.rb
+++ b/test/smokes/misspell/expectations.rb
@@ -1,5 +1,7 @@
 s = Runners::Testing::Smoke
 
+default_version = "0.3.4"
+
 s.add_offline_test(
   "success",
   type: "success",
@@ -14,7 +16,7 @@ s.add_offline_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Misspell", version: "0.3.4" }
+  analyzer: { name: "Misspell", version: default_version }
 )
 
 s.add_offline_test(
@@ -40,7 +42,7 @@ s.add_offline_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Misspell", version: "0.3.4" },
+  analyzer: { name: "Misspell", version: default_version },
   warnings: [
     {
       message: <<~MSG.strip,
@@ -68,7 +70,14 @@ s.add_offline_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Misspell", version: "0.3.4" }
+  analyzer: { name: "Misspell", version: default_version }
+)
+
+s.add_offline_test(
+  "ignore_array",
+  type: "success",
+  issues: [],
+  analyzer: { name: "Misspell", version: default_version }
 )
 
 s.add_offline_test(
@@ -130,7 +139,7 @@ s.add_offline_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Misspell", version: "0.3.4" },
+  analyzer: { name: "Misspell", version: default_version },
   warnings: [{ message: <<~MSG.strip, file: "sideci.yml" }]
     DEPRECATION WARNING!!!
     The following options in your `sideci.yml` are deprecated and will be removed.
@@ -216,7 +225,7 @@ s.add_offline_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Misspell", version: "0.3.4" }
+  analyzer: { name: "Misspell", version: default_version }
 )
 
 s.add_offline_test(
@@ -250,5 +259,5 @@ s.add_offline_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "Misspell", version: "0.3.4" }
+  analyzer: { name: "Misspell", version: default_version }
 )

--- a/test/smokes/misspell/ignore_array/badspell.rb
+++ b/test/smokes/misspell/ignore_array/badspell.rb
@@ -1,0 +1,4 @@
+def foo
+  infomation
+  recieve
+end

--- a/test/smokes/misspell/ignore_array/sider.yml
+++ b/test/smokes/misspell/ignore_array/sider.yml
@@ -1,0 +1,5 @@
+linter:
+  misspell:
+    ignore:
+      - infomation
+      - recieve


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims that users can configure the `ignore` option in their `sider.yml` more easily.

E.g.

```diff
-ignore: center,behavior
+ignore:
+  - center
+  - behavior
```

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

Fix #1071
~~Wait for PR #1253~~ Merged

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
