### PR TITLE
Optimize git-blame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - **Brakeman** Syntax highlight for warning message [#1309](https://github.com/sider/runners/pull/1309)
 - **stylelint** Add `stylelint-order` to pre-installed list [#1310](https://github.com/sider/runners/pull/1310)
+- Optimize git-blame [#1312](https://github.com/sider/runners/pull/1312)
 
 ## 0.30.0
 

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -5,9 +5,16 @@ module Runners
     class BlameFailed < SystemError; end
 
     def range_git_blame_info(path_string, start_line, end_line)
+      @git_blame_cache ||= {}
+      cache_key = "#{path_string}\t#{start_line}\t#{end_line}"
+      cache_value = @git_blame_cache[cache_key]
+      return cache_value if cache_value
+
       stdout, _ = shell.capture3!("git", "blame", "-p", "-L", "#{start_line},#{end_line}", git_source.head, "--", path_string,
                                   trace_stdout: false, trace_stderr: true)
-      GitBlameInfo.parse(stdout)
+      GitBlameInfo.parse(stdout).tap do |result|
+        @git_blame_cache[cache_key] = result
+      end
     rescue Shell::ExecError => exn
       raise BlameFailed, "git-blame failed: #{exn.stderr_str}"
     end

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -105,14 +105,19 @@ class WorkspaceGitTest < Minitest::Test
   def test_git_blame_info
     with_workspace(**workspace_params_with_base) do |workspace|
       workspace.send(:prepare_head_source, nil)
-      info = workspace.range_git_blame_info('test/smokes/haml_lint/expectations.rb', 137, 140)
-      assert_equal(
-        [
-          GitBlameInfo.new(commit: "839d63e3a4b0c9654a501474b5fe922d4f3f8842", original_line: 126, final_line: 137, line_hash: "c57a7c8a63aa22b9aa40625f019fe097c3a23ab8"),
-          GitBlameInfo.new(commit: "998bc02a913e3899f3a1cd327e162dd54d489a4b", original_line: 138, final_line: 138, line_hash: "a77048541cecbd797666107ed16818e10cc594cb"),
-          GitBlameInfo.new(commit: "998bc02a913e3899f3a1cd327e162dd54d489a4b", original_line: 139, final_line: 139, line_hash: "aa9e4a8125d41d419481f799965c6a8e98392502"),
-          GitBlameInfo.new(commit: "998bc02a913e3899f3a1cd327e162dd54d489a4b", original_line: 140, final_line: 140, line_hash: "03ad52e876f71079c3e662b6d5aac4b47f33698c"),
-        ], info)
+      actual = workspace.range_git_blame_info('test/smokes/haml_lint/expectations.rb', 137, 140)
+      expected = [
+        GitBlameInfo.new(commit: "839d63e3a4b0c9654a501474b5fe922d4f3f8842", original_line: 126, final_line: 137, line_hash: "c57a7c8a63aa22b9aa40625f019fe097c3a23ab8"),
+        GitBlameInfo.new(commit: "998bc02a913e3899f3a1cd327e162dd54d489a4b", original_line: 138, final_line: 138, line_hash: "a77048541cecbd797666107ed16818e10cc594cb"),
+        GitBlameInfo.new(commit: "998bc02a913e3899f3a1cd327e162dd54d489a4b", original_line: 139, final_line: 139, line_hash: "aa9e4a8125d41d419481f799965c6a8e98392502"),
+        GitBlameInfo.new(commit: "998bc02a913e3899f3a1cd327e162dd54d489a4b", original_line: 140, final_line: 140, line_hash: "03ad52e876f71079c3e662b6d5aac4b47f33698c"),
+      ]
+      assert_equal expected, actual
+
+      # Using cache
+      actual = workspace.range_git_blame_info('test/smokes/haml_lint/expectations.rb', 137, 140)
+      assert_equal expected, actual
+      assert_equal 1, workspace.trace_writer.writer.count { _1[:command_line]&.slice(0, 2) == %w[git blame] }
     end
   end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

An output of git-blame is **idempotent**.
Thus, I think this optimization is effective, especially when there are many issues to be reported.

> Link related issues, e.g. "Fix #<ISSUE_ID>", "Related to #<ISSUE_ID>", or "None."

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
