### PR TITLE
Install 3rd-party JVM dependencies via `sider.yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Updated tools:
 Misc:
 
 - Download JVM dependencies via Gradle [#1352](https://github.com/sider/runners/pull/1352)
+- Install 3rd-party JVM dependencies via `sider.yml` [#1361](https://github.com/sider/runners/pull/1361)
 
 ## 0.31.0
 

--- a/lib/runners/java.rb
+++ b/lib/runners/java.rb
@@ -68,7 +68,7 @@ module Runners
           #{deps}
           }
           task deps(type: Copy) {
-            from configurations.runtimeClasspath
+            from configurations.compileClasspath
             into '.'
           }
         GRADLE

--- a/lib/runners/java.rb
+++ b/lib/runners/java.rb
@@ -1,8 +1,82 @@
 module Runners
   module Java
+    class InvalidDependency < UserError; end
+
     def show_runtime_versions
       capture3! "java", "-version"
       capture3! "mvn", "--version"
+      capture3! "gradle", "--version"
+    end
+
+    def install_jvm_deps
+      return if config_jvm_deps.empty?
+
+      chdir jvm_deps_dir do
+        generate_jvm_deps_file
+
+        trace_writer.message "Install dependencies..." do
+          fetch_deps_via_gradle!
+          deps = config_jvm_deps.map { |dep| "* #{dep.join(':')}" }
+          trace_writer.message <<~MSG
+            Successfully installed #{deps.size} #{deps.size == 1 ? 'dependency' : 'dependencies'}:
+            #{deps.join("\n")}
+          MSG
+        end
+      end
+    end
+
+    private
+
+    def jvm_deps_dir
+      Pathname(Dir.home) / "dependencies"
+    end
+
+    def fetch_deps_via_gradle!
+      capture3! "gradle", "--no-build-cache", "--parallel", "--quiet", "deps"
+    end
+
+    def config_jvm_deps
+      @config_jvm_deps ||= Array(config_linter[:jvm_deps]).each do |dep|
+        group, name, version = dep
+        unless group && name && version
+          message = <<~MSG
+            An invalid dependency is found in your `#{config.path_name}`: `#{dep.inspect}`
+            Dependencies should be of the form: `[group, name, version]`
+          MSG
+          trace_writer.error message
+          raise InvalidDependency, message
+        end
+      end
+    end
+
+    def generate_jvm_deps_file
+      filename = "build.gradle"
+
+      trace_writer.message "Generating #{filename}..." do
+        deps = config_jvm_deps.map { |dep| "  implementation '#{dep.join(":")}'" }.join("\n")
+        content = <<~GRADLE
+          plugins {
+            id 'java'
+          }
+          repositories {
+            mavenCentral()
+          }
+          dependencies {
+          #{deps}
+          }
+          task deps(type: Copy) {
+            from configurations.runtimeClasspath
+            into '.'
+          }
+        GRADLE
+
+        File.write filename, content
+        trace_writer.message <<~MSG
+          ---
+          #{content.chomp}
+          ---
+        MSG
+      end
     end
   end
 end

--- a/lib/runners/java.rb
+++ b/lib/runners/java.rb
@@ -52,6 +52,9 @@ module Runners
     def generate_jvm_deps_file
       filename = "build.gradle"
 
+      # @see https://docs.gradle.org/current/userguide/declaring_repositories.html
+      repos = ["mavenCentral()", "jcenter()", "google()"].map { |repo| "  #{repo}" }.join("\n")
+
       trace_writer.message "Generating #{filename}..." do
         deps = config_jvm_deps.map { |dep| "  implementation '#{dep.join(":")}'" }.join("\n")
         content = <<~GRADLE
