### PR TITLE
[Brakeman] Syntax highlight for warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.30.0...HEAD)
 
+- **Brakeman** Syntax highlight for warning message [#1309](https://github.com/sider/runners/pull/1309)
+
 ## 0.30.0
 
 [Full diff](https://github.com/sider/runners/compare/0.29.3...0.30.0)

--- a/lib/runners/processor/brakeman.rb
+++ b/lib/runners/processor/brakeman.rb
@@ -42,9 +42,11 @@ module Runners
             #{analyzer_name} is for Rails only. Your repository may not have a Rails application.
             If your Rails is not located in the root directory, configure your `#{config.path_name}` as follows:
 
-                linter:
-                  #{analyzer_id}:
-                    root_dir: "path/to/your/rails/root"
+            ```yaml
+            linter:
+              #{analyzer_id}:
+                root_dir: "path/to/your/rails/root"
+            ```
           MSG
           return Results::Success.new(guid: guid, analyzer: analyzer)
         else

--- a/test/smokes/brakeman/expectations.rb
+++ b/test/smokes/brakeman/expectations.rb
@@ -101,9 +101,11 @@ s.add_test(
     Brakeman is for Rails only. Your repository may not have a Rails application.
     If your Rails is not located in the root directory, configure your `sider.yml` as follows:
 
-        linter:
-          brakeman:
-            root_dir: "path/to/your/rails/root"
+    ```yaml
+    linter:
+      brakeman:
+        root_dir: "path/to/your/rails/root"
+    ```
   MSG
 )
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to make the YAML content in the warning message easier to see.

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
