### PR TITLE
Refactor `Runners::Process#read_report_xml` method

### DIFF
--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -258,13 +258,13 @@ module Runners
 
     def read_report_xml(file_path = report_file)
       output = read_report_file(file_path)
-      REXML::Document.new(output).tap do |document|
-        unless document.root
-          message = "Output XML is invalid from #{file_path}"
-          trace_writer.error message
-          raise InvalidXML, message
-        end
+      root = REXML::Document.new(output).root
+      unless root
+        message = "Output XML is invalid from #{file_path}"
+        trace_writer.error message
+        raise InvalidXML, message
       end
+      root
     end
 
     def read_report_json(file_path = report_file)

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -259,12 +259,13 @@ module Runners
     def read_report_xml(file_path = report_file)
       output = read_report_file(file_path)
       root = REXML::Document.new(output).root
-      unless root
+      if root
+        root
+      else
         message = "Output XML is invalid from #{file_path}"
         trace_writer.error message
         raise InvalidXML, message
       end
-      root
     end
 
     def read_report_json(file_path = report_file)

--- a/lib/runners/processor/detekt.rb
+++ b/lib/runners/processor/detekt.rb
@@ -102,7 +102,7 @@ module Runners
     end
 
     def parse_output
-      read_report_xml.root.each_element("file") do |file|
+      read_report_xml.each_element("file") do |file|
         file.each_element do |error|
           case error.name
           when "error"

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -103,7 +103,7 @@ module Runners
       end
 
       begin
-        xml_doc = read_report_xml
+        xml_root = read_report_xml
       rescue REXML::ParseException => exn
         trace_writer.error exn.message
         return Results::Failure.new(guid: guid, analyzer: analyzer,
@@ -112,7 +112,7 @@ module Runners
 
       change_paths = changes.changed_paths
       errors = []
-      xml_doc.root.each_element('error') do |error|
+      xml_root.each_element('error') do |error|
         errors << error[:msg] if change_paths.include?(relative_path(error[:filename]))
       end
       unless errors.empty?

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -121,7 +121,7 @@ module Runners
       end
 
       Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
-        xml_doc.root.each_element('file') do |file|
+        xml_root.each_element('file') do |file|
           path = relative_path(file[:name])
 
           file.each_element('violation') do |violation|

--- a/lib/runners/processor/pmd_java.rb
+++ b/lib/runners/processor/pmd_java.rb
@@ -87,7 +87,7 @@ module Runners
     def construct_result(xml)
       # https://github.com/pmd/pmd.github.io/blob/8b0c31ff8e18215ed213b7df400af27b9137ee67/report_2_0_0.xsd
 
-      xml.root.each_element do |element|
+      xml.each_element do |element|
         case element.name
         when "file"
           path = relative_path(element[:name])

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -152,7 +152,7 @@ class Runners::Processor
   def report_file: -> String
   def report_file_exist?: -> bool
   def read_report_file: (?String) -> String
-  def read_report_xml: (?String) -> REXML::Element
+  def read_report_xml: (?String) -> untyped
   def read_report_json: <'x> (?String) { () -> 'x } -> (Hash<Symbol, any> | 'x)
   def comma_separated_list: (String | Array<String> | nil) -> String?
 end

--- a/sig/runners.rbi
+++ b/sig/runners.rbi
@@ -152,7 +152,7 @@ class Runners::Processor
   def report_file: -> String
   def report_file_exist?: -> bool
   def read_report_file: (?String) -> String
-  def read_report_xml: (?String) -> REXML::Document
+  def read_report_xml: (?String) -> REXML::Element
   def read_report_json: <'x> (?String) { () -> 'x } -> (Hash<Symbol, any> | 'x)
   def comma_separated_list: (String | Array<String> | nil) -> String?
 end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -489,7 +489,9 @@ class ProcessorTest < Minitest::Test
       file = (workspace.working_dir / "a_file.xml").tap { |f| f.write "<foo></foo>" }.then(&:to_path)
 
       processor = new_processor(workspace: workspace)
-      assert_instance_of REXML::Document, processor.read_report_xml(file)
+      root = processor.read_report_xml(file)
+      assert_instance_of REXML::Element, root
+      assert_equal "<foo/>", root.to_s
     end
   end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring changes the return type of the `Runners::Process#read_report_xml` method
from `REXML::Document` to `REXML::Element` (the root element).

This makes the code simpler.

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

None.