@@ -59,7 +62,7 @@ module Runners
             id 'java'
           }
           repositories {
-            mavenCentral()
+          #{repos}
           }
           dependencies {
           #{deps}

--- a/lib/runners/processor/pmd_java.rb
+++ b/lib/runners/processor/pmd_java.rb
@@ -3,13 +3,13 @@ module Runners
     include Java
 
     Schema = StrongJSON.new do
-      let :runner_config, Schema::BaseConfig.base.update_fields { |fields|
+      let :runner_config, Schema::BaseConfig.java.update_fields { |fields|
         fields.merge!({
-                        dir: string?,
-                        rulesets: enum?(string, array(string)),
-                        encoding: string?,
-                        min_priority: numeric?
-                      })
+          dir: string?,
+          rulesets: enum?(string, array(string)),
+          encoding: string?,
+          min_priority: numeric?,
+        })
       }
 
       let :issue, object(
@@ -29,6 +29,16 @@ module Runners
 
     def analyzer_bin
       "pmd"
+    end
+
+    def setup
+      begin
+        install_jvm_deps
+      rescue UserError => exn
+        return Results::Failure.new(guid: guid, message: exn.message)
+      end
+
+      yield
     end
 
     def analyze(changes)

--- a/lib/runners/schema/config.rb
+++ b/lib/runners/schema/config.rb
@@ -37,6 +37,10 @@ module Runners
       let :npm, (base.update_fields { |fields|
         fields.merge!(npm_install: optional(npm_install))
       })
+
+      let :java, (base.update_fields { |fields|
+        fields.merge!(jvm_deps: array?(array(string)))
+      })
     end
 
     Config = _ = StrongJSON.new do

--- a/lib/runners/schema/config.rb
+++ b/lib/runners/schema/config.rb
@@ -39,7 +39,7 @@ module Runners
       })
 
       let :java, (base.update_fields { |fields|
-        fields.merge!(jvm_deps: array?(array(string)))
+        fields.merge!(jvm_deps: array?(array(enum(string, number))))
       })
     end
 

--- a/sig/polyfill.rbi
+++ b/sig/polyfill.rbi
@@ -115,6 +115,7 @@ class Dir
   def self.mktmpdir: <'a> { (String) -> 'a } -> 'a
                    | () -> String
   def self.chdir: <'a> (String) { (String) -> 'a } -> 'a
+  def self.home: () -> String
 end
 
 class URI

--- a/sig/runners/java.rbi
+++ b/sig/runners/java.rbi
@@ -1,0 +1,9 @@
+module Runners::Java : Processor
+  def install_jvm_deps: () -> void
+
+  # private
+  def jvm_deps_dir: () -> Pathname
+  def fetch_deps_via_gradle!: () -> void
+  def config_jvm_deps: () -> Array<[String, String, String]>
+  def generate_jvm_deps_file: () -> void
+end

--- a/test/java_test.rb
+++ b/test/java_test.rb
@@ -31,7 +31,7 @@ class JavaTest < Minitest::Test
           implementation 'org.foo:baz:4.9'
         }
         task deps(type: Copy) {
-          from configurations.runtimeClasspath
+          from configurations.compileClasspath
           into '.'
         }
       GRADLE

--- a/test/java_test.rb
+++ b/test/java_test.rb
@@ -1,0 +1,130 @@
+require_relative 'test_helper'
+
+class JavaTest < Minitest::Test
+  include TestHelper
+
+  def test_install_jvm_deps
+    with_workspace do |workspace|
+      processor = new_processor workspace, config_yaml: <<~YAML
+        linter:
+          checkstyle:
+            jvm_deps:
+              - [com.foo, bar, 1.2.3]
+              - [org.foo, baz, 0.5.1]
+      YAML
+
+      processor.install_jvm_deps
+
+      deps_dir = processor.jvm_deps_dir
+      assert_path_exists deps_dir / "build.gradle"
+      assert_equal <<~GRADLE, (deps_dir / "build.gradle").read
+        plugins {
+          id 'java'
+        }
+        repositories {
+          mavenCentral()
+        }
+        dependencies {
+          implementation 'com.foo:bar:1.2.3'
+          implementation 'org.foo:baz:0.5.1'
+        }
+        task deps(type: Copy) {
+          from configurations.runtimeClasspath
+          into '.'
+        }
+      GRADLE
+
+      assert_includes trace_messages, <<~MSG.strip
+        Successfully installed 2 dependencies:
+        * com.foo:bar:1.2.3
+        * org.foo:baz:0.5.1
+      MSG
+    end
+  end
+
+  def test_install_jvm_deps_without_config
+    with_workspace do |workspace|
+      processor = new_processor workspace, config_yaml: ""
+      processor.install_jvm_deps
+      refute_includes trace_messages, "Install dependencies..."
+    end
+  end
+
+  def test_install_jvm_deps_without_value
+    with_workspace do |workspace|
+      processor = new_processor workspace, config_yaml: <<~YAML
+        linter:
+          checkstyle:
+            jvm_deps:
+      YAML
+      processor.install_jvm_deps
+      refute_includes trace_messages, "Install dependencies..."
+    end
+  end
+
+  def test_install_jvm_deps_with_invalid_format
+    with_workspace do |workspace|
+      processor = new_processor workspace, config_yaml: <<~YAML
+        linter:
+          checkstyle:
+            jvm_deps:
+              - [a, b]
+      YAML
+
+      error = assert_raises Runners::Java::InvalidDependency do
+        processor.install_jvm_deps
+      end
+      assert_equal <<~MSG, error.message
+        An invalid dependency is found in your `sider.yml`: `["a", "b"]`
+        Dependencies should be of the form: `[group, name, version]`
+      MSG
+    end
+  end
+
+  def test_invalid_config
+    with_workspace do |workspace|
+      error = assert_raises Runners::Config::InvalidConfiguration do
+        new_processor workspace, config_yaml: <<~YAML
+          linter:
+            checkstyle:
+              jvm_deps:
+                - [a, b, 10]
+        YAML
+      end
+      assert_includes error.message, "`linter.checkstyle.jvm_deps[0][2]`"
+    end
+  end
+
+  private
+
+  def new_processor(workspace, config_yaml:)
+    klass = Class.new(Runners::Processor) do
+      include Runners::Java
+      def analyzer_id; "checkstyle"; end
+      def analyzer_bin; "checkstyle"; end
+      def analyzer_name; "Checkstyle"; end
+      def jvm_deps_dir
+        (working_dir / "deps").tap { _1.mkpath }
+      end
+      def fetch_deps_via_gradle!
+        # noop
+      end
+    end
+
+    klass.new(
+      guid: "test-guid",
+      working_dir: workspace.working_dir,
+      config: config(config_yaml),
+      git_ssh_path: nil,
+      trace_writer: trace_writer,
+    )
+  end
+
+  def trace_writer
+    @trace_writer ||= new_trace_writer
+  end
+
+  def trace_messages
+    trace_writer.writer.map { _1[:message] }.compact
+  end
+end

