### PR TITLE
Increase :tries and :sleep of Retryable for git-fetch(1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Misc:
 - **GolangCI-Lint** Add `severity` and `replacement` to issue result [#1268](https://github.com/sider/runners/pull/1268)
 - **HAML-Lint** Add `target` option [#1265](https://github.com/sider/runners/pull/1265)
 - **stylelint** Pre-install popular configs and plugins [#1272](https://github.com/sider/runners/pull/1272)
+- Increase :tries and :sleep of Retryable for git-fetch(1) [#1279](https://github.com/sider/runners/pull/1279)
 
 ## 0.29.3
 

--- a/lib/runners/shell.rb
+++ b/lib/runners/shell.rb
@@ -80,11 +80,11 @@ module Runners
       [stdout, stderr]
     end
 
-    def capture3_with_retry!(command, *args, tries: 3)
+    def capture3_with_retry!(command, *args, tries: 3, sleep: -> (n) { n + 1 })
       Retryable.retryable(
         tries: tries,
         on: ExecError,
-        sleep: -> (n) { n + 1 },
+        sleep: sleep,
         exception_cb: -> (_ex) { trace_writer.message "Command failed. Retrying..." }
       ) do
         capture3!(command, *args)

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -20,7 +20,12 @@ module Runners
 
     # for testing
     def try_count
-      3
+      10
+    end
+
+    # for testing
+    def sleep_lambda
+      -> (n) { n ** 2.5 }
     end
 
     def prepare_head_source(_dest)
@@ -30,7 +35,7 @@ module Runners
       shell.capture3!("git", "remote", "add", "origin", remote_url.to_s)
 
       begin
-        shell.capture3_with_retry!("git", "fetch", *git_fetch_args, tries: try_count)
+        shell.capture3_with_retry!("git", "fetch", *git_fetch_args, tries: try_count, sleep: sleep_lambda)
       rescue Shell::ExecError => exn
         raise FetchFailed, "git-fetch failed: #{exn.stderr_str}"
       end

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -225,3 +225,8 @@ end
 extension Float (Polyfill)
   def to_i: () -> Integer
 end
+
+extension Integer (Polyfill)
+  def **: (Float) -> Float
+        | super
+end

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -127,7 +127,7 @@ class Runners::Processor
   def self.register_config_schema: (**any) -> void
   def capture3: (String, *String, **capture3_options) -> [String, String, Process::Status]
   def capture3!: (String, *String, **capture3_options) -> [String, String]
-  def capture3_with_retry!: (String, *String, ?tries: Integer) -> [String, String]
+  def capture3_with_retry!: (String, *String, ?tries: Integer, ?sleep: ^(Integer) -> Numeric) -> [String, String]
   def capture3_trace: (String, *String, **capture3_options) -> [String, String, Process::Status]
 
   def push_env_hash: <'x> (Hash<String, String?>) { -> 'x } -> 'x
@@ -174,7 +174,7 @@ class Runners::Shell
 
   def capture3: (String, *String, **capture3_options) -> [String, String, Process::Status]
   def capture3!: (String, *String, **capture3_options) -> [String, String]
-  def capture3_with_retry!: (String, *String, ?tries: Integer) -> [String, String]
+  def capture3_with_retry!: (String, *String, ?tries: Integer, ?sleep: ^(Integer) -> Numeric) -> [String, String]
   def capture3_trace: (String, *String, **capture3_options) -> [String, String, Process::Status]
 
   def chdir: <'x> (Pathname) { (Pathname) -> 'x } -> 'x

--- a/sig/runners/workspace.rbi
+++ b/sig/runners/workspace.rbi
@@ -42,4 +42,5 @@ class Runners::Workspace::Git < Workspace
   def remote_url: () -> URI
   def git_fetch_args: () -> Array<String>
   def try_count: () -> Integer
+  def sleep_lambda: () -> (^(Integer) -> Numeric)
 end

--- a/sig_new/runners/shell.rbs
+++ b/sig_new/runners/shell.rbs
@@ -11,7 +11,7 @@ class Runners::Shell
   def env_hash: () -> Hash[String, String?]
   def capture3: (String, *String, **untyped) -> [String, String, Process::Status]
   def capture3!: (String, *String, **untyped) -> [String, String]
-  def capture3_with_retry!: (String, *String, ?tries: Integer) -> [String, String]
+  def capture3_with_retry!: (String, *String, ?tries: Integer, ?sleep: ^(Integer) -> Integer | Float) -> [String, String]
   def capture3_trace: (String, *String, **untyped) -> [String, String, Process::Status]
 end
 

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -22,7 +22,9 @@ class WorkspaceGitTest < Minitest::Test
   def with_workspace(**params)
     super(**params) do |workspace|
       workspace.stub :try_count, 1 do
-        yield workspace
+        workspace.stub :sleep_lambda, lambda { 0 } do
+          yield workspace
+        end
       end
     end
   end


### PR DESCRIPTION
git-fetch(1) sometimes fails because of Rate-Limit.  Ideally, we should see the HTTP header `X-RateLimit-Reset` from GitHub, but I just made Runners try fetching again more.

### Related issues

#1233 

### Checklist

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.