### PR TITLE
Replace :pull_number with :refspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 Breaking changes:
 
 - Remove :owner and :repo, and rename :git_http_url and :git_http_userinfo [#1411](https://github.com/sider/runners/pull/1411)
+- Replace :pull_number with :refspecs [#1412](https://github.com/sider/runners/pull/1412)
 
 ## 0.33.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 Breaking changes:
 
 - Remove :owner and :repo, and rename :git_http_url and :git_http_userinfo [#1411](https://github.com/sider/runners/pull/1411)
-- Replace :pull_number with :refspecs [#1412](https://github.com/sider/runners/pull/1412)
+- Replace :pull_number with :refspec [#1412](https://github.com/sider/runners/pull/1412)
 
 ## 0.33.0
 

--- a/lib/runners/options.rb
+++ b/lib/runners/options.rb
@@ -1,6 +1,6 @@
 module Runners
   class Options
-    GitSource = Struct.new(:head, :base, :git_url, :git_url_userinfo, :refspecs, keyword_init: true)
+    GitSource = Struct.new(:head, :base, :git_url, :git_url_userinfo, :refspec, keyword_init: true)
 
     # @dynamic stdout, stderr, source, ssh_key, io
     attr_reader :stdout, :stderr, :source, :ssh_key, :io

--- a/lib/runners/options.rb
+++ b/lib/runners/options.rb
@@ -1,6 +1,6 @@
 module Runners
   class Options
-    GitSource = Struct.new(:head, :base, :git_url, :git_url_userinfo, :pull_number, keyword_init: true)
+    GitSource = Struct.new(:head, :base, :git_url, :git_url_userinfo, :refspecs, keyword_init: true)
 
     # @dynamic stdout, stderr, source, ssh_key, io
     attr_reader :stdout, :stderr, :source, :ssh_key, :io

--- a/lib/runners/schema/options.rb
+++ b/lib/runners/schema/options.rb
@@ -8,7 +8,7 @@ module Runners
         base: string?,
         git_url: string,
         git_url_userinfo: string?,
-        pull_number: number?,
+        refspecs: array?(string),
       )
 
       let :payload, object(

--- a/lib/runners/schema/options.rb
+++ b/lib/runners/schema/options.rb
@@ -8,7 +8,7 @@ module Runners
         base: string?,
         git_url: string,
         git_url_userinfo: string?,
-        refspecs: array?(string),
+        refspec: enum?(string, array(string)),
       )
 
       let :payload, object(

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -63,12 +63,14 @@ module Runners
     end
 
     def git_fetch_args
-      @git_fetch_args ||= %w[--quiet --no-tags --no-recurse-submodules origin].tap do |command|
-        command << "+refs/heads/*:refs/remotes/origin/*"
-
-        refspecs = git_source.refspecs
-        refspecs.each { |refspec| command << refspec } if refspecs
-      end
+      @git_fetch_args ||= [
+        '--quiet',
+        '--no-tags',
+        '--no-recurse-submodules',
+        'origin',
+        '+refs/heads/*:refs/remotes/origin/*',
+        *Array(git_source.refspec),
+      ]
     end
 
     def patches

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -70,7 +70,7 @@ module Runners
         'origin',
         '+refs/heads/*:refs/remotes/origin/*',
         *Array(git_source.refspec),
-      ]
+      ].freeze
     end
 
     def patches

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -66,8 +66,8 @@ module Runners
       @git_fetch_args ||= %w[--quiet --no-tags --no-recurse-submodules origin].tap do |command|
         command << "+refs/heads/*:refs/remotes/origin/*"
 
-        num = git_source.pull_number
-        command << "+refs/pull/#{num}/head:refs/remotes/pull/#{num}/head" if num
+        refspecs = git_source.refspecs
+        refspecs.each { command << _1 } if refspecs
       end
     end
 

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -67,7 +67,7 @@ module Runners
         command << "+refs/heads/*:refs/remotes/origin/*"
 
         refspecs = git_source.refspecs
-        refspecs.each { command << _1 } if refspecs
+        refspecs.each { |refspec| command << refspec } if refspecs
       end
     end
 

--- a/sig/runners/options.rbi
+++ b/sig/runners/options.rbi
@@ -18,8 +18,8 @@ class Runners::Options::GitSource
   attr_accessor base: String?
   attr_accessor git_url: String
   attr_accessor git_url_userinfo: String?
-  attr_accessor pull_number: Integer?
+  attr_accessor refspecs: Array<String>?
 
   def initialize: (head: String, ?base: String, git_url: String,
-                   ?git_url_userinfo: String, ?pull_number: Integer) -> any
+                   ?git_url_userinfo: String, ?refspecs: Array<String>) -> any
 end

--- a/sig/runners/options.rbi
+++ b/sig/runners/options.rbi
@@ -18,8 +18,8 @@ class Runners::Options::GitSource
   attr_accessor base: String?
   attr_accessor git_url: String
   attr_accessor git_url_userinfo: String?
-  attr_accessor refspecs: Array<String>?
+  attr_accessor refspec: (Array<String>? | String?)
 
   def initialize: (head: String, ?base: String, git_url: String,
-                   ?git_url_userinfo: String, ?refspecs: Array<String>) -> any
+                   ?git_url_userinfo: String, ?refspec: Array<String> | String) -> any
 end

--- a/sig_new/runners/options.rbs
+++ b/sig_new/runners/options.rbs
@@ -14,11 +14,11 @@ class Runners::Options::GitSource
   attr_reader base: String?
   attr_reader git_url: String
   attr_reader git_url_userinfo: String?
-  attr_reader pull_number: Integer?
+  attr_reader refspecs: Array[String]?
 
   def initialize: (head: String,
                    ?base: String?,
                    git_url: String,
                    ?git_url_userinfo: String?,
-                   ?pull_number: Integer?) -> void
+                   ?refspecs: Array[String]?) -> void
 end

