### PR TITLE
Make deprecation warning messages more useful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Misc:
 - Fix Kotlin file extensions [#1252](https://github.com/sider/runners/pull/1252)
 - Increase :tries and :sleep of Retryable for git-fetch(1) [#1279](https://github.com/sider/runners/pull/1279)
 - Allow `location(start_line,start_column)` format [#1257](https://github.com/sider/runners/pull/1257)
+- Make deprecation warning messages more useful [#1292](https://github.com/sider/runners/pull/1292)
 - **ESLint** Add `target` option instead of `dir` option [#1264](https://github.com/sider/runners/pull/1264)
 - **ESLint** Pre-install popular configs and plugins [#1271](https://github.com/sider/runners/pull/1271)
 - **ESLint** Update the default configuration [#1270](https://github.com/sider/runners/pull/1270)

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -203,7 +203,7 @@ module Runners
       file = config.path_name
       add_warning <<~MSG, file: file
         DEPRECATION WARNING!!!
-        The `#{config_field_path(name)}` option is deprecated in your `#{file}`. Use the `#{config_field_path(to)}` option instead.
+        The `#{config_field_path(name)}` option is deprecated. Use the `#{config_field_path(to)}` option instead in your `#{file}`.
         See #{analyzer_doc} for details.
       MSG
     end

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -184,7 +184,7 @@ module Runners
       file = config.path_name
       add_warning <<~MSG, file: file
         DEPRECATION WARNING!!!
-        The `#{config_field_path(name)}` option is deprecated in your `#{file}`. Fix it as follows:
+        The `#{config_field_path(name)}` option is deprecated. Fix your `#{file}` as follows:
         See #{analyzer_doc} for details.
 
         ```diff

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -177,18 +177,35 @@ module Runners
       end
     end
 
-    def add_warning_if_deprecated_options(keys)
-      deprecated_keys = config_linter.slice(*keys).compact.keys
-        .map { |k| "- `#{config_field_path(k)}`" }
+    def add_warning_if_deprecated_options
+      name = :options
+      return unless config_linter[name]
 
-      unless deprecated_keys.empty?
-        add_warning <<~MSG, file: config.path_name
-          DEPRECATION WARNING!!!
-          The following options in your `#{config.path_name}` are deprecated and will be removed.
-          See #{analyzer_doc} for details.
-          #{deprecated_keys.join("\n")}
-        MSG
-      end
+      file = config.path_name
+      add_warning <<~MSG, file: file
+        DEPRECATION WARNING!!!
+        The `#{config_field_path(name)}` option is deprecated in your `#{file}`. Fix it as follows:
+        See #{analyzer_doc} for details.
+
+        ```diff
+         linter:
+           #{analyzer_id}:
+        -    options:
+        -      foo: "bar"
+        +    foo: "bar"
+        ```
+      MSG
+    end
+
+    def add_warning_for_deprecated_option(name, to:)
+      return unless config_linter[name]
+
+      file = config.path_name
+      add_warning <<~MSG, file: file
+        DEPRECATION WARNING!!!
+        The `#{config_field_path(name)}` option is deprecated in your `#{file}`. Use the `#{config_field_path(to)}` option instead.
+        See #{analyzer_doc} for details.
+      MSG
     end
 
     def add_warning_for_deprecated_linter(alternative:, ref:, deadline: nil)

--- a/lib/runners/processor/code_sniffer.rb
+++ b/lib/runners/processor/code_sniffer.rb
@@ -32,7 +32,7 @@ module Runners
     register_config_schema(name: :code_sniffer, schema: Schema.runner_config)
 
     def setup
-      add_warning_if_deprecated_options([:options])
+      add_warning_if_deprecated_options
       yield
     end
 

--- a/lib/runners/processor/coffeelint.rb
+++ b/lib/runners/processor/coffeelint.rb
@@ -22,7 +22,7 @@ module Runners
     }.freeze
 
     def setup
-      add_warning_if_deprecated_options([:options])
+      add_warning_if_deprecated_options
 
       begin
         install_nodejs_deps(constraints: CONSTRAINTS, install_option: config_linter[:npm_install])

--- a/lib/runners/processor/eslint.rb
+++ b/lib/runners/processor/eslint.rb
@@ -47,13 +47,8 @@ module Runners
     DEFAULT_TARGET = ".".freeze
 
     def setup
-      add_warning_if_deprecated_options([:options])
-
-      if config_linter[:dir]
-        add_warning <<~MSG, file: config.path_name
-          The `dir` option is deprecated. Use the `target` option instead.
-        MSG
-      end
+      add_warning_if_deprecated_options
+      add_warning_for_deprecated_option :dir, to: :target
 
       begin
         install_nodejs_deps(constraints: CONSTRAINTS, install_option: config_linter[:npm_install])

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -59,13 +59,8 @@ module Runners
     end
 
     def setup
-      add_warning_if_deprecated_options([:options])
-
-      if config_linter[:file]
-        add_warning <<~MSG, file: config.path_name
-          The `#{config_field_path(:file)}` option is deprecated. Use the `#{config_field_path(:target)}` option instead.
-        MSG
-      end
+      add_warning_if_deprecated_options
+      add_warning_for_deprecated_option :file, to: :target
 
       install_gems default_gem_specs, optionals: OPTIONAL_GEMS, constraints: CONSTRAINTS do
         yield

--- a/lib/runners/processor/jshint.rb
+++ b/lib/runners/processor/jshint.rb
@@ -18,7 +18,7 @@ module Runners
     register_config_schema(name: :jshint, schema: Schema.runner_config)
 
     def setup
-      add_warning_if_deprecated_options([:options])
+      add_warning_if_deprecated_options
       yield
     end
 

--- a/lib/runners/processor/misspell.rb
+++ b/lib/runners/processor/misspell.rb
@@ -31,7 +31,8 @@ module Runners
     end
 
     def setup
-      add_warning_if_deprecated_options([:options, :targets])
+      add_warning_if_deprecated_options
+      add_warning_for_deprecated_option :targets, to: :target
       yield
     end
 

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -30,7 +30,7 @@ module Runners
     DEFAULT_CONFIG_FILE = (Pathname(Dir.home) / "sider_config.xml").to_path.freeze
 
     def setup
-      add_warning_if_deprecated_options([:options])
+      add_warning_if_deprecated_options
       yield
     end
 

--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -43,7 +43,7 @@ module Runners
     }.freeze
 
     def setup
-      add_warning_if_deprecated_options([:options])
+      add_warning_if_deprecated_options
 
       prepare_config
       install_gems default_gem_specs, optionals: OPTIONAL_GEMS, constraints: CONSTRAINTS do

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -82,7 +82,7 @@ module Runners
     end
 
     def setup
-      add_warning_if_deprecated_options([:options])
+      add_warning_if_deprecated_options
 
       install_gems default_gem_specs, optionals: OPTIONAL_GEMS, constraints: CONSTRAINTS do
         yield

--- a/lib/runners/processor/stylelint.rb
+++ b/lib/runners/processor/stylelint.rb
@@ -40,7 +40,7 @@ module Runners
     DEFAULT_GLOB = "**/#{DEFAULT_TARGET_FILES}".freeze
 
     def setup
-      add_warning_if_deprecated_options([:options])
+      add_warning_if_deprecated_options
 
       prepare_ignore_file
 

--- a/lib/runners/processor/swiftlint.rb
+++ b/lib/runners/processor/swiftlint.rb
@@ -31,7 +31,7 @@ module Runners
     end
 
     def setup
-      add_warning_if_deprecated_options([:options])
+      add_warning_if_deprecated_options
       yield
     end
 

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -136,7 +136,8 @@ class Runners::Processor
   def delete_unchanged_files: (Changes, ?except: Array<String>, ?only: Array<String>) -> void
   def add_warning: (String, ?file: String?) -> void
   def add_warning_if_deprecated_version: (minimum: String, ?file: String?, ?deadline: Time?) -> void
-  def add_warning_if_deprecated_options: (Array<Symbol>) -> void
+  def add_warning_if_deprecated_options: () -> void
+  def add_warning_for_deprecated_option: (Symbol, to: Symbol) -> void
   def add_warning_for_deprecated_linter: (alternative: String, ref: String, ?deadline: Time?) -> void
   def analyzer: -> Analyzer
   def analyzers: -> Analyzers

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -252,7 +252,7 @@ class ProcessorTest < Minitest::Test
 
       expected_message = <<~MSG.strip
         DEPRECATION WARNING!!!
-        The `linter.eslint.options` option is deprecated in your `sider.yml`. Fix it as follows:
+        The `linter.eslint.options` option is deprecated. Fix your `sider.yml` as follows:
         See https://help.sider.review/tools/javascript/eslint for details.
 
         ```diff

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -244,25 +244,56 @@ class ProcessorTest < Minitest::Test
       processor = new_processor(workspace: workspace, config_yaml: <<~YAML)
         linter:
           eslint:
-            quiet: true
             options:
               ext: .ts
       YAML
 
-      processor.add_warning_if_deprecated_options([:quiet, :options])
-      processor.add_warning_if_deprecated_options([:global])
+      processor.add_warning_if_deprecated_options
 
       expected_message = <<~MSG.strip
         DEPRECATION WARNING!!!
-        The following options in your `sider.yml` are deprecated and will be removed.
+        The `linter.eslint.options` option is deprecated in your `sider.yml`. Fix it as follows:
         See https://help.sider.review/tools/javascript/eslint for details.
-        - `linter.eslint.quiet`
-        - `linter.eslint.options`
+
+        ```diff
+         linter:
+           eslint:
+        -    options:
+        -      foo: "bar"
+        +    foo: "bar"
+        ```
       MSG
 
       assert_equal(
         [{ trace: :warning, message: expected_message, file: "sider.yml" }],
         trace_writer.writer.map { |hash| hash.slice(:trace, :message, :file) }.select { |hash| hash[:trace] == :warning },
+      )
+      assert_equal(
+        [{ message: expected_message, file: "sider.yml" }],
+        processor.warnings,
+      )
+    end
+  end
+
+  def test_add_warning_for_deprecated_option
+    with_workspace do |workspace|
+      processor = new_processor(workspace: workspace, config_yaml: <<~YAML)
+        linter:
+          eslint:
+            dir: src
+      YAML
+
+      processor.add_warning_for_deprecated_option(:dir, to: :target)
+
+      expected_message = <<~MSG.strip
+        DEPRECATION WARNING!!!
+        The `linter.eslint.dir` option is deprecated in your `sider.yml`. Use the `linter.eslint.target` option instead.
+        See https://help.sider.review/tools/javascript/eslint for details.
+      MSG
+
+      assert_equal(
+        [{ trace: :warning, message: expected_message, file: "sider.yml" }],
+        trace_writer.writer.filter_map { |hash| hash.slice(:trace, :message, :file) if hash[:trace] == :warning },
       )
       assert_equal(
         [{ message: expected_message, file: "sider.yml" }],

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -287,7 +287,7 @@ class ProcessorTest < Minitest::Test
 
       expected_message = <<~MSG.strip
         DEPRECATION WARNING!!!
-        The `linter.eslint.dir` option is deprecated in your `sider.yml`. Use the `linter.eslint.target` option instead.
+        The `linter.eslint.dir` option is deprecated. Use the `linter.eslint.target` option instead in your `sider.yml`.
         See https://help.sider.review/tools/javascript/eslint for details.
       MSG
 

--- a/test/smokes/code_sniffer/expectations.rb
+++ b/test/smokes/code_sniffer/expectations.rb
@@ -36,12 +36,7 @@ s.add_test(
   analyzer: { name: "PHP_CodeSniffer", version: "3.5.5" },
   warnings: [
     {
-      message: <<~MSG.strip,
-        DEPRECATION WARNING!!!
-        The following options in your `sideci.yml` are deprecated and will be removed.
-        See https://help.sider.review/tools/php/code-sniffer for details.
-        - `linter.code_sniffer.options`
-      MSG
+      message: /The `linter.code_sniffer.options` option is deprecated/,
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/coffeelint/expectations.rb
+++ b/test/smokes/coffeelint/expectations.rb
@@ -44,12 +44,7 @@ s.add_test(
   analyzer: { name: "CoffeeLint", version: "1.16.0" },
   warnings: [
     {
-      message: <<~MSG.strip,
-        DEPRECATION WARNING!!!
-        The following options in your `sideci.yml` are deprecated and will be removed.
-        See https://help.sider.review/tools/javascript/coffeelint for details.
-        - `linter.coffeelint.options`
-      MSG
+      message: /The `linter.coffeelint.options` option is deprecated/,
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -166,12 +166,7 @@ s.add_test(
   analyzer: { name: "ESLint", version: default_version },
   warnings: [
     {
-      message: <<~MSG.strip,
-        DEPRECATION WARNING!!!
-        The following options in your `sideci.yml` are deprecated and will be removed.
-        See https://help.sider.review/tools/javascript/eslint for details.
-        - `linter.eslint.options`
-      MSG
+      message: /The `linter.eslint.options` option is deprecated/,
       file: "sideci.yml"
     }
   ]
@@ -254,7 +249,13 @@ s.add_test(
     }
   ],
   analyzer: { name: "ESLint", version: "5.16.0" },
-  warnings: [{ message: "The `dir` option is deprecated. Use the `target` option instead.", file: "sideci.yml" }]
+  warnings: [
+    { message: <<~MSG.strip, file: "sideci.yml" }
+      DEPRECATION WARNING!!!
+      The `linter.eslint.dir` option is deprecated in your `sideci.yml`. Use the `linter.eslint.target` option instead.
+      See https://help.sider.review/tools/javascript/eslint for details.
+    MSG
+  ]
 )
 
 s.add_test(

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -252,7 +252,7 @@ s.add_test(
   warnings: [
     { message: <<~MSG.strip, file: "sideci.yml" }
       DEPRECATION WARNING!!!
-      The `linter.eslint.dir` option is deprecated in your `sideci.yml`. Use the `linter.eslint.target` option instead.
+      The `linter.eslint.dir` option is deprecated. Use the `linter.eslint.target` option instead in your `sideci.yml`.
       See https://help.sider.review/tools/javascript/eslint for details.
     MSG
   ]

--- a/test/smokes/haml_lint/expectations.rb
+++ b/test/smokes/haml_lint/expectations.rb
@@ -42,7 +42,7 @@ s.add_test(
     {
       message: <<~MSG.strip,
         DEPRECATION WARNING!!!
-        The `linter.haml_lint.file` option is deprecated in your `sideci.yml`. Use the `linter.haml_lint.target` option instead.
+        The `linter.haml_lint.file` option is deprecated. Use the `linter.haml_lint.target` option instead in your `sideci.yml`.
         See https://help.sider.review/tools/ruby/haml-lint for details.
       MSG
       file: "sideci.yml"

--- a/test/smokes/haml_lint/expectations.rb
+++ b/test/smokes/haml_lint/expectations.rb
@@ -36,16 +36,15 @@ s.add_test(
   analyzer: { name: "HAML-Lint", version: default_version },
   warnings: [
     {
-      message: <<~MSG.strip,
-        DEPRECATION WARNING!!!
-        The following options in your `sideci.yml` are deprecated and will be removed.
-        See https://help.sider.review/tools/ruby/haml-lint for details.
-        - `linter.haml_lint.options`
-      MSG
+      message: /The `linter.haml_lint.options` option is deprecated/,
       file: "sideci.yml"
     },
     {
-      message: "The `linter.haml_lint.file` option is deprecated. Use the `linter.haml_lint.target` option instead.",
+      message: <<~MSG.strip,
+        DEPRECATION WARNING!!!
+        The `linter.haml_lint.file` option is deprecated in your `sideci.yml`. Use the `linter.haml_lint.target` option instead.
+        See https://help.sider.review/tools/ruby/haml-lint for details.
+      MSG
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/jshint/expectations.rb
+++ b/test/smokes/jshint/expectations.rb
@@ -93,12 +93,7 @@ s.add_test(
   analyzer: { name: "JSHint", version: "2.11.1" },
   warnings: [
     {
-      message: <<~MSG.strip,
-        DEPRECATION WARNING!!!
-        The following options in your `sideci.yml` are deprecated and will be removed.
-        See https://help.sider.review/tools/javascript/jshint for details.
-        - `linter.jshint.options`
-      MSG
+      message: /The `linter.jshint.options` option is deprecated/,
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/misspell/expectations.rb
+++ b/test/smokes/misspell/expectations.rb
@@ -45,12 +45,7 @@ s.add_offline_test(
   analyzer: { name: "Misspell", version: default_version },
   warnings: [
     {
-      message: <<~MSG.strip,
-        DEPRECATION WARNING!!!
-        The following options in your `sideci.yml` are deprecated and will be removed.
-        See https://help.sider.review/tools/others/misspell for details.
-        - `linter.misspell.options`
-      MSG
+      message: /The `linter.misspell.options` option is deprecated/,
       file: "sideci.yml"
     }
   ]
@@ -142,9 +137,8 @@ s.add_offline_test(
   analyzer: { name: "Misspell", version: default_version },
   warnings: [{ message: <<~MSG.strip, file: "sideci.yml" }]
     DEPRECATION WARNING!!!
-    The following options in your `sideci.yml` are deprecated and will be removed.
+    The `linter.misspell.targets` option is deprecated in your `sideci.yml`. Use the `linter.misspell.target` option instead.
     See https://help.sider.review/tools/others/misspell for details.
-    - `linter.misspell.targets`
   MSG
 )
 

--- a/test/smokes/misspell/expectations.rb
+++ b/test/smokes/misspell/expectations.rb
@@ -137,7 +137,7 @@ s.add_offline_test(
   analyzer: { name: "Misspell", version: default_version },
   warnings: [{ message: <<~MSG.strip, file: "sideci.yml" }]
     DEPRECATION WARNING!!!
-    The `linter.misspell.targets` option is deprecated in your `sideci.yml`. Use the `linter.misspell.target` option instead.
+    The `linter.misspell.targets` option is deprecated. Use the `linter.misspell.target` option instead in your `sideci.yml`.
     See https://help.sider.review/tools/others/misspell for details.
   MSG
 )

--- a/test/smokes/phpmd/expectations.rb
+++ b/test/smokes/phpmd/expectations.rb
@@ -60,12 +60,7 @@ s.add_test(
   analyzer: { name: "PHPMD", version: default_version },
   warnings: [
     {
-      message: <<~MSG.strip,
-        DEPRECATION WARNING!!!
-        The following options in your `sideci.yml` are deprecated and will be removed.
-        See https://help.sider.review/tools/php/phpmd for details.
-        - `linter.phpmd.options`
-      MSG
+      message: /The `linter.phpmd.options` option is deprecated/,
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/rails_best_practices/expectations.rb
+++ b/test/smokes/rails_best_practices/expectations.rb
@@ -71,12 +71,7 @@ s.add_test(
   ],
   warnings: [
     {
-      message: <<~MSG.strip,
-        DEPRECATION WARNING!!!
-        The following options in your `sideci.yml` are deprecated and will be removed.
-        See https://help.sider.review/tools/ruby/rails-best-practices for details.
-        - `linter.rails_best_practices.options`
-      MSG
+      message: /The `linter.rails_best_practices.options` option is deprecated/,
       file: "sideci.yml"
     }
   ]

--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -222,12 +222,7 @@ s.add_test(
   analyzer: { name: "RuboCop", version: default_version },
   warnings: [
     {
-      message: <<~MSG.strip,
-        DEPRECATION WARNING!!!
-        The following options in your `sideci.yml` are deprecated and will be removed.
-        See https://help.sider.review/tools/ruby/rubocop for details.
-        - `linter.rubocop.options`
-      MSG
+      message: /The `linter.rubocop.options` option is deprecated/,
       file: "sideci.yml"
     },
     { message: "Metrics/LineLength has the wrong namespace - should be Layout", file: "my.rubocop.yml" }

--- a/test/smokes/stylelint/expectations.rb
+++ b/test/smokes/stylelint/expectations.rb
@@ -509,12 +509,7 @@ s.add_test(
   issues: [],
   warnings: [
     {
-      message: <<~MSG.strip,
-        DEPRECATION WARNING!!!
-        The following options in your `sider.yml` are deprecated and will be removed.
-        See https://help.sider.review/tools/css/stylelint for details.
-        - `linter.stylelint.options`
-      MSG
+      message: /The `linter.stylelint.options` option is deprecated/,
       file: "sider.yml"
     }
   ]

--- a/test/smokes/swiftlint/expectations.rb
+++ b/test/smokes/swiftlint/expectations.rb
@@ -150,12 +150,7 @@ s.add_test(
   analyzer: { name: "SwiftLint", version: "0.39.2" },
   warnings: [
     {
-      message: <<~MSG.strip,
-        DEPRECATION WARNING!!!
-        The following options in your `sideci.yml` are deprecated and will be removed.
-        See https://help.sider.review/tools/swift/swiftlint for details.
-        - `linter.swiftlint.options`
-      MSG
+      message: /The `linter.swiftlint.options` option is deprecated/,
       file: "sideci.yml"
     }
   ]


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The current warning messages may be less kind because:

- Users do not know how to fix such warnings.
- Users do not have time to read the documents.

So, this change aims to try reducing users' potential complaints.

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.

