### PR TITLE
Improve `IgnoringTest`

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,6 +58,14 @@ module TestHelper
     end
   end
 
+  def with_workspace_open(**params)
+    with_workspace(**params) do |workspace|
+      workspace.open do
+        yield workspace
+      end
+    end
+  end
+
   def config(yaml = nil)
     mktmpdir do |path|
       (path / 'sider.yml').write(yaml) if yaml


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The `git init` and `git add .` commands in the `Ignoring` class will be removed.

https://github.com/sider/runners/blob/ad88f247d193d5750035bd28563dd7a56a086a77/lib/runners/ignoring.rb#L15-L16

This improvement of `IgnoringTest` works whether or not these commands are present.

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

This change is a follow-up of #1324.
