### PR TITLE
Replace PAT with GitHub App token

### DIFF
--- a/.github/workflows/bump_analyzers.yml
+++ b/.github/workflows/bump_analyzers.yml
@@ -18,9 +18,14 @@ jobs:
           gem install bundler --no-document
           bundle config set path vendor/bundle
           bundle install --jobs=4 --retry=3
+      - uses: tibdex/github-app-token@v1
+        id: generate_token
+        with:
+          app_id: ${{ secrets.SIDER_INTERNAL_BOT_APP_ID }}
+          private_key: ${{ secrets.SIDER_INTERNAL_BOT_PRIVATE_KEY }}
       - run: |
           bundle exec rake bump:analyzers
         env:
-          GITHUB_TOKEN: ${{ secrets.SIDERBOT_PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           GITHUB_AUTHOR_NAME: GitHub Actions
           GITHUB_AUTHOR_EMAIL: actions@github.com


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The Personal Access Token (PAT) is insecure, so this change replaces the PAT token with a more secure token of our internal GitHub App.

See <https://github.com/tibdex/github-app-token>

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

None.
