### PR TITLE
Refactor IO classes

### DIFF
--- a/lib/runners/io.rb
+++ b/lib/runners/io.rb
@@ -1,21 +1,17 @@
 module Runners
   class IO
-    REQUIRED_METHODS_FOR_IOS = %i[write flush].freeze
-
     attr_reader :ios
 
     def initialize(*ios)
-      @ios = ios.each do |io|
-        raise ArgumentError unless REQUIRED_METHODS_FOR_IOS.all? { |method| io.respond_to?(method) }
-      end
+      @ios = ios
     end
 
     def write(*args)
       ios.each { |io| io.write(*args) }
     end
 
-    def flush(*args)
-      ios.each { |io| io.flush(*args) }
+    def flush
+      ios.each { |io| io.flush }
     end
 
     def flush!

--- a/lib/runners/io/aws_s3.rb
+++ b/lib/runners/io/aws_s3.rb
@@ -19,7 +19,6 @@ module Runners
 
     attr_reader :uri, :bucket_name, :object_name, :tempfile, :written_items, :client
 
-    # @param uri [String]
     def initialize(uri)
       @uri = uri
       @bucket_name, @object_name = self.class.parse_s3_uri!(uri)
@@ -31,11 +30,10 @@ module Runners
         retry_base_delay: 1.2,
         instance_profile_credentials_retries: 5,
         instance_profile_credentials_timeout: 3,
-      }.tap do |hash|
-        if ENV["S3_ENDPOINT"]
-          hash[:endpoint] = ENV["S3_ENDPOINT"]
-          hash[:force_path_style] = true
-        end
+      }
+      if ENV["S3_ENDPOINT"]
+        args[:endpoint] = ENV["S3_ENDPOINT"]
+        args[:force_path_style] = true
       end
       @client = Aws::S3::Client.new(**args)
     end
@@ -45,8 +43,8 @@ module Runners
       tempfile.write(*args)
     end
 
-    def flush(*args)
-      tempfile.flush(*args)
+    def flush
+      tempfile.flush
       flush_to_s3! if should_flush?
     end
 

--- a/sig/runners/io.rbi
+++ b/sig/runners/io.rbi
@@ -2,9 +2,7 @@ class Runners::IO
   attr_reader ios: Array<any>
 
   def initialize: (*any) -> any
-  def write: (*any) -> void
-  def flush: (*any) -> void
+  def write: (*_ToS) -> void
+  def flush: () -> void
   def flush!: () -> void
 end
-
-Runners::IO::REQUIRED_METHODS_FOR_IOS: Array<Symbol>

--- a/sig_new/runners/io.rbs
+++ b/sig_new/runners/io.rbs
@@ -2,9 +2,7 @@ class Runners::IO
   attr_reader ios: Array[::IO]
 
   def initialize: (*::IO ios) -> void
-  def write: (*untyped args) -> void
-  def flush: (*untyped args) -> void
+  def write: (*_ToS) -> void
+  def flush: () -> void
   def flush!: () -> void
 end
-
-Runners::IO::REQUIRED_METHODS_FOR_IOS: Array[Symbol]

--- a/test/io/aws_s3_test.rb
+++ b/test/io/aws_s3_test.rb
@@ -44,11 +44,11 @@ class AwsS3Test < Minitest::Test
                               instance_profile_credentials_timeout: is_a(Numeric))
     io = Runners::IO::AwsS3.new('s3://bucket_name/object_name')
 
-    2.times { io.write }
+    2.times { io.write("a") }
     assert_equal 2, io.written_items
     refute io.should_flush?
 
-    300.times { io.write }
+    300.times { io.write("b") }
     assert 302, io.written_items
     assert io.should_flush?
   end
@@ -60,7 +60,7 @@ class AwsS3Test < Minitest::Test
                               instance_profile_credentials_timeout: is_a(Numeric)) { mock_object }
     mock(mock_object).put_object(bucket: 'bucket_name', key: 'object_name', body: instance_of(Tempfile))
     io = Runners::IO::AwsS3.new('s3://bucket_name/object_name')
-    io.write
+    io.write("a")
     assert_equal 1, io.written_items
 
     io.flush!


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to follow the interface of the standard library [`IO`](https://ruby-doc.org/core-2.7.1/IO.html) class.

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

None.
