### PR TITLE
Avoid git-blame when base commit is not given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Misc:
 - Allow `location(start_line,start_column)` format [#1257](https://github.com/sider/runners/pull/1257)
 - Make deprecation warning messages more useful [#1292](https://github.com/sider/runners/pull/1292)
 - Prevent unexpected error when missing issue ID [#1301](https://github.com/sider/runners/pull/1301)
+- Avoid git-blame when base commit is not given [#1307](https://github.com/sider/runners/pull/1307)
 - **ESLint** Add `target` option instead of `dir` option [#1264](https://github.com/sider/runners/pull/1264)
 - **ESLint** Pre-install popular configs and plugins [#1271](https://github.com/sider/runners/pull/1271)
 - **ESLint** Update the default configuration [#1270](https://github.com/sider/runners/pull/1270)

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -57,7 +57,9 @@ module Runners
               when Results::Success
                 trace_writer.message "Removing issues from unchanged or untracked files..." do
                   result.filter_issues(changes)
-                  result.add_git_blame_info(workspace)
+                  if options.source.head && options.source.base
+                    result.add_git_blame_info(workspace)
+                  end
                 end
                 result.each_missing_id_warning { |msg| trace_writer.message(msg) }
                 result

--- a/test/harness_test.rb
+++ b/test/harness_test.rb
@@ -49,7 +49,6 @@ class HarnessTest < Minitest::Test
   def test_run
     mktmpdir do |working_dir|
       with_options do |options|
-        mock.proxy(Workspace).prepare(options: options, working_dir: working_dir, trace_writer: trace_writer)
         harness = Harness.new(guid: SecureRandom.uuid, processor_class: TestProcessor,
                               options: options, working_dir: working_dir, trace_writer: trace_writer)
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Only when head and base commit are given, git-blame is useful.

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