--- a/test/java_test.rb
+++ b/test/java_test.rb
@@ -31,8 +31,7 @@ class JavaTest < Minitest::Test
           implementation 'org.foo:baz:4.9'
         }
         task deps(type: Copy) {
-          from configurations.compile
-"Classpath
+          from configurations.compileClasspath
           into '.'
         }
       GRADLE

--- a/test/java_test.rb
+++ b/test/java_test.rb
@@ -23,6 +23,8 @@ class JavaTest < Minitest::Test
         }
         repositories {
           mavenCentral()
+          jcenter()
+          google()
         }
         dependencies {
           implementation 'com.foo:bar:1.2.3'

--- a/test/java_test.rb
+++ b/test/java_test.rb
@@ -10,7 +10,7 @@ class JavaTest < Minitest::Test
           checkstyle:
             jvm_deps:
               - [com.foo, bar, 1.2.3]
-              - [org.foo, baz, 0.5.1]
+              - [org.foo, baz, 4.9]
       YAML
 
       processor.install_jvm_deps
@@ -26,7 +26,7 @@ class JavaTest < Minitest::Test
         }
         dependencies {
           implementation 'com.foo:bar:1.2.3'
-          implementation 'org.foo:baz:0.5.1'
+          implementation 'org.foo:baz:4.9'
         }
         task deps(type: Copy) {
           from configurations.runtimeClasspath
@@ -37,7 +37,7 @@ class JavaTest < Minitest::Test
       assert_includes trace_messages, <<~MSG.strip
         Successfully installed 2 dependencies:
         * com.foo:bar:1.2.3
-        * org.foo:baz:0.5.1
+        * org.foo:baz:4.9
       MSG
     end
   end
@@ -88,7 +88,7 @@ class JavaTest < Minitest::Test
           linter:
             checkstyle:
               jvm_deps:
-                - [a, b, 10]
+                - [a, b, false]
         YAML
       end
       assert_includes error.message, "`linter.checkstyle.jvm_deps[0][2]`"

--- a/test/java_test.rb
+++ b/test/java_test.rb
@@ -31,7 +31,8 @@ class JavaTest < Minitest::Test
           implementation 'org.foo:baz:4.9'
         }
         task deps(type: Copy) {
-          from configurations.compileClasspath
+          from configurations.compile
+"Classpath
           into '.'
         }
       GRADLE

--- a/test/smokes/checkstyle/deps/Foo.java
+++ b/test/smokes/checkstyle/deps/Foo.java
@@ -1,0 +1,3 @@
+@XXX
+class Foo {
+}

--- a/test/smokes/checkstyle/deps/checkstyle.xml
+++ b/test/smokes/checkstyle/deps/checkstyle.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="com.github.sevntu.checkstyle.checks.annotation.ForbidAnnotationCheck">
+      <property name="annotationNames" value="XXX"/>
+      <property name="annotationTargets" value="METHOD_DEF,CLASS_DEF"/>
+    </module>
+  </module>
+</module>