--- a/sig_new/runners/options.rbs
+++ b/sig_new/runners/options.rbs
@@ -14,11 +14,11 @@ class Runners::Options::GitSource
   attr_reader base: String?
   attr_reader git_url: String
   attr_reader git_url_userinfo: String?
-  attr_reader refspecs: Array[String]?
+  attr_reader refspec: (Array[String] | String)?
 
   def initialize: (head: String,
                    ?base: String?,
                    git_url: String,
                    ?git_url_userinfo: String?,
-                   ?refspecs: Array[String]?) -> void
+                   ?refspec: (Array[String] | String)?) -> void
 end

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -9,10 +9,7 @@ class OptionsTest < Minitest::Test
       base: 'base_commit',
       git_url: 'https://github.com/foo/bar',
       git_url_userinfo: 'user:secret',
-      refspecs: [
-        "+refs/pull/1234/head:refs/remotes/pull/1234/head",
-        "+refs/foo/1234/head:refs/remotes/foo/1234/head",
-      ],
+      refspec: "+refs/pull/1234/head:refs/remotes/pull/1234/head",
     }
     with_runners_options_env(source: source_params) do
       options = Runners::Options.new(stdout, stderr)
@@ -26,10 +23,7 @@ class OptionsTest < Minitest::Test
       head: 'head_commit',
       git_url: 'https://github.com/foo/bar',
       git_url_userinfo: 'user:secret',
-      refspecs: [
-        "+refs/pull/1234/head:refs/remotes/pull/1234/head",
-        "+refs/foo/1234/head:refs/remotes/foo/1234/head",
-      ],
+      refspec: "+refs/pull/1234/head:refs/remotes/pull/1234/head",
     }
     with_runners_options_env(source: source_params) do
       options = Runners::Options.new(stdout, stderr)
@@ -43,10 +37,7 @@ class OptionsTest < Minitest::Test
       head: 'head_commit',
       base: 'base',
       git_url: 'https://github.com/foo/bar',
