### PR TITLE
[Flake8] Support `target` and `config` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Misc:
 - **ESLint** Add `target` option instead of `dir` option [#1264](https://github.com/sider/runners/pull/1264)
 - **ESLint** Pre-install popular configs and plugins [#1271](https://github.com/sider/runners/pull/1271)
 - **ESLint** Update the default configuration [#1270](https://github.com/sider/runners/pull/1270)
+- **Flake8** Support `target` and `config` options [#1287](https://github.com/sider/runners/pull/1287)
 - **GolangCI-Lint** Add `severity` and `replacement` to issue result [#1268](https://github.com/sider/runners/pull/1268)
 - **HAML-Lint** Add `target` option [#1265](https://github.com/sider/runners/pull/1265)
 - **stylelint** Pre-install popular configs and plugins [#1272](https://github.com/sider/runners/pull/1272)

--- a/test/smokes/flake8/expectations.rb
+++ b/test/smokes/flake8/expectations.rb
@@ -205,3 +205,53 @@ s.add_test(
   analyzer: { name: "Flake8", version: default_version },
   warnings: [{ message: "Python 2 is deprecated. Consider migrating to Python 3.", file: nil }]
 )
+
+s.add_test(
+  "option_config",
+  type: "success",
+  issues: [],
+  analyzer: { name: "Flake8", version: default_version }
+)
+
+s.add_test(
+  "option_target",
+  type: "success",
+  issues: [
+    {
+      message: "local variable 'a' is assigned to but never used",
+      links: [],
+      id: "F841",
+      path: "src/bar.py",
+      location: { start_line: 2, start_column: 5 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Flake8", version: default_version }
+)
+
+s.add_test(
+  "option_target_multiple",
+  type: "success",
+  issues: [
+    {
+      message: "local variable 'a' is assigned to but never used",
+      links: [],
+      id: "F841",
+      path: "lib/baz.py",
+      location: { start_line: 2, start_column: 5 },
+      object: nil,
+      git_blame_info: nil
+    },
+    {
+      message: "local variable 'a' is assigned to but never used",
+      links: [],
+      id: "F841",
+      path: "src/bar.py",
+      location: { start_line: 2, start_column: 5 },
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "Flake8", version: default_version }
+)

--- a/test/smokes/flake8/option_config/foo.py
+++ b/test/smokes/flake8/option_config/foo.py
@@ -1,0 +1,2 @@
+def hello():
+    a = None

--- a/test/smokes/flake8/option_config/my_flake8.cfg
+++ b/test/smokes/flake8/option_config/my_flake8.cfg
@@ -1,0 +1,2 @@
+[flake8]
+ignore = F841

--- a/test/smokes/flake8/option_config/sider.yml
+++ b/test/smokes/flake8/option_config/sider.yml
@@ -1,0 +1,3 @@
+linter:
+  flake8:
+    config: my_flake8.cfg

--- a/test/smokes/flake8/option_target/foo.py
+++ b/test/smokes/flake8/option_target/foo.py
@@ -1,0 +1,2 @@
+def hello():
+    a = None

--- a/test/smokes/flake8/option_target/sider.yml
+++ b/test/smokes/flake8/option_target/sider.yml
@@ -1,0 +1,3 @@
+linter:
+  flake8:
+    target: src

--- a/test/smokes/flake8/option_target/src/bar.py
+++ b/test/smokes/flake8/option_target/src/bar.py
@@ -1,0 +1,2 @@
+def hello():
+    a = None

--- a/test/smokes/flake8/option_target_multiple/foo.py
+++ b/test/smokes/flake8/option_target_multiple/foo.py
@@ -1,0 +1,2 @@
+def hello():
+    a = None

--- a/test/smokes/flake8/option_target_multiple/lib/baz.py
+++ b/test/smokes/flake8/option_target_multiple/lib/baz.py
@@ -1,0 +1,2 @@
+def hello():
+    a = None

--- a/test/smokes/flake8/option_target_multiple/sider.yml
+++ b/test/smokes/flake8/option_target_multiple/sider.yml
@@ -1,0 +1,5 @@
+linter:
+  flake8:
+    target:
+      - lib/baz.py
+      - src

--- a/test/smokes/flake8/option_target_multiple/src/bar.py
+++ b/test/smokes/flake8/option_target_multiple/src/bar.py
@@ -1,0 +1,2 @@
+def hello():
+    a = None


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- `target`: files or directories to analyze (unsupported glob patterns)
- `config`: config file location

For example:

```yaml
# sider.yml
linter:
  flake8:
    target: [src, lib]
    config: my_flake8.cfg
```

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

Fix #1285

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
