### PR TITLE
[PHPMD] Improve runtime error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.32.1...HEAD)
 
+- **PHPMD** Improve runtime error message [#1383](https://github.com/sider/runners/pull/1383)
+
 ## 0.32.1
 
 [Full diff](https://github.com/sider/runners/compare/0.32.0...0.32.1)

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -95,8 +95,10 @@ module Runners
       unless status.success?
         if stderr.include? "Cannot find specified rule-set"
           return Results::Failure.new(guid: guid, analyzer: analyzer, message: "Invalid rule: #{rule.inspect}")
-        else
+        elsif !stderr.empty?
           raise stderr
+        else
+          raise status.inspect
         end
       end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

When `stderr` is empty, a runtime error message is not useful.

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

None.

> Check the following items (please remove needless items).

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
