### PR TITLE
Fix non-ascii filename on git-diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Optimize git-blame [#1312](https://github.com/sider/runners/pull/1312)
 - Remove unused `Result::MissingFilesFailure` [#1315](https://github.com/sider/runners/pull/1315)
 - Avoid needless calculation of changed files [#1320](https://github.com/sider/runners/pull/1320)
+- Fix non-ascii filename on git-diff [#1323](https://github.com/sider/runners/pull/1323)
 
 ## 0.30.0
 

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -39,6 +39,7 @@ module Runners
       shell.capture3!("git", "init")
       shell.capture3!("git", "config", "gc.auto", "0")
       shell.capture3!("git", "config", "advice.detachedHead", "false")
+      shell.capture3!("git", "config", "core.quotePath", "false")
       shell.capture3!("git", "remote", "add", "origin", remote_url.to_s)
 
       begin

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -63,16 +63,17 @@ class WorkspaceGitTest < Minitest::Test
     end
   end
 
-  def test_patches_returns_nil_because_base_is_nil
-    with_workspace do |workspace|
+  def test_patches_returns_nil
+    with_workspace(base: nil) do |workspace|
       assert_nil workspace.send(:patches)
     end
   end
 
-  def test_patches_returns_patches
-    with_workspace(base: base_commit) do |workspace|
+  def test_patches
+    with_workspace(head: "836880fdd04e5e1d7d82ed17dae838a16cfa50b2", base: base_commit) do |workspace|
       workspace.send(:prepare_head_source, nil)
-      assert_instance_of GitDiffParser::Patches, workspace.send(:patches)
+      patches = workspace.send(:patches)
+      assert_equal ["README.md", "sider.yml", "てすと.txt"], patches.files
     end
   end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

git-diff outputs quoted filenames by default.
`GitDiffParser::Patches` does not handle these quoted filenames.

See below for `core.quotePath`:

https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

None.

> Check the following items (please remove needless items).

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
