### PR TITLE
Prevent unexpected error when missing issue ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Misc:
 - Increase :tries and :sleep of Retryable for git-fetch(1) [#1279](https://github.com/sider/runners/pull/1279)
 - Allow `location(start_line,start_column)` format [#1257](https://github.com/sider/runners/pull/1257)
 - Make deprecation warning messages more useful [#1292](https://github.com/sider/runners/pull/1292)
+- Prevent unexpected error when missing issue ID [#1301](https://github.com/sider/runners/pull/1301)
 - **ESLint** Add `target` option instead of `dir` option [#1264](https://github.com/sider/runners/pull/1264)
 - **ESLint** Pre-install popular configs and plugins [#1271](https://github.com/sider/runners/pull/1271)
 - **ESLint** Update the default configuration [#1270](https://github.com/sider/runners/pull/1270)

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -56,11 +56,11 @@ module Runners
               case result
               when Results::Success
                 trace_writer.message "Removing issues from unchanged or untracked files..." do
-                  result.tap do |r|
-                    r.filter_issues(changes)
-                    r.add_git_blame_info(workspace)
-                  end
+                  result.filter_issues(changes)
+                  result.add_git_blame_info(workspace)
                 end
+                result.each_missing_id_warning { |msg| trace_writer.message(msg) }
+                result
               else
                 result
               end

--- a/lib/runners/issue.rb
+++ b/lib/runners/issue.rb
@@ -12,9 +12,6 @@ module Runners
       path.instance_of?(Pathname) or
         raise ArgumentError, "`path` must be a #{Pathname}: #{path.inspect}"
 
-      (id && !id.empty?) or
-        raise ArgumentError, "`id` must be required: #{id.inspect}"
-
       (message && !message.empty?) or
         raise ArgumentError, "`message` must be required: #{message.inspect}"
 
@@ -22,10 +19,16 @@ module Runners
 
       @path = path
       @location = location
-      @id = id
+      @missing_id = id.to_s.empty?
+      # @type var _: String
+      @id = _ = missing_id? ? Digest::SHA1.hexdigest(message) : id
       @message = message
       @links = links
       @object = object
+    end
+
+    def missing_id?
+      @missing_id
     end
 
     def ==(other)

--- a/lib/runners/processor/eslint.rb
+++ b/lib/runners/processor/eslint.rb
@@ -126,14 +126,6 @@ module Runners
         path = relative_path(issue[:filePath])
         # ESLint informs errors as an array if ESLint detects errors in a file.
         issue[:messages].each do |details|
-          id = details[:ruleId]
-          message = details[:message]
-
-          unless id
-            trace_writer.message("No rule ID found! - #{message} in #{path}")
-            id = Digest::SHA1.hexdigest(message)
-          end
-
           yield Issue.new(
             path: path,
             location: details[:line] ? Location.new(
@@ -142,8 +134,8 @@ module Runners
               end_line: details[:endLine],
               end_column: details[:endColumn],
             ) : nil,
-            id: id,
-            message: message,
+            id: details[:ruleId],
+            message: details[:message],
             links: Array(details.dig(:docs, :url)),
             object: {
               severity: normalize_severity(details[:severity]),

--- a/lib/runners/processor/jshint.rb
+++ b/lib/runners/processor/jshint.rb
@@ -61,7 +61,7 @@ module Runners
           yield Issue.new(
             path: relative_path(file[:name]),
             location: Location.new(start_line: error[:line], start_column: error[:column]),
-            id: error[:source] || Digest::SHA1.hexdigest(message),
+            id: error[:source],
             message: message,
           )
         end

--- a/lib/runners/processor/ktlint.rb
+++ b/lib/runners/processor/ktlint.rb
@@ -183,11 +183,11 @@ module Runners
       end
     end
 
-    def construct_issue(file:, line:, column:, message:, rule: "")
+    def construct_issue(file:, line:, column:, message:, rule: nil)
       Issue.new(
         path: relative_path(working_dir / file, from: working_dir),
         location: Location.new(start_line: line, start_column: column),
-        id: rule.empty? ? Digest::SHA1.hexdigest(message)[0, 8] : rule,
+        id: rule,
         message: message,
       )
     end

--- a/lib/runners/results.rb
+++ b/lib/runners/results.rb
@@ -72,6 +72,19 @@ module Runners
           issue.add_git_blame_info(workspace)
         end
       end
+
+      def each_missing_id_warning
+        issues.each do |issue|
+          next unless issue.missing_id?
+
+          path = issue.path.to_path
+          line = issue&.location&.start_line || "-"
+          column = issue&.location&.start_column || "-"
+          message = issue.message
+
+          yield "Missing issue ID - #{path}:#{line}:#{column}: #{message}"
+        end
+      end
     end
 
     # Result to indicate that processing failed by some error.

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -66,6 +66,7 @@ class Runners::Results::Success < Runners::Results::Base
   def add_issue: (*Runners::Issue) -> void
   def filter_issues: (Changes) -> void
   def add_git_blame_info: (Workspace) -> void
+  def each_missing_id_warning: { (String) -> void } -> void
 end
 
 class Runners::Results::Failure < Runners::Results::Base

--- a/sig/runners/issue.rbi
+++ b/sig/runners/issue.rbi
@@ -9,11 +9,12 @@ class Runners::Issue
 
   def initialize: (path: Pathname,
                    location: Location?,
-                   id: String,
+                   id: String?,
                    message: String,
                    ?links: Array<String>,
                    ?object: any,
                    ?schema: any) -> void
+  def missing_id?: () -> bool
   def as_json: () -> any
   def add_git_blame_info: (Workspace) -> void
 end

--- a/test/issue_test.rb
+++ b/test/issue_test.rb
@@ -143,4 +143,11 @@ class IssueTest < Minitest::Test
                    git_blame_info: { commit: "abe1cfc294c8d39de7484954bf8c3d7792fd8ad1", original_line: 137, final_line: 137, line_hash: "c57a7c8a63aa22b9aa40625f019fe097c3a23ab8" },
                  }, issue.as_json)
   end
+
+  def test_missing_id?
+    args = { message: "Foo", path: Pathname("foo.rb"), location: nil }
+    assert Issue.new(id: nil, **args).missing_id?
+    assert Issue.new(id: "", **args).missing_id?
+    refute Issue.new(id: "a", **args).missing_id?
+  end
 end

--- a/test/smokes/ktlint/expectations.rb
+++ b/test/smokes/ktlint/expectations.rb
@@ -8,7 +8,7 @@ s.add_test(
   analyzer: { name: "ktlint", version: default_version },
   issues: [
     {
-      id: "18748d47",
+      id: "18748d47ed6c20995492c1190b0fb829b794f8c1",
       path: "src/Foo.kt",
       location: { start_line: 1, start_column: 1 },
       message: "Not a valid Kotlin file (1:1 expecting a top level declaration) (cannot be auto-corrected)",
@@ -78,7 +78,7 @@ s.add_test(
   analyzer: { name: "ktlint", version: "0.34.0" },
   issues: [
     {
-      id: "0ebc0f91",
+      id: "0ebc0f91e8cfb83e28a81acd00e39d30d1ca76d6",
       path: "src/main/kotlin/gradle/App.kt",
       location: { start_line: 9, start_column: 1 },
       message: "Unexpected indentation (12) (it should be 6) (cannot be auto-corrected)",
@@ -87,7 +87,7 @@ s.add_test(
       git_blame_info: nil
     },
     {
-      id: "5e2630c4",
+      id: "5e2630c41b5d03f9b8c0e413a08de2a8d3e8aa1d",
       path: "src/main/kotlin/gradle/App.kt",
       location: { start_line: 8, start_column: 1 },
       message: "Unexpected indentation (2) (it should be 4) (cannot be auto-corrected)",

--- a/test/smokes/remark_lint/expectations.rb
+++ b/test/smokes/remark_lint/expectations.rb
@@ -1,9 +1,20 @@
 s = Runners::Testing::Smoke
 
+default_version = "8.0.0"
+
 s.add_test(
   "success",
   type: "success",
   issues: [
+    {
+      path: "readme.md",
+      location: { start_line: 5, start_column: 6 },
+      id: "2f2aa88b3c64e39930228cb265d844b1efc343d2",
+      message: "Numeric character references must be terminated by a semicolon",
+      links: [],
+      object: { severity: "warn" },
+      git_blame_info: nil
+    },
     {
       path: "readme.md",
       location: { start_line: 3, start_column: 1 },
@@ -23,10 +34,10 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "remark-lint", version: "8.0.0" }
+  analyzer: { name: "remark-lint", version: default_version }
 )
 
-s.add_test("no_files", type: "success", issues: [], analyzer: { name: "remark-lint", version: "8.0.0" })
+s.add_test("no_files", type: "success", issues: [], analyzer: { name: "remark-lint", version: default_version })
 
 s.add_test(
   "option_target",
@@ -51,7 +62,7 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "remark-lint", version: "8.0.0" }
+  analyzer: { name: "remark-lint", version: default_version }
 )
 
 s.add_test(
@@ -77,7 +88,7 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "remark-lint", version: "8.0.0" }
+  analyzer: { name: "remark-lint", version: default_version }
 )
 
 s.add_test(
@@ -94,7 +105,7 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "remark-lint", version: "8.0.0" }
+  analyzer: { name: "remark-lint", version: default_version }
 )
 
 s.add_test(
@@ -111,7 +122,7 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "remark-lint", version: "8.0.0" }
+  analyzer: { name: "remark-lint", version: default_version }
 )
 
 s.add_test(
@@ -137,7 +148,7 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "remark-lint", version: "8.0.0" }
+  analyzer: { name: "remark-lint", version: default_version }
 )
 
 s.add_test(
@@ -187,10 +198,10 @@ s.add_test(
   "broken_remarkrc",
   type: "failure",
   message: "2 error(s) reported. See the log for details.",
-  analyzer: { name: "remark-lint", version: "8.0.0" }
+  analyzer: { name: "remark-lint", version: default_version }
 )
 
-s.add_test("with_remark_lint_package", type: "success", issues: [], analyzer: { name: "remark-lint", version: "8.0.0" })
+s.add_test("with_remark_lint_package", type: "success", issues: [], analyzer: { name: "remark-lint", version: default_version })
 
 s.add_test(
   "without_remark_lint_package",
@@ -206,5 +217,5 @@ s.add_test(
       git_blame_info: nil
     }
   ],
-  analyzer: { name: "remark-lint", version: "8.0.0" }
+  analyzer: { name: "remark-lint", version: default_version }
 )

--- a/test/smokes/remark_lint/success/readme.md
+++ b/test/smokes/remark_lint/success/readme.md
@@ -1,3 +1,5 @@
 * Hello
 
 [World][]
+
+&#x60 <!-- Errored by https://github.com/wooorm/parse-entities -->


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to prevent an unexpected error when an issue ID is missing.
Some processors for tools like ESLint have addressed missing IDs, but some never do it.
Today we discovered missing IDs also when running remark-lint.

Thus, this change addresses missing IDs for all processors.

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
