### PR TITLE
Refactor value classes

### DIFF
--- a/lib/runners/git_blame_info.rb
+++ b/lib/runners/git_blame_info.rb
@@ -28,6 +28,11 @@ module Runners
         final_line == other.final_line &&
         line_hash == other.line_hash
     end
+    alias eql? ==
+
+    def hash
+      commit.hash ^ original_line.hash ^ final_line.hash ^ line_hash.hash
+    end
 
     def as_json
       {

--- a/lib/runners/git_blame_info.rb
+++ b/lib/runners/git_blame_info.rb
@@ -1,5 +1,5 @@
 module Runners
-  GitBlameInfo = Struct.new(:commit, :original_line, :final_line, :line_hash, keyword_init: true) do
+  class GitBlameInfo
     # @param porcelain_output [String] The output of git-blame(1) with -p option
     # @see https://www.git-scm.com/docs/git-blame#_the_porcelain_format
     def self.parse(porcelain_output)
@@ -10,6 +10,32 @@ module Runners
         commit, original_line, final_line, content = item.flatten
         new(commit: commit, original_line: Integer(original_line), final_line: Integer(final_line), line_hash: Digest::SHA1.hexdigest(content))
       end
+    end
+
+    attr_reader :commit, :original_line, :final_line, :line_hash
+
+    def initialize(commit:, original_line:, final_line:, line_hash:)
+      @commit = commit
+      @original_line = original_line
+      @final_line = final_line
+      @line_hash = line_hash
+    end
+
+    def ==(other)
+      self.class == other.class &&
+        commit == other.commit &&
+        original_line == other.original_line &&
+        final_line == other.final_line &&
+        line_hash == other.line_hash
+    end
+
+    def as_json
+      {
+        commit: commit,
+        original_line: original_line,
+        final_line: final_line,
+        line_hash: line_hash,
+      }
     end
   end
 end

--- a/lib/runners/issue.rb
+++ b/lib/runners/issue.rb
@@ -25,6 +25,7 @@ module Runners
       @message = message
       @links = links
       @object = object
+      @git_blame_info = nil
     end
 
     def missing_id?
@@ -38,7 +39,8 @@ module Runners
         other.id == id &&
         other.message == message &&
         other.links == links &&
-        other.object == object
+        other.object == object &&
+        other.git_blame_info == git_blame_info
     end
     alias eql? ==
 
@@ -54,7 +56,7 @@ module Runners
         message: message,
         links: links,
         object: object,
-        git_blame_info: git_blame_info&.to_h,
+        git_blame_info: git_blame_info&.as_json,
       })
     end
 

--- a/lib/runners/location.rb
+++ b/lib/runners/location.rb
@@ -25,31 +25,17 @@ module Runners
       start_line.hash ^ start_column.hash ^ end_line.hash ^ end_column.hash
     end
 
-    def self.from_json(json)
-      self.new(start_line: json[:start_line],
-               start_column: json[:start_column],
-               end_line: json[:end_line],
-               end_column: json[:end_column])
-    end
-
     def as_json
-      # @type _: Hash<json_key, Integer>
-      @as_json ||= _ = Schema::Issue.location.coerce({
+      {
         start_line: start_line,
         start_column: start_column,
         end_line: end_line,
         end_column: end_column,
-      }.compact)
+      }.compact
     end
 
     def to_s
-      attrs = %W[
-        start_line=#{start_line.inspect}
-        start_column=#{start_column.inspect}
-        end_line=#{end_line.inspect}
-        end_column=#{end_column.inspect}
-      ].join(", ")
-      "{ #{attrs} }"
+      "{ start_line: #{start_line.inspect}, start_column: #{start_column.inspect}, end_line: #{end_line.inspect}, end_column: #{end_column.inspect} }"
     end
   end
 end

--- a/lib/runners/location.rb
+++ b/lib/runners/location.rb
@@ -35,7 +35,7 @@ module Runners
     end
 
     def to_s
-      "{ start_line: #{start_line.inspect}, start_column: #{start_column.inspect}, end_line: #{end_line.inspect}, end_column: #{end_column.inspect} }"
+      "{ start_line=#{start_line.inspect}, start_column=#{start_column.inspect}, end_line=#{end_line.inspect}, end_column=#{end_column.inspect} }"
     end
   end
 end

--- a/sig/runners/git_blame_info.rbi
+++ b/sig/runners/git_blame_info.rbi
@@ -6,5 +6,5 @@ class Runners::GitBlameInfo
 
   def self.parse: (String) -> Array<instance>
   def initialize: (commit: String, original_line: Integer, final_line: Integer, line_hash: String) -> any
