### PR TITLE
[stylelint] Add `stylelint-order` to pre-installed list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.30.0...HEAD)
 
 - **Brakeman** Syntax highlight for warning message [#1309](https://github.com/sider/runners/pull/1309)
+- **stylelint** Add `stylelint-order` to pre-installed list [#1310](https://github.com/sider/runners/pull/1310)
 
 ## 0.30.0
 

--- a/images/stylelint/package.json
+++ b/images/stylelint/package.json
@@ -3,6 +3,7 @@
     "stylelint": "13.6.1",
     "stylelint-config-recommended": "3.0.0",
     "stylelint-config-standard": "20.0.0",
+    "stylelint-order": "4.1.0",
     "stylelint-scss": "3.18.0"
   }
 }

--- a/test/smokes/stylelint/expectations.rb
+++ b/test/smokes/stylelint/expectations.rb
@@ -250,6 +250,15 @@ s.add_test(
   type: "success",
   issues: [
     {
+      message: "Expected custom property to come before declaration",
+      links: [],
+      id: "order/order",
+      path: "test.css",
+      object: { severity: "error" },
+      git_blame_info: nil,
+      location: { start_line: 4, start_column: 3 }
+    },
+    {
       message: 'Unexpected unknown property "someattr"',
       links: %W[https://github.com/stylelint/stylelint/tree/#{default_version}/lib/rules/property-no-unknown],
       id: "property-no-unknown",

--- a/test/smokes/stylelint/only_stylelintrc/.stylelintrc.yaml
+++ b/test/smokes/stylelint/only_stylelintrc/.stylelintrc.yaml
@@ -3,8 +3,10 @@ extends:
 
 plugins:
   - stylelint-scss
+  - stylelint-order
 
 rules:
   at-rule-no-unknown: null
   scss/at-rule-no-unknown: true
   scss/comment-no-empty: true
+  order/order: [custom-properties, declarations]

--- a/test/smokes/stylelint/only_stylelintrc/test.css
+++ b/test/smokes/stylelint/only_stylelintrc/test.css
@@ -1,4 +1,5 @@
 #some-id {
   someattr: #fff;
   color: #f00 !important;
+  --main-bg-color: brown;
 }


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Deprecated SCSS-Lint recommends [`stylelint-order`](https://github.com/hudochenkov/stylelint-order):

> One alternative worthy of consideration is stylelint, which supports SCSS natively.
> If you want to use SCSS-specific rules in addition to stylelint core rules,
> you need to configure stylelint plugins like stylelint-scss or stylelint-order.

---

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
