### PR TITLE
Unify `S3_ENDPOINT` to `RUNNERS_OPTIONS` (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking changes:
 
 - Remove :owner and :repo, and rename :git_http_url and :git_http_userinfo [#1411](https://github.com/sider/runners/pull/1411)
 - Replace :pull_number with :refspec [#1412](https://github.com/sider/runners/pull/1412)
+- Unify `S3_ENDPOINT` to `RUNNERS_OPTIONS` [#1414](https://github.com/sider/runners/pull/1414)
 
 ## 0.33.0
 

--- a/lib/runners/io/aws_s3.rb
+++ b/lib/runners/io/aws_s3.rb
@@ -19,7 +19,7 @@ module Runners
 
     attr_reader :uri, :bucket_name, :object_name, :tempfile, :written_items, :client
 
-    def initialize(uri)
+    def initialize(uri, endpoint: nil)
       @uri = uri
       @bucket_name, @object_name = self.class.parse_s3_uri!(uri)
       @tempfile = Tempfile.new
@@ -31,8 +31,8 @@ module Runners
         instance_profile_credentials_retries: 5,
         instance_profile_credentials_timeout: 3,
       }
-      if ENV["S3_ENDPOINT"]
-        args[:endpoint] = ENV["S3_ENDPOINT"]
+      if endpoint
+        args[:endpoint] = endpoint
         args[:force_path_style] = true
       end
       @client = Aws::S3::Client.new(**args)

--- a/lib/runners/options.rb
+++ b/lib/runners/options.rb
@@ -23,7 +23,7 @@ module Runners
                 when 'stderr'
                   stderr
                 when /^s3:/
-                  Runners::IO::AwsS3.new(output)
+                  Runners::IO::AwsS3.new(output, endpoint: options.dig(:s3, :endpoint))
                 else
                   raise "Invalid output option. You included '#{output}'"
                 end

--- a/lib/runners/schema/options.rb
+++ b/lib/runners/schema/options.rb
@@ -15,6 +15,7 @@ module Runners
         source: source,
         outputs: array?(string),
         ssh_key: string?,
+        s3: object?(endpoint: string),
       )
     end
   end

--- a/sig/runners/schema/options.rbi
+++ b/sig/runners/schema/options.rbi
@@ -12,10 +12,15 @@ type Runners::Schema::Types::source_head_only = {
 
 type Runners::Schema::Types::source = source_full | source_head_only
 
+type Runners::Schema::Types::s3 = {
+  endpoint: String
+}
+
 class Runners::Schema::Types::Options < StrongJSON
   def source: -> StrongJSON::Type::Enum<source>
   def outputs: -> StrongJSON::Type::Array<String>?
   def ssh_key: -> String?
+  def s3: -> StrongJSON::Type::Object<s3>?
 end
 
 Runners::Schema::Options: Runners::Schema::Types::Options

--- a/test/io/aws_s3_test.rb
+++ b/test/io/aws_s3_test.rb
@@ -4,20 +4,18 @@ class AwsS3Test < Minitest::Test
   include TestHelper
 
   def test_initialize
-    with_stubbed_env('S3_ENDPOINT', nil) do
-      mock(Aws::S3::Client).new(retry_limit: is_a(Numeric), retry_base_delay: is_a(Numeric),
-                                instance_profile_credentials_retries: is_a(Numeric),
-                                instance_profile_credentials_timeout: is_a(Numeric))
-      Runners::IO::AwsS3.new('s3://bucket_name/object_name')
-    end
+    mock(Aws::S3::Client).new(retry_limit: is_a(Numeric), retry_base_delay: is_a(Numeric),
+                              instance_profile_credentials_retries: is_a(Numeric),
+                              instance_profile_credentials_timeout: is_a(Numeric))
+    Runners::IO::AwsS3.new('s3://bucket_name/object_name')
+  end
 
-    with_stubbed_env('S3_ENDPOINT', 'https://s3.example.com') do
-      mock(Aws::S3::Client).new(retry_limit: is_a(Numeric), retry_base_delay: is_a(Numeric),
-                                instance_profile_credentials_retries: is_a(Numeric),
-                                instance_profile_credentials_timeout: is_a(Numeric),
-                                endpoint: 'https://s3.example.com', force_path_style: true)
-      Runners::IO::AwsS3.new('s3://bucket_name/object_name')
-    end
+  def test_initialize_with_endpoint
+    mock(Aws::S3::Client).new(retry_limit: is_a(Numeric), retry_base_delay: is_a(Numeric),
+                              instance_profile_credentials_retries: is_a(Numeric),
+                              instance_profile_credentials_timeout: is_a(Numeric),
+                              endpoint: 'https://s3.example.com', force_path_style: true)
+    Runners::IO::AwsS3.new('s3://bucket_name/object_name', endpoint: 'https://s3.example.com')
   end
 
   def test_parse_s3_uri

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -88,7 +88,7 @@ class OptionsTest < Minitest::Test
       stub(s3_mock).write
       stub(s3_mock).flush
       stub(s3_mock).flush!
-      mock(Runners::IO::AwsS3).new("s3://bucket/abc") { s3_mock }
+      mock(Runners::IO::AwsS3).new("s3://bucket/abc", endpoint: nil) { s3_mock }
       mock.proxy(Runners::IO).new(stdout, s3_mock)
 
       options = Runners::Options.new(stdout, stderr)


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change removes `ENV["S3_ENDPOINT"]` and unifies it to `ENV["RUNNERS_OPTIONS"]`:

E.g.

```ruby
RUNNERS_OPTIONS = {
  # ...
  S3: { endpoint: "https://s3.endpoint.com/" }
}
```

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

Fix #1413

> Check the following items (please remove needless items).

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