-  def to_h: () -> Hash<Symbol, any>
+  def as_json: () -> Hash<Symbol, any>
 end

--- a/sig/runners/location.rbi
+++ b/sig/runners/location.rbi
@@ -1,5 +1,3 @@
-type Runners::Location::json_key = :start_line | :start_column | :end_line | :end_column
-
 class Runners::Location
   attr_reader start_line: Integer?
   attr_reader start_column: Integer?
@@ -10,12 +8,5 @@ class Runners::Location
                    ?start_column: Integer | String | nil,
                    ?end_line: Integer | String | nil,
                    ?end_column: Integer | String | nil) -> void
-  def as_json: -> Hash<json_key, Integer>
-  def self.from_json: (any) -> Location
-end
-
-class Runners::Location::InvalidLocationError < StandardError
-  attr_reader location: Location
-
-  def initialize: (location: Location) -> any
+  def as_json: -> any
 end

--- a/test/git_blame_info_test.rb
+++ b/test/git_blame_info_test.rb
@@ -55,7 +55,7 @@ cb1af575f65f7cc49668b891fb34a5df692d3a0e 14 8
     )
   end
 
-  def test_to_h
+  def test_as_json
     info = GitBlameInfo.new(commit: "cb1af575f65f7cc49668b891fb34a5df692d3a0e", original_line: 13, final_line: 7, line_hash: "a5f52a5e0847c750ab9f24cc5ee4e8aa0b6dfc1d")
     assert_equal(
       {
@@ -64,7 +64,7 @@ cb1af575f65f7cc49668b891fb34a5df692d3a0e 14 8
         final_line: 7,
         line_hash: "a5f52a5e0847c750ab9f24cc5ee4e8aa0b6dfc1d",
       },
-      info.to_h,
+      info.as_json,
     )
   end
 end

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -20,11 +20,11 @@ class LocationTest < Minitest::Test
 
   def test_to_s
     assert_equal(
-      "{ start_line: 1, start_column: 2, end_line: 3, end_column: 4 }",
+      "{ start_line=1, start_column=2, end_line=3, end_column=4 }",
       Location.new(start_line: 1, start_column: 2, end_line: 3, end_column: 4).to_s,
     )
     assert_equal(
-      "{ start_line: 1, start_column: nil, end_line: nil, end_column: nil }",
+      "{ start_line=1, start_column=nil, end_line=nil, end_column=nil }",
       Location.new(start_line: 1).to_s,
     )
   end

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -4,15 +4,28 @@ class LocationTest < Minitest::Test
   Location = Runners::Location
 
   def test_as_json
-    loc = Location.new(start_line: 1, start_column: 1, end_line: 3, end_column: 2)
-    assert_equal({ start_line: 1, start_column: 1, end_line: 3, end_column: 2 }, loc.as_json)
-
-    loc = Location.new(start_line: 1, start_column: nil, end_line: 3, end_column: nil)
-    assert_equal({ start_line: 1, end_line: 3 }, loc.as_json)
+    assert_equal(
+      { start_line: 1, start_column: 2, end_line: 3, end_column: 4 },
+      Location.new(start_line: 1, start_column: 2, end_line: 3, end_column: 4).as_json,
+    )
+    assert_equal(
+      { start_line: 1, end_line: 3 },
+      Location.new(start_line: 1, start_column: nil, end_line: 3, end_column: nil).as_json,
+    )
+    assert_equal(
+      { start_line: 1 },
+      Location.new(start_line: 1).as_json,
+    )
   end
 
-  def test_from_json
-    assert_equal Location.new(start_line: 1, start_column: nil, end_line: 3, end_column: nil),
-                 Location.from_json({ start_line: 1, end_line: 3 })
+  def test_to_s
+    assert_equal(
+      "{ start_line: 1, start_column: 2, end_line: 3, end_column: 4 }",
+      Location.new(start_line: 1, start_column: 2, end_line: 3, end_column: 4).to_s,
+    )
+    assert_equal(
+      "{ start_line: 1, start_column: nil, end_line: nil, end_column: nil }",
+      Location.new(start_line: 1).to_s,
+    )
   end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- Stop using `Struct` in the `GitBlameInfo` class for better type-checking (See #1215)
- Remove the unused `Location.from_json` method
- Fix some trivial bugs

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

See also #1215
