### PR TITLE
Unify `DEBUG` and `SHOW_TRACE` env vars for smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,13 @@ $ bundle exec rake test TEST=test/cli_test.rb TESTOPTS='--name=test_parsing_opti
 You can run smoke tests via the `rake docker:smoke` command as follow:
 
 ```shell-session
-$ bundle exec rake docker:smoke ANALYZER=rubocop [ONLY=test1,test2,...] [SHOW_TRACE=true]
+$ bundle exec rake docker:smoke ANALYZER=rubocop [ONLY=test1,test2,...] [DEBUG=(true|trace)]
 ```
 
 - `ONLY`: Specify test name(s). You can specify a comma-separated list.
-- `SHOW_TRACE`: Show trace log to console. Useful to debug.
+- `DEBUG`: Show debug log to your console.
+  - `DEBUG=true`: All log.
+  - `DEBUG=trace`: Only trace log (colored).
 
 If you want to run tests right after changing code, you can run one command as follow:
 

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -97,7 +97,7 @@ module Runners
 
         reader = JSONSEQ::Reader.new(io: StringIO.new(command_output), decoder: -> (json) { JSON.parse(json, symbolize_names: true) })
         traces = reader.each_object.to_a
-        if ENV['SHOW_TRACE']
+        if debug_trace?
           traces.each do |trace|
             out.puts colored_pretty_inspect(trace)
           end
@@ -127,7 +127,7 @@ module Runners
             end
           end
         end
-        out.puts colored_pretty_inspect(result) if !ok && debug?
+        out.puts colored_pretty_inspect(result, multiline: true) if !ok && debug?
 
         ok
       end
@@ -179,7 +179,11 @@ module Runners
       end
 
       def debug?
-        ENV["DEBUG"]
+        ENV["DEBUG"] == "true"
+      end
+
+      def debug_trace?
+        ENV["DEBUG"] == "trace"
       end
 
       def sh!(*command, out:, exception: true)
@@ -199,8 +203,8 @@ module Runners
         [stdout_str, stderr_str]
       end
 
-      def colored_pretty_inspect(hash)
-        hash.awesome_inspect(indent: 2, index: false)
+      def colored_pretty_inspect(obj, multiline: false)
+        obj.awesome_inspect(indent: 2, index: false, multiline: multiline)
       end
 
       @tests = []

--- a/sig/runners/testing.rbi
+++ b/sig/runners/testing.rbi
@@ -18,8 +18,9 @@ class Runners::Testing::Smoke
   def command_line: (params: TestParams, repo_dir: String, base: String, head: String) -> Array<String>
   def prepare_git_repository: (workdir: Pathname, smoke_target: Pathname, out: StringIO) -> Array<String>
   def debug?: () -> bool
+  def debug_trace?: () -> bool
   def sh!: (*String, out: StringIO, ?exception: bool) -> [String, String]
-  def colored_pretty_inspect: (any) -> String
+  def colored_pretty_inspect: (any, ?multiline: bool) -> String
 
   def self.only?: (String) -> bool
   def self.add_test: (String, type: String,


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The `DEBUG` environment variable was added with PR #1316,
but it can be confusing by the existing `SHOW_TRACE`.

So, this change aims to resolve such potential confusion by unifying both.

- `DEBUG=true`: All log.
- `DEBUG=trace`: Only trace log (colored).

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

See also #1316