-      refspecs: [
-        "+refs/pull/1234/head:refs/remotes/pull/1234/head",
-        "+refs/foo/1234/head:refs/remotes/foo/1234/head",
-      ],
+      refspec: "+refs/pull/1234/head:refs/remotes/pull/1234/head",
     }
     with_runners_options_env(source: source_params) do
       options = Runners::Options.new(stdout, stderr)
@@ -65,7 +56,7 @@ class OptionsTest < Minitest::Test
     with_runners_options_env(source: source_params) do
       options = Runners::Options.new(stdout, stderr)
       assert_instance_of Runners::Options::GitSource, options.source
-      assert_equal source_params.merge(refspecs: nil), options.source.to_h
+      assert_equal source_params.merge(refspec: nil), options.source.to_h
     end
   end
 

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -9,7 +9,10 @@ class OptionsTest < Minitest::Test
       base: 'base_commit',
       git_url: 'https://github.com/foo/bar',
       git_url_userinfo: 'user:secret',
-      pull_number: 1234,
+      refspecs: [
+        "+refs/pull/1234/head:refs/remotes/pull/1234/head",
+        "+refs/foo/1234/head:refs/remotes/foo/1234/head",
+      ],
     }
     with_runners_options_env(source: source_params) do
       options = Runners::Options.new(stdout, stderr)
@@ -23,7 +26,10 @@ class OptionsTest < Minitest::Test
       head: 'head_commit',
       git_url: 'https://github.com/foo/bar',
       git_url_userinfo: 'user:secret',
-      pull_number: 1234,
+      refspecs: [
+        "+refs/pull/1234/head:refs/remotes/pull/1234/head",
+        "+refs/foo/1234/head:refs/remotes/foo/1234/head",
+      ],
     }
     with_runners_options_env(source: source_params) do
       options = Runners::Options.new(stdout, stderr)
@@ -37,7 +43,10 @@ class OptionsTest < Minitest::Test
       head: 'head_commit',
       base: 'base',
       git_url: 'https://github.com/foo/bar',
-      pull_number: 1234,
+      refspecs: [
+        "+refs/pull/1234/head:refs/remotes/pull/1234/head",
+        "+refs/foo/1234/head:refs/remotes/foo/1234/head",
+      ],
     }
     with_runners_options_env(source: source_params) do
       options = Runners::Options.new(stdout, stderr)
@@ -46,7 +55,7 @@ class OptionsTest < Minitest::Test
     end
   end
 
-  def test_options_git_source_without_pull_number
+  def test_options_git_source_without_refspecs
     source_params = {
       head: 'head_commit',
       base: 'base',
@@ -56,7 +65,7 @@ class OptionsTest < Minitest::Test
     with_runners_options_env(source: source_params) do
       options = Runners::Options.new(stdout, stderr)
       assert_instance_of Runners::Options::GitSource, options.source
-      assert_equal source_params.merge(pull_number: nil), options.source.to_h
+      assert_equal source_params.merge(refspecs: nil), options.source.to_h
     end
   end
 

--- a/test/sensitive_filter_test.rb
+++ b/test/sensitive_filter_test.rb
@@ -14,7 +14,6 @@ class SensitiveFilterTest < Minitest::Test
       base: "456def",
       git_url: "https://github.com/foo/bar",
       git_url_userinfo: "user:secret",
-      pull_number: 105,
     }
     with_runners_options_env(source: source) do
       filter = new_filter

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -77,7 +77,7 @@ module TestHelper
       base: "456def",
       git_url: "https://github.com/foo/bar",
       git_url_userinfo: "user:secret",
-      pull_number: 105,
+      refspecs: ["+refs/pull/1234/head:refs/remotes/pull/1234/head"],
     }
     with_runners_options_env(source: source) do
       options = Runners::Options.new(StringIO.new, StringIO.new)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -77,7 +77,7 @@ module TestHelper
       base: "456def",
       git_url: "https://github.com/foo/bar",
       git_url_userinfo: "user:secret",
-      refspecs: ["+refs/pull/1234/head:refs/remotes/pull/1234/head"],
+      refspec: "+refs/pull/1234/head:refs/remotes/pull/1234/head",
     }
     with_runners_options_env(source: source) do
       options = Runners::Options.new(StringIO.new, StringIO.new)

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -51,7 +51,7 @@ class WorkspaceGitTest < Minitest::Test
   end
 
   def test_git_fetch_args
