### PR TITLE
Remove :owner and :repo, and rename :git_http_url and :git_http_userinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.33.0...HEAD)
 
+Breaking changes:
+
+- Remove :owner and :repo, and rename :git_http_url and :git_http_userinfo [#1411](https://github.com/sider/runners/pull/1411)
+
 ## 0.33.0
 
 [Full diff](https://github.com/sider/runners/compare/0.32.2...0.33.0)

--- a/lib/runners/options.rb
+++ b/lib/runners/options.rb
@@ -1,6 +1,6 @@
 module Runners
   class Options
-    GitSource = Struct.new(:head, :base, :git_http_url, :owner, :repo, :git_http_userinfo, :pull_number, keyword_init: true)
+    GitSource = Struct.new(:head, :base, :git_url, :git_url_userinfo, :pull_number, keyword_init: true)
 
     # @dynamic stdout, stderr, source, ssh_key, io
     attr_reader :stdout, :stderr, :source, :ssh_key, :io

--- a/lib/runners/schema/options.rb
+++ b/lib/runners/schema/options.rb
@@ -6,10 +6,8 @@ module Runners
       let :source, object?(
         head: string,
         base: string?,
-        git_http_url: string,
-        git_http_userinfo: string?,
-        owner: string,
-        repo: string,
+        git_url: string,
+        git_url_userinfo: string?,
         pull_number: number?,
       )
 

--- a/lib/runners/sensitive_filter.rb
+++ b/lib/runners/sensitive_filter.rb
@@ -21,7 +21,7 @@ module Runners
         source = @options.source
         if source.is_a?(Options::GitSource)
           # @type var source: Options::GitSource
-          user_info = source.git_http_userinfo
+          user_info = source.git_url_userinfo
           list << user_info if user_info
         end
         list

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -137,7 +137,7 @@ module Runners
         source = {
           head: head,
           base: base,
-          git_url: URI.join("file:///", (Pathname(project_dir) / 'smoke' / params.name).to_path).to_s,
+          git_url: URI.join("file:///", project_dir).to_s,
         }
         runners_options = JSON.dump({ source: source })
         commands = ["docker", "run"]

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -137,9 +137,7 @@ module Runners
         source = {
           head: head,
           base: base,
-          git_http_url: "file://#{project_dir}",
-          owner: "smoke",
-          repo: params.name,
+          git_url: URI.join("file:///", (Pathname(project_dir) / 'smoke' / params.name).to_path).to_s,
         }
         runners_options = JSON.dump({ source: source })
         commands = ["docker", "run"]

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -56,11 +56,6 @@ module Runners
     end
 
     def remote_url
-      # For smoke test
-      if git_source.git_url.start_with? "file://"
-        return URI(git_source.git_url)
-      end
-
       @remote_url ||= URI(git_source.git_url).tap do |uri|
         git_url_userinfo = git_source.git_url_userinfo
         uri.userinfo = git_url_userinfo if git_url_userinfo

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -57,13 +57,13 @@ module Runners
 
     def remote_url
       # For smoke test
-      if git_source.git_http_url.start_with? "file://"
-        return URI(git_source.git_http_url)
+      if git_source.git_url.start_with? "file://"
+        return URI(git_source.git_url)
       end
 
-      @remote_url ||= URI.join(git_source.git_http_url, "#{git_source.owner}/#{git_source.repo}").tap do |uri|
-        git_http_userinfo = git_source.git_http_userinfo
-        uri.userinfo = git_http_userinfo if git_http_userinfo
+      @remote_url ||= URI(git_source.git_url).tap do |uri|
+        git_url_userinfo = git_source.git_url_userinfo
+        uri.userinfo = git_url_userinfo if git_url_userinfo
       end
     end
 

--- a/sig/runners/options.rbi
+++ b/sig/runners/options.rbi
@@ -16,12 +16,10 @@ end
 class Runners::Options::GitSource
   attr_accessor head: String
   attr_accessor base: String?
-  attr_accessor git_http_url: String
-  attr_accessor owner: String
-  attr_accessor repo: String
-  attr_accessor git_http_userinfo: String?
+  attr_accessor git_url: String
+  attr_accessor git_url_userinfo: String?
   attr_accessor pull_number: Integer?
 
-  def initialize: (head: String, ?base: String, git_http_url: String,
-                   owner: String, repo: String, ?git_http_userinfo: String, ?pull_number: Integer) -> any
+  def initialize: (head: String, ?base: String, git_url: String,
+                   ?git_url_userinfo: String, ?pull_number: Integer) -> any
 end

--- a/sig_new/runners/options.rbs
+++ b/sig_new/runners/options.rbs
@@ -12,17 +12,13 @@ end
 class Runners::Options::GitSource
   attr_reader head: String
   attr_reader base: String?
-  attr_reader git_http_url: String
-  attr_reader owner: String
-  attr_reader repo: String
-  attr_reader git_http_userinfo: String?
+  attr_reader git_url: String
+  attr_reader git_url_userinfo: String?
   attr_reader pull_number: Integer?
 
   def initialize: (head: String,
                    ?base: String?,
-                   git_http_url: String,
-                   owner: String,
-                   repo: String,
-                   ?git_http_userinfo: String?,
+                   git_url: String,
+                   ?git_url_userinfo: String?,
                    ?pull_number: Integer?) -> void
 end

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -7,10 +7,8 @@ class OptionsTest < Minitest::Test
     source_params = {
       head: 'head_commit',
       base: 'base_commit',
-      git_http_url: 'https://github.com',
-      owner: 'foo',
-      repo: 'bar',
-      git_http_userinfo: 'user:secret',
+      git_url: 'https://github.com/foo/bar',
+      git_url_userinfo: 'user:secret',
       pull_number: 1234,
     }
     with_runners_options_env(source: source_params) do
@@ -23,10 +21,8 @@ class OptionsTest < Minitest::Test
   def test_options_git_source_without_base
     source_params = {
       head: 'head_commit',
-      git_http_url: 'https://github.com',
-      owner: 'foo',
-      repo: 'bar',
-      git_http_userinfo: 'user:secret',
+      git_url: 'https://github.com/foo/bar',
+      git_url_userinfo: 'user:secret',
       pull_number: 1234,
     }
     with_runners_options_env(source: source_params) do
@@ -40,15 +36,13 @@ class OptionsTest < Minitest::Test
     source_params = {
       head: 'head_commit',
       base: 'base',
-      git_http_url: 'https://github.com',
-      owner: 'foo',
-      repo: 'bar',
+      git_url: 'https://github.com/foo/bar',
       pull_number: 1234,
     }
     with_runners_options_env(source: source_params) do
       options = Runners::Options.new(stdout, stderr)
       assert_instance_of Runners::Options::GitSource, options.source
-      assert_equal source_params.merge(git_http_userinfo: nil), options.source.to_h
+      assert_equal source_params.merge(git_url_userinfo: nil), options.source.to_h
     end
   end
 
@@ -56,10 +50,8 @@ class OptionsTest < Minitest::Test
     source_params = {
       head: 'head_commit',
       base: 'base',
-      git_http_url: 'https://github.com',
-      owner: 'foo',
-      repo: 'bar',
-      git_http_userinfo: 'user:secret',
+      git_url: 'https://github.com/foo/bar',
+      git_url_userinfo: 'user:secret',
     }
     with_runners_options_env(source: source_params) do
       options = Runners::Options.new(stdout, stderr)

--- a/test/sensitive_filter_test.rb
+++ b/test/sensitive_filter_test.rb
@@ -12,10 +12,8 @@ class SensitiveFilterTest < Minitest::Test
     source = {
       head: "123abc",
       base: "456def",
-      git_http_url: "https://github.com",
-      owner: "foo",
-      repo: "bar",
-      git_http_userinfo: "user:secret",
+      git_url: "https://github.com/foo/bar",
+      git_url_userinfo: "user:secret",
       pull_number: 105,
     }
     with_runners_options_env(source: source) do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,9 +35,7 @@ module TestHelper
   def new_source(**source)
     {
       head: "6ba85479fc406a64b7202f7bc3ea8da3ada93084",
-      git_http_url: "https://github.com",
-      owner: "sider",
-      repo: "runners_test",
+      git_url: "https://github.com/sider/runners_test",
       **source,
     }
   end
@@ -77,10 +75,8 @@ module TestHelper
     source = {
       head: "123abc",
       base: "456def",
-      git_http_url: "https://github.com",
-      owner: "foo",
-      repo: "bar",
-      git_http_userinfo: "user:secret",
+      git_url: "https://github.com/foo/bar",
+      git_url_userinfo: "user:secret",
       pull_number: 105,
     }
     with_runners_options_env(source: source) do

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -38,6 +38,12 @@ class WorkspaceGitTest < Minitest::Test
     end
   end
 
+  def test_remote_url_with_file
+    with_workspace(git_url: 'file:///project/smoke/foo/bar') do |workspace|
+      assert_equal URI("file:///project/smoke/foo/bar"), workspace.send(:remote_url)
+    end
+  end
+
   def test_remote_url_with_token
     with_workspace(git_url_userinfo: "x-access-token:v1.aaabbbcccdddeeefffgggbc06400127f248a82ac") do |workspace|
       assert_equal URI("https://x-access-token:v1.aaabbbcccdddeeefffgggbc06400127f248a82ac@github.com/sider/runners_test"), workspace.send(:remote_url)

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -39,7 +39,7 @@ class WorkspaceGitTest < Minitest::Test
   end
 
   def test_remote_url_with_token
-    with_workspace(git_http_userinfo: "x-access-token:v1.aaabbbcccdddeeefffgggbc06400127f248a82ac") do |workspace|
+    with_workspace(git_url_userinfo: "x-access-token:v1.aaabbbcccdddeeefffgggbc06400127f248a82ac") do |workspace|
       assert_equal URI("https://x-access-token:v1.aaabbbcccdddeeefffgggbc06400127f248a82ac@github.com/sider/runners_test"), workspace.send(:remote_url)
     end
   end

--- a/test/workspace_test.rb
+++ b/test/workspace_test.rb
@@ -6,7 +6,7 @@ class WorkspaceTest < Minitest::Test
   Workspace = Runners::Workspace
 
   def test_prepare
-    with_runners_options_env(source: { head: "commit", git_http_url: "https://github.com", owner: "foo", repo: "bar" }) do
+    with_runners_options_env(source: { head: "commit", git_url: "https://github.com/foo/bar" }) do
       options = Runners::Options.new(StringIO.new, StringIO.new)
       filter = Runners::SensitiveFilter.new(options: options)
       workspace = Workspace.prepare(options: options, trace_writer: new_trace_writer(filter: filter), working_dir: Pathname("/"))


### PR DESCRIPTION
Runners assume the Git remote URL has one parent path and its child
path, such as `https://example.com/foo/project`. We call foo as an `owner`
and project as a `repo`, and they are used to construct a Git remote URL
here. As you know from these terms, we assumes the Git repositories are
on GitHub.

However, Runners can handle other Git repositories other than on GitHub,
such as GitLab. That's why this change made Runners handle the Git
remote URL fairly universal.

Now, `git_http_url` should be `git_url`, and `git_http_userinfo` should
be `git_url_user_info`.

Close #1403

To-Do

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) and explains this is a braking change