### PR TITLE
[ESLint] Update the default configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Misc:
 - Allow `location(start_line,start_column)` format [#1257](https://github.com/sider/runners/pull/1257)
 - **ESLint** Add `target` option instead of `dir` option [#1264](https://github.com/sider/runners/pull/1264)
 - **HAML-Lint** Add `target` option [#1265](https://github.com/sider/runners/pull/1265)
+- **ESLint** Update the default configuration [#1270](https://github.com/sider/runners/pull/1270)
 
 ## 0.29.3
 

--- a/images/eslint/sider_eslintrc.yml
+++ b/images/eslint/sider_eslintrc.yml
@@ -1,4 +1,10 @@
-extends: 'eslint:recommended'
+root: true
+
+extends:
+  - eslint:recommended
+
 rules:
+  # NOTE: Disable the `no-undef` rule by default.
+  #       Because it requires to set `globals` or `env` in some cases.
+  #       See https://eslint.org/docs/rules/no-undef
   no-undef: off
-  no-unused-vars: off

--- a/lib/runners/processor/eslint.rb
+++ b/lib/runners/processor/eslint.rb
@@ -161,7 +161,7 @@ module Runners
       end
     end
 
-    def run_analyzer(config:)
+    def run_analyzer(config: nil)
       # NOTE: eslint exit with status code 1 when some issues are found.
       #       We use `capture3` instead of `capture3!`
       #
@@ -198,7 +198,9 @@ module Runners
       elsif no_linting_files?(stderr)
         Results::Success.new(guid: guid, analyzer: analyzer)
       elsif no_eslint_config?(stderr)
-        run_analyzer config: DEFAULT_ESLINT_CONFIG # retry with the default configuration
+        trace_writer.message "Retrying with the default configuration file because no configuration files were found..."
+        FileUtils.copy(DEFAULT_ESLINT_CONFIG, ".eslintrc.yml")
+        run_analyzer
       else
         Results::Failure.new(guid: guid, message: stderr.strip, analyzer: analyzer)
       end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change enables the [`no-unused-vars`](https://eslint.org/docs/rules/no-unused-vars) rule in the default configuration. Because:

- it is included in the `eslint:recommended` ruleset.
- it is useful in most cases, especially in refactoring.
- it is designed not to produce false positives as possible by default.

Also, this change sets `root: true` to make the ESLint behavior clear.

> in successive parent directories all the way up to the root directory of the filesystem (unless `root: true` is specified)

https://eslint.org/docs/user-guide/configuring#using-configuration-files-1

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