-    with_workspace(refspecs: ["+refs/pull/533/head:refs/remotes/pull/533/head"]) do |workspace|
+    with_workspace(refspec: "+refs/pull/533/head:refs/remotes/pull/533/head") do |workspace|
       assert_equal %w[
         --quiet --no-tags --no-recurse-submodules origin
         +refs/heads/*:refs/remotes/origin/*
@@ -61,7 +61,7 @@ class WorkspaceGitTest < Minitest::Test
   end
 
   def test_git_fetch_args_with_multiple_refspecs
-    with_workspace(refspecs: ["+refs/pull/533/head:refs/remotes/pull/533/head", "+refs/foo/533/head:refs/remotes/foo/533/head"]) do |workspace|
+    with_workspace(refspec: ["+refs/pull/533/head:refs/remotes/pull/533/head", "+refs/foo/533/head:refs/remotes/foo/533/head"]) do |workspace|
       assert_equal %w[
         --quiet --no-tags --no-recurse-submodules origin
         +refs/heads/*:refs/remotes/origin/*
@@ -134,7 +134,7 @@ class WorkspaceGitTest < Minitest::Test
   end
 
   def test_git_fetch_failed
-    with_workspace(refspecs: ["+refs/pull/999999999/head:refs/remotes/pull/999999999/head"]) do |workspace|
+    with_workspace(refspec: "+refs/pull/999999999/head:refs/remotes/pull/999999999/head") do |workspace|
       error = assert_raises(Runners::Workspace::Git::FetchFailed) do
         workspace.prepare_head_source
       end

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -51,7 +51,7 @@ class WorkspaceGitTest < Minitest::Test
   end
 
   def test_git_fetch_args
-    with_workspace(pull_number: 533) do |workspace|
+    with_workspace(refspecs: ["+refs/pull/533/head:refs/remotes/pull/533/head"]) do |workspace|
       assert_equal %w[
         --quiet --no-tags --no-recurse-submodules origin
         +refs/heads/*:refs/remotes/origin/*
@@ -60,7 +60,18 @@ class WorkspaceGitTest < Minitest::Test
     end
   end
 
-  def test_git_fetch_args_without_pull_number
+  def test_git_fetch_args_with_multiple_refspecs
+    with_workspace(refspecs: ["+refs/pull/533/head:refs/remotes/pull/533/head", "+refs/foo/533/head:refs/remotes/foo/533/head"]) do |workspace|
+      assert_equal %w[
+        --quiet --no-tags --no-recurse-submodules origin
+        +refs/heads/*:refs/remotes/origin/*
+        +refs/pull/533/head:refs/remotes/pull/533/head
+        +refs/foo/533/head:refs/remotes/foo/533/head
+      ], workspace.send(:git_fetch_args)
+    end
+  end
+
+  def test_git_fetch_args_without_refspaces
     with_workspace do |workspace|
       assert_equal %w[
         --quiet --no-tags --no-recurse-submodules origin
@@ -123,7 +134,7 @@ class WorkspaceGitTest < Minitest::Test
   end
 
   def test_git_fetch_failed
-    with_workspace(pull_number: 999999999) do |workspace|
+    with_workspace(refspecs: ["+refs/pull/999999999/head:refs/remotes/pull/999999999/head"]) do |workspace|
       error = assert_raises(Runners::Workspace::Git::FetchFailed) do
         workspace.prepare_head_source
       end


### PR DESCRIPTION
This change allows analyses for any Git repositories with additional refspecs. The previous implementation assumes that the Git repositories are on GitHub, so it had prepared the `:pull_number` parameter to construct an additional refspec. We should support other platforms, such as GitLab. So, Runners will receive the new parameter `:refspecs`. From
this change, the Runners users should construct refspecs by themselves and pass them to Runners.

Close #1395

To-Do:

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) as it contains a breaking change