--- a/test/smokes/checkstyle/deps/sider.yml
+++ b/test/smokes/checkstyle/deps/sider.yml
@@ -1,0 +1,5 @@
+linter:
+  checkstyle:
+    jvm_deps:
+      - [com.github.sevntu-checkstyle, sevntu-checks, 1.37.1]
+    config: checkstyle.xml

--- a/test/smokes/checkstyle/deps_invalid_definition/sider.yml
+++ b/test/smokes/checkstyle/deps_invalid_definition/sider.yml
@@ -1,0 +1,4 @@
+linter:
+  checkstyle:
+    jvm_deps:
+      - [foo, bar, 0.1.0]

--- a/test/smokes/checkstyle/deps_invalid_format/sider.yml
+++ b/test/smokes/checkstyle/deps_invalid_format/sider.yml
@@ -1,0 +1,4 @@
+linter:
+  checkstyle:
+    jvm_deps:
+      - [com.github.sevntu-checkstyle, sevntu-checks]

--- a/test/smokes/checkstyle/deps_not_default/Foo.java
+++ b/test/smokes/checkstyle/deps_not_default/Foo.java
@@ -1,0 +1,5 @@
+class Foo {
+  public Function<String, Integer> test() {
+    return (string) -> 1;
+  }
+}

--- a/test/smokes/checkstyle/deps_not_default/checkstyle.xml
+++ b/test/smokes/checkstyle/deps_not_default/checkstyle.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="io.spring.javaformat.checkstyle.check.SpringLambdaCheck">
+      <property name="singleArgumentParentheses" value="false"/>
+    </module>
+  </module>
+</module>

--- a/test/smokes/checkstyle/deps_not_default/sider.yml
+++ b/test/smokes/checkstyle/deps_not_default/sider.yml
@@ -1,0 +1,5 @@
+linter:
+  checkstyle:
+    jvm_deps:
+      - [io.spring.javaformat, spring-javaformat-checkstyle, 0.0.23]
+    config: checkstyle.xml

--- a/test/smokes/checkstyle/expectations.rb
+++ b/test/smokes/checkstyle/expectations.rb
@@ -179,3 +179,60 @@ s.add_test(
   message: "Analysis failed. See the log for details.",
   analyzer: { name: "Checkstyle", version: default_version }
 )
+
+s.add_test(
+  "deps",
+  type: "success",
+  issues: [
+    {
+      message: "Incorrect target: 'CLASS_DEF' for annotation: 'XXX'.",
+      links: [],
+      id: "com.github.sevntu.checkstyle.checks.annotation.ForbidAnnotationCheck",
+      path: "Foo.java",
+      location: { start_line: 1, start_column: 1 },
+      object: { severity: "error" },
+      git_blame_info: {
+        commit: :_, line_hash: "1dc0736e1e427ace652a896ca5c096be7acd8133", original_line: 1, final_line: 1
+      }
+    }
+  ],
+  analyzer: { name: "Checkstyle", version: default_version }
+)
+
+s.add_test(
+  "deps_not_default",
+  type: "success",
+  issues: [
+    {
+      message: "Lambda argument has unnecessary parentheses.",
+      links: [],
+      id: "io.spring.javaformat.checkstyle.check.SpringLambdaCheck",
+      path: "Foo.java",
+      location: { start_line: 3, start_column: 21 },
+      object: { severity: "error" },
+      git_blame_info: {
+        commit: :_, line_hash: "8dedd49bab7f8372d3784a0d03ee1e6cfa8a61e4", original_line: 3, final_line: 3
+      }
+    }
+  ],
+  analyzer: { name: "Checkstyle", version: "8.32" }
+)
+
+s.add_test(
+  "deps_invalid_format",
+  type: "failure",
+  message: <<~MSG,
+    An invalid dependency is found in your `sider.yml`: `["com.github.sevntu-checkstyle", "sevntu-checks"]`
+    Dependencies should be of the form: `[group, name, version]`
+  MSG
+  analyzer: :_
+)
+
+s.add_test(
+  "deps_invalid_definition",
+  type: "error",
+  class: "Runners::Shell::ExecError",
+  backtrace: :_,
+  inspect: /#<Runners::Shell::ExecError: type=capture3, args=\["gradle", "--no-build-cache",/,
+  analyzer: :_
+)

--- a/test/smokes/detekt/deps/Foo.kt
+++ b/test/smokes/detekt/deps/Foo.kt
@@ -1,0 +1,13 @@
+class Foo {
+  fun f1() {}
+  fun f2() {}
+  fun f3() {}
+  fun f4() {}
+  fun f5() {}
+  fun f6() {}
+  fun f7() {}
+  fun f8() {}
+  fun f9() {}
+  fun f10() {}
+  fun f11() {}
+}

