### PR TITLE
Use stronger PAT for `rake bump:analyzers`

### DIFF
--- a/.github/workflows/bump_analyzers.yml
+++ b/.github/workflows/bump_analyzers.yml
@@ -19,6 +19,6 @@ jobs:
       - run: |
           bundle exec rake bump:analyzers
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SIDERBOT_PERSONAL_ACCESS_TOKEN }}
           GITHUB_AUTHOR_NAME: GitHub Actions
           GITHUB_AUTHOR_EMAIL: actions@github.com


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

`secrets.GITHUB_TOKEN` has weaker permissions, so it cannot trigger other workflows when a pull request is created.

This change uses stronger "Personal Access Token" (PAT) of `siderbot`.

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

None.
