### PR TITLE
Refactor `Ignoring` class

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -7,7 +7,7 @@ target :lib do
   check "lib/runners/cli.rb"
   check "lib/runners/config.rb"
   check "lib/runners/errors.rb"
-  check "lib/runners/ignoring.rb"
+  # check "lib/runners/ignoring.rb"
   check "lib/runners/shell.rb"
   # TODO: Add checking...
 

--- a/lib/runners/config.rb
+++ b/lib/runners/config.rb
@@ -35,8 +35,8 @@ module Runners
       path
     end
 
-    def ignore
-      @ignore ||= Array(content[:ignore])
+    def ignore_patterns
+      @ignore_patterns ||= Array(content[:ignore])
     end
 
     def linter(id)

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -36,7 +36,12 @@ module Runners
         workspace.open do |git_ssh_path, changes|
           @config = conf = Config.new(workspace.working_dir)
 
-          Ignoring.new(working_dir: working_dir, trace_writer: trace_writer, config: conf).delete_ignored_files!
+          unless conf.ignore_patterns.empty?
+            trace_writer.message "Deleting ignored files..." do
+              files = Ignoring.new(workspace: workspace, ignore_patterns: conf.ignore_patterns).delete_ignored_files!
+              trace_writer.message "Successfully deleted #{files.size} file(s)"
+            end
+          end
 
           begin
             processor = processor_class.new(guid: guid, working_dir: working_dir, config: conf, git_ssh_path: git_ssh_path, trace_writer: trace_writer)

--- a/lib/runners/ignoring.rb
+++ b/lib/runners/ignoring.rb
@@ -1,43 +1,17 @@
 module Runners
   class Ignoring
-    # @dynamic working_dir, trace_writer, config
-    attr_reader :working_dir, :trace_writer, :config
+    attr_reader :workspace, :ignore_patterns
 
-    def initialize(working_dir:, trace_writer:, config:)
-      @working_dir = working_dir
-      @trace_writer = trace_writer
-      @config = config
+    def initialize(workspace:, ignore_patterns:)
+      @workspace = workspace
+      @ignore_patterns = ignore_patterns
     end
 
     def delete_ignored_files!
-      return [] if ignores.empty?
+      Tempfile.create("gitignore-") do |gitignore|
+        File.write gitignore, ignore_patterns.join("\n")
 
-      # @type var deleted_files: Array[String]
-      deleted_files = []
-
-      trace_writer.message("Deleting ignored files...") do
-        each_ignored_file do |file|
-          (working_dir / file).delete
-          deleted_files << file
-        end
-        trace_writer.message "Successfully deleted #{deleted_files.size} file(s)"
-      end
-
-      deleted_files
-    end
-
-    private
-
-    def ignores
-      config.ignore
-    end
-
-    def each_ignored_file(&block)
-      Tempfile.create("gitignore-") do |file|
-        gitignore = file.path
-        File.write gitignore, ignores.join("\n")
-
-        shell = Shell.new(current_dir: working_dir, trace_writer: trace_writer, env_hash: {})
+        shell = workspace.shell
         shell.capture3! "git", "init"
         shell.capture3! "git", "add", "."
 
@@ -45,15 +19,17 @@ module Runners
         shell.capture3! "git", "config", "core.quotePath", "false"
 
         # @see https://git-scm.com/docs/git-ls-files
