### PR TITLE
[stylelint] Add `stylelint-prettier` as a pre-installed package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Updated tools:
 Misc:
 
 - **stylelint** Add `stylelint-config-prettier` as pre-installed package [#1396](https://github.com/sider/runners/pull/1396)
+- **stylelint** Add `stylelint-prettier` as a pre-installed package [#1402](https://github.com/sider/runners/pull/1402)
 
 ## 0.32.2
 

--- a/images/stylelint/package.json
+++ b/images/stylelint/package.json
@@ -1,10 +1,12 @@
 {
   "dependencies": {
+    "prettier": "2.0.5",
     "stylelint": "13.6.1",
     "stylelint-config-prettier": "8.0.2",
     "stylelint-config-recommended": "3.0.0",
     "stylelint-config-standard": "20.0.0",
     "stylelint-order": "4.1.0",
+    "stylelint-prettier": "1.1.2",
     "stylelint-scss": "3.18.0"
   }
 }

--- a/test/smokes/stylelint/only_stylelintrc/.stylelintrc.yaml
+++ b/test/smokes/stylelint/only_stylelintrc/.stylelintrc.yaml
@@ -5,6 +5,7 @@ extends:
 plugins:
   - stylelint-scss
   - stylelint-order
+  - stylelint-prettier
 
 rules:
   at-rule-no-unknown: null


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

`stylelint-config-prettier` was added in PR #1396, so I think it reasonable to add also `stylelint-prettier`.
Note that we need to add also `prettier` as a required peer dependency.
See <https://github.com/prettier/stylelint-prettier>

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

Related to #1396

> Check the following items (please remove needless items).

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