--- a/test/smokes/detekt/deps/detekt.yml
+++ b/test/smokes/detekt/deps/detekt.yml
@@ -1,0 +1,3 @@
+sample:
+  TooManyFunctionsTwo:
+    active: true

--- a/test/smokes/detekt/deps/sider.yml
+++ b/test/smokes/detekt/deps/sider.yml
@@ -1,0 +1,5 @@
+linter:
+  detekt:
+    jvm_deps:
+      - [io.gitlab.arturbosch.detekt, detekt-sample-extensions, 1.10.0]
+    config: detekt.yml

--- a/test/smokes/detekt/expectations.rb
+++ b/test/smokes/detekt/expectations.rb
@@ -205,3 +205,33 @@ s.add_test(
 )
 
 s.add_test("no_files", type: "success", analyzer: { name: "detekt", version: default_version }, issues: [])
+
+s.add_test(
+  "deps",
+  type: "success",
+  analyzer: { name: "detekt", version: default_version },
+  issues: [
+    {
+      id: "detekt.TooManyFunctions",
+      path: "Foo.kt",
+      location: { start_line: 1, start_column: 1 },
+      message: "The file Foo.kt has 11 function declarations. Threshold is specified with 10.",
+      links: [],
+      object: { severity: "warning" },
+      git_blame_info: {
+        commit: :_, line_hash: "1e643aae3d233605968d1478dacf8c5d2aa2d8f9", original_line: 1, final_line: 1
+      }
+    },
+    {
+      id: "detekt.TooManyFunctionsTwo",
+      path: "Foo.kt",
+      location: { start_line: 1, start_column: 1 },
+      message: "The file Foo.kt has 11 function declarations. Threshold is specified with 10.",
+      links: [],
+      object: { severity: "warning" },
+      git_blame_info: {
+        commit: :_, line_hash: "1e643aae3d233605968d1478dacf8c5d2aa2d8f9", original_line: 1, final_line: 1
+      }
+    }
+  ]
+)

--- a/test/smokes/pmd_java/deps/Foo.java
+++ b/test/smokes/pmd_java/deps/Foo.java
@@ -1,0 +1,7 @@
+import java.math.BigDecimal;
+
+class Foo {
+  public void test() {
+    BigDecimal num = new BigDecimal(8.9);
+  }
+}

--- a/test/smokes/pmd_java/deps/ruleset.xml
+++ b/test/smokes/pmd_java/deps/ruleset.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="My ruleset"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+  <description>My ruleset</description>
+  <rule ref="rulesets/java/ali-oop.xml" />
+</ruleset>

--- a/test/smokes/pmd_java/deps/sider.yml
+++ b/test/smokes/pmd_java/deps/sider.yml
@@ -1,0 +1,6 @@
+linter:
+  pmd_java:
+    jvm_deps:
+      - [com.alibaba.p3c, p3c-pmd, 2.0.1]
+    rulesets:
+      - ruleset.xml

--- a/test/smokes/pmd_java/expectations.rb
+++ b/test/smokes/pmd_java/expectations.rb
@@ -284,3 +284,22 @@ s.add_test(
     }
   ]
 )
+
+s.add_test(
+  "deps",
+  type: "success",
+  analyzer: { name: "PMD Java", version: "6.15.0" },
+  issues: [
+    {
+      message: "使用了new BigDecimal(double)构造函数",
+      links: [],
+      id: "BigDecimalAvoidDoubleConstructorRule",
+      path: "Foo.java",
+      location: { start_line: 5, start_column: 22, end_line: 5, end_column: 40 },
+      object: { ruleset: "AlibabaJavaOop", priority: "3" },
+      git_blame_info: {
+        commit: :_, line_hash: "3c5a62ddee69a8abdd787478563feaea8a7fa1f7", original_line: 5, final_line: 5
+      }
+    }
+  ]
+)


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change allows users to install 3rd-party JVM dependencies via `sider.yml`.

For example, users can do it to use 3rd-party Checkstyle rules:

```yaml
linter:
  checkstyle:
    jvm_deps:
      # [group, name, version] format
      - [com.github.sevntu-checkstyle, sevntu-checks, 1.37.1]
```

NOTE:
I suggested `maven` instead of `jvm_deps` in [this comment](https://github.com/sider/runners/issues/1000#issuecomment-657994815), but I think it not good that naming depends on a specific tool name (e.g. Maven, Gradle, etc.).
So, I renamed it to `jvm_deps` and adopted only the format `[group, name, version]`.

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

Fix #1000

> Check the following items (please remove needless items).

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