-        ignored_files, = shell.capture3!(
-          "git", "ls-files", "--ignored", "--exclude-from", gitignore,
-          trace_command_line: true,
+        ignored_files, _ = shell.capture3!(
+          "git", "ls-files", "--ignored", "--exclude-from", gitignore.path,
           trace_stdout: false,
         )
 
         shell.capture3! "git", "config", "--unset", "core.quotePath" # restore
 
-        ignored_files.each_line(chomp: true, &block)
+        ignored_files.lines(chomp: true).map do |file|
+          (workspace.working_dir / file).delete
+          file
+        end
       end
     end
   end

--- a/sig/runners/config.rbi
+++ b/sig/runners/config.rbi
@@ -7,7 +7,7 @@ class Runners::Config
   def raw_content!: () -> String
   def path_name: -> String
   def path_exist?: -> bool
-  def ignore: -> Array<String>
+  def ignore_patterns: -> Array<String>
   def linter: (String) -> Hash<Symbol, any>
   def linter?: (String) -> bool
   def path: -> Pathname?

--- a/sig/runners/ignoring.rbi
+++ b/sig/runners/ignoring.rbi
@@ -1,10 +1,7 @@
 class Runners::Ignoring
-  attr_reader working_dir: Pathname
-  attr_reader trace_writer: TraceWriter
-  attr_reader config: Config
+  attr_reader workspace: Workspace
+  attr_reader ignore_patterns: Array<String>
 
-  def initialize: (working_dir: Pathname, trace_writer: TraceWriter, config: Config) -> void
+  def initialize: (workspace: Workspace, ignore_patterns: Array<String>) -> void
   def delete_ignored_files!: () -> Array<String>
-  def ignores: () -> Array<String>
-  def each_ignored_file: () { (String) -> void } -> void
 end

--- a/sig_new/runners/config.rbs
+++ b/sig_new/runners/config.rbs
@@ -7,7 +7,7 @@ class Runners::Config
   def raw_content!: () -> String
   def path_name: () -> String
   def path_exist?: () -> bool
-  def ignore: () -> Array[String]
+  def ignore_patterns: () -> Array[String]
   def linter: (String) -> Hash[Symbol, untyped]
   def linter?: (String) -> bool
 

--- a/sig_new/runners/ignoring.rbs
+++ b/sig_new/runners/ignoring.rbs
@@ -1,12 +1,7 @@
 class Runners::Ignoring
-  attr_reader working_dir: Pathname
-  attr_reader trace_writer: TraceWriter
-  attr_reader config: Config
+  attr_reader workspace: Workspace
+  attr_reader ignore_patterns: Array[String]
 
-  def initialize: (working_dir: Pathname, trace_writer: TraceWriter, config: Config) -> untyped
+  def initialize: (workspace: Workspace, ignore_patterns: Array[String]) -> void
   def delete_ignored_files!: () -> Array[String]
-
-  private
-  def ignores: () -> Array[String]
-  def each_ignored_file: () { (String) -> void } -> void
 end

--- a/sig_new/runners/workspace.rbs
+++ b/sig_new/runners/workspace.rbs
@@ -1,0 +1,2 @@
+class Runners::Workspace
+end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -190,14 +190,14 @@ class ConfigTest < Minitest::Test
     end
   end
 
-  def test_ignore
+  def test_ignore_patterns
     mktmpdir do |path|
-      assert_equal [], Runners::Config.new(path).ignore
+      assert_equal [], Runners::Config.new(path).ignore_patterns
     end
 
     mktmpdir do |path|
       (path / "sider.yml").write("ignore: abc")
-      assert_equal %w[abc], Runners::Config.new(path).ignore
+      assert_equal %w[abc], Runners::Config.new(path).ignore_patterns
     end
 
     mktmpdir do |path|
@@ -206,7 +206,7 @@ class ConfigTest < Minitest::Test
           - "*.mp4"
           - docs/**/*.pdf
       YAML
-      assert_equal %w[*.mp4 docs/**/*.pdf], Runners::Config.new(path).ignore
+      assert_equal %w[*.mp4 docs/**/*.pdf], Runners::Config.new(path).ignore_patterns
     end
   end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to improve the readability of the code around the `Ignoring` class.
The `Ignoring` class uses internally the `git` command, so I think the class depends on `Workspace::Git` implicitly.

Thus, this change clarifies the dependency on `Workspace::Git`.
After this change is merged, I will remove unnecessary the `git init` command finally.
(The smoke test, which depends on `Workspace::File`, would fail if removing `git init` in this change).

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

See also #1316 and <https://github.com/sider/runners/pull/1323#pullrequestreview-452240525>
