### PR TITLE
[Cppcheck] Run multiple threads with the `-j` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.34.1...HEAD)
 
+- **Cppcheck** Run multiple threads with the `-j` option [#1462](https://github.com/sider/runners/pull/1462)
+
 ## 0.34.1
 
 [Full diff](https://github.com/sider/runners/compare/0.34.0...0.34.1)
 
 - Reconsider `Results::Failure` message [#1459](https://github.com/sider/runners/pull/1459)
-- **Cppcheck** Run multiple threads with the `-j` option [#1462](https://github.com/sider/runners/pull/1462)
 
 ## 0.34.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.34.0...HEAD)
 
 - Reconsider `Results::Failure` message [#1459](https://github.com/sider/runners/pull/1459)
+- **Cppcheck** Run multiple threads with the `-j` option [#1462](https://github.com/sider/runners/pull/1462)
 
 ## 0.34.0
 

--- a/lib/runners/processor/cppcheck.rb
+++ b/lib/runners/processor/cppcheck.rb
@@ -18,7 +18,7 @@ module Runners
           project: string?,
           language: string?,
           'bug-hunting': boolean?,
-          parallel: boolean?
+          parallel: boolean?,
         )
       }
 
@@ -105,7 +105,6 @@ module Runners
     def step_analyzer(*args)
       stdout, stderr, status = capture3(
         analyzer_bin,
-        *jobs,
         "--quiet",
         "--xml",
         "--output-file=#{report_file}",
@@ -113,6 +112,7 @@ module Runners
         *project,
         *language,
         *config_include_path,
+        *jobs,
         *args,
         *target
       )

--- a/lib/runners/processor/cppcheck.rb
+++ b/lib/runners/processor/cppcheck.rb
@@ -1,3 +1,5 @@
+require "etc"
+
 module Runners
   class Processor::Cppcheck < Processor
     include CPlusPlus
@@ -98,6 +100,7 @@ module Runners
     def step_analyzer(*args)
       stdout, stderr, status = capture3(
         analyzer_bin,
+        "-j", Etc.nprocessors.to_s,
         "--quiet",
         "--xml",
         "--output-file=#{report_file}",

--- a/lib/runners/processor/cppcheck.rb
+++ b/lib/runners/processor/cppcheck.rb
@@ -71,7 +71,20 @@ module Runners
     end
 
     def jobs
-      (config_linter[:parallel] && !config_linter[:project]) ? ["-j", Etc.nprocessors.to_s] : []
+      @jobs ||=
+        if config_linter[:parallel]
+          if config_linter[:project]
+            add_warning <<~MSG, file: config.path_name
+              The `parallel` option is ignored when the `project` option is specified.
+              This limitation is due to the behavior of #{analyzer_name}.
+            MSG
+            []
+          else
+            ["-j", Etc.nprocessors.to_s]
+          end
+        else
+          []
+        end
     end
 
     def run_analyzer

--- a/lib/runners/processor/cppcheck.rb
+++ b/lib/runners/processor/cppcheck.rb
@@ -17,7 +17,8 @@ module Runners
           std: string?,
           project: string?,
           language: string?,
-          'bug-hunting': boolean?
+          'bug-hunting': boolean?,
+          parallel: boolean?
         )
       }
 
@@ -69,6 +70,10 @@ module Runners
       config_linter[:language].then { |lang| lang ? ["--language=#{lang}"] : [] }
     end
 
+    def jobs
+      (config_linter[:parallel] && !config_linter[:project]) ? ["-j", Etc.nprocessors.to_s] : []
+    end
+
     def run_analyzer
       issues = []
 
@@ -100,7 +105,7 @@ module Runners
     def step_analyzer(*args)
       stdout, stderr, status = capture3(
         analyzer_bin,
-        "-j", Etc.nprocessors.to_s,
+        *jobs,
         "--quiet",
         "--xml",
         "--output-file=#{report_file}",

--- a/test/smokes/cppcheck/expectations.rb
+++ b/test/smokes/cppcheck/expectations.rb
@@ -37,6 +37,45 @@ s.add_test(
       }
     },
     {
+      id: "ctunullpointer",
+      path: "src/nullpointer.c",
+      location: { start_line: 2, start_column: 6 },
+      message: "Null pointer dereference: q",
+      links: [],
+      object: {
+        severity: "error", verbose: nil, inconclusive: false, cwe: "476", location_info: "Dereferencing argument q that is null"
+      },
+      git_blame_info: {
+        commit: :_, line_hash: "18737ae19d9ba677cc75212276757fefbeff2d5a", original_line: 2, final_line: 2
+      }
+    },
+    {
+      id: "ctunullpointer",
+      path: "src/nullpointer.c",
+      location: { start_line: 6, start_column: 14 },
+      message: "Null pointer dereference: q",
+      links: [],
+      object: {
+        severity: "error", verbose: nil, inconclusive: false, cwe: "476", location_info: "Assignment 'a=0', assigned value is 0"
+      },
+      git_blame_info: {
+        commit: :_, line_hash: "3fa4dc7d4e6657a293c827b3e374636b3ccea575", original_line: 6, final_line: 6
+      }
+    },
+    {
+      id: "ctunullpointer",
+      path: "src/nullpointer.c",
+      location: { start_line: 7, start_column: 6 },
+      message: "Null pointer dereference: q",
+      links: [],
+      object: {
+        severity: "error", verbose: nil, inconclusive: false, cwe: "476", location_info: "Calling function f, 1st argument is null"
+      },
+      git_blame_info: {
+        commit: :_, line_hash: "26d62c425999f29ac2a500ca5913cd47d409d642", original_line: 7, final_line: 7
+      }
+    },
+    {
       id: "invalidContainer",
       path: "src/erase.cpp",
       location: { start_line: 4, start_column: 22 },
@@ -315,6 +354,53 @@ s.add_test(
       git_blame_info: {
         commit: :_, line_hash: "90556cd318a1aaf1aa004d2b6c37189d79f5d3a0", original_line: 4, final_line: 4
       }
+    },
+    {
+      id: "unusedFunction",
+      path: "bad.c",
+      location: { start_line: 1, start_column: 0 },
+      message: "The function 'foo' is never used.",
+      links: [],
+      object: {
+        severity: "style", verbose: nil, inconclusive: false, cwe: "561", location_info: nil
+      },
+      git_blame_info: {
+        commit: :_, line_hash: "aba21ca7df06967d62bb367398a9d2f826c398f9", original_line: 1, final_line: 1
+      }
+    }
+  ],
+  analyzer: { name: "Cppcheck", version: default_version }
+)
+
+s.add_test(
+  "parallel",
+  type: "success",
+  issues: [
+    {
+      id: "readWriteOnlyFile",
+      path: "bad.c",
+      location: { start_line: 5, start_column: 5 },
+      message: "Read operation on a file that was opened only for writing.",
+      links: [],
+      object: {
+        severity: "error", verbose: nil, inconclusive: false, cwe: "664", location_info: nil
+      },
+      git_blame_info: {
+        commit: :_, line_hash: "479ce88b23ce551981eed443165ea6a466a3e7e2", original_line: 5, final_line: 5
+      }
+    },
+    {
+      id: "seekOnAppendedFile",
+      path: "bad.c",
+      location: { start_line: 4, start_column: 5 },
+      message: "Repositioning operation performed on a file opened in append mode has no effect.",
+      links: [],
+      object: {
+        severity: "warning", verbose: nil, inconclusive: false, cwe: "398", location_info: nil
+      },
+      git_blame_info: {
+        commit: :_, line_hash: "90556cd318a1aaf1aa004d2b6c37189d79f5d3a0", original_line: 4, final_line: 4
+      }
     }
   ],
   analyzer: { name: "Cppcheck", version: default_version }
@@ -346,19 +432,6 @@ s.add_test(
   "project",
   type: "success",
   issues: [
-    {
-      id: "arrayIndexOutOfBounds",
-      path: "arrayIndexOutOfBounds.c",
-      location: { start_line: 7, start_column: 6 },
-      message: "Array 'a[2]' accessed at index 2, which is out of bounds.",
-      links: [],
-      object: {
-        severity: "error", verbose: nil, inconclusive: false, cwe: "788", location_info: "Array index out of bounds"
-      },
-      git_blame_info: {
-        commit: :_, line_hash: "0385494c4c5930cf676a075a1eff5644b391b1c8", original_line: 7, final_line: 7
-      }
-    },
     {
       id: "zerodiv",
       path: "main.c",
@@ -785,19 +858,6 @@ s.add_test(
     },
     {
       id: "bughuntingDivByZero",
-      path: "src/cpp_sample_2.c++",
-      location: { start_line: 9, start_column: 15 },
-      message: "There is division, cannot determine that there can't be a division by zero.",
-      links: [],
-      object: {
-        severity: "error", verbose: nil, inconclusive: false, cwe: "369", location_info: nil
-      },
-      git_blame_info: {
-        commit: :_, line_hash: "74cc2eab823e61f73b1c85432ea4ecca95512c49", original_line: 9, final_line: 9
-      }
-    },
-    {
-      id: "bughuntingDivByZero",
       path: "src/cpp_sample_3.c++",
       location: { start_line: 11, start_column: 15 },
       message: "There is division, cannot determine that there can't be a division by zero.",
@@ -820,19 +880,6 @@ s.add_test(
       },
       git_blame_info: {
         commit: :_, line_hash: "fe526b59f18512f140fb71bea18d10db1d4b0c61", original_line: 20, final_line: 20
-      }
-    },
-    {
-      id: "bughuntingDivByZeroFloat",
-      path: "src/cpp_sample_2.c++",
-      location: { start_line: 22, start_column: 14 },
-      message: "There is division, cannot determine that there can't be a division by zero.",
-      links: [],
-      object: {
-        severity: "error", verbose: nil, inconclusive: false, cwe: "369", location_info: nil
-      },
-      git_blame_info: {
-        commit: :_, line_hash: "fe526b59f18512f140fb71bea18d10db1d4b0c61", original_line: 22, final_line: 22
       }
     },
     {
@@ -872,32 +919,6 @@ s.add_test(
       },
       git_blame_info: {
         commit: :_, line_hash: "acf5ddfa8e7109366a023a35caed04623817c40d", original_line: 21, final_line: 21
-      }
-    },
-    {
-      id: "bughuntingUninit",
-      path: "src/cpp_sample_2.c++",
-      location: { start_line: 20, start_column: 12 },
-      message: "Cannot determine that 'dz' is initialized",
-      links: [],
-      object: {
-        severity: "error", verbose: nil, inconclusive: false, cwe: "457", location_info: nil
-      },
-      git_blame_info: {
-        commit: :_, line_hash: "d1dc81b8c917189f68cc5bec2965b205d13162d5", original_line: 20, final_line: 20
-      }
-    },
-    {
-      id: "bughuntingUninit",
-      path: "src/cpp_sample_2.c++",
-      location: { start_line: 23, start_column: 16 },
-      message: "Cannot determine that 'dz' is initialized",
-      links: [],
-      object: {
-        severity: "error", verbose: nil, inconclusive: false, cwe: "457", location_info: nil
-      },
-      git_blame_info: {
-        commit: :_, line_hash: "acf5ddfa8e7109366a023a35caed04623817c40d", original_line: 23, final_line: 23
       }
     },
     {
@@ -950,32 +971,6 @@ s.add_test(
       },
       git_blame_info: {
         commit: :_, line_hash: "acf5ddfa8e7109366a023a35caed04623817c40d", original_line: 21, final_line: 21
-      }
-    },
-    {
-      id: "uninitvar",
-      path: "src/cpp_sample_2.c++",
-      location: { start_line: 20, start_column: 12 },
-      message: "Uninitialized variable: dz",
-      links: [],
-      object: {
-        severity: "error", verbose: nil, inconclusive: false, cwe: "457", location_info: nil
-      },
-      git_blame_info: {
-        commit: :_, line_hash: "d1dc81b8c917189f68cc5bec2965b205d13162d5", original_line: 20, final_line: 20
-      }
-    },
-    {
-      id: "uninitvar",
-      path: "src/cpp_sample_2.c++",
-      location: { start_line: 23, start_column: 16 },
-      message: "Uninitialized variable: dz",
-      links: [],
-      object: {
-        severity: "error", verbose: nil, inconclusive: false, cwe: "457", location_info: nil
-      },
-      git_blame_info: {
-        commit: :_, line_hash: "acf5ddfa8e7109366a023a35caed04623817c40d", original_line: 23, final_line: 23
       }
     },
     {

--- a/test/smokes/cppcheck/expectations.rb
+++ b/test/smokes/cppcheck/expectations.rb
@@ -446,6 +446,10 @@ s.add_test(
       }
     }
   ],
+  warnings: [{ message: <<~MSG.strip, file: "sider.yml" }],
+    The `parallel` option is ignored when the `project` option is specified.
+    This limitation is due to the behavior of Cppcheck.
+  MSG
   analyzer: { name: "Cppcheck", version: default_version }
 )
 

--- a/test/smokes/cppcheck/expectations.rb
+++ b/test/smokes/cppcheck/expectations.rb
@@ -37,45 +37,6 @@ s.add_test(
       }
     },
     {
-      id: "ctunullpointer",
-      path: "src/nullpointer.c",
-      location: { start_line: 2, start_column: 6 },
-      message: "Null pointer dereference: q",
-      links: [],
-      object: {
-        severity: "error", verbose: nil, inconclusive: false, cwe: "476", location_info: "Dereferencing argument q that is null"
-      },
-      git_blame_info: {
-        commit: :_, line_hash: "18737ae19d9ba677cc75212276757fefbeff2d5a", original_line: 2, final_line: 2
-      }
-    },
-    {
-      id: "ctunullpointer",
-      path: "src/nullpointer.c",
-      location: { start_line: 6, start_column: 14 },
-      message: "Null pointer dereference: q",
-      links: [],
-      object: {
-        severity: "error", verbose: nil, inconclusive: false, cwe: "476", location_info: "Assignment 'a=0', assigned value is 0"
-      },
-      git_blame_info: {
-        commit: :_, line_hash: "3fa4dc7d4e6657a293c827b3e374636b3ccea575", original_line: 6, final_line: 6
-      }
-    },
-    {
-      id: "ctunullpointer",
-      path: "src/nullpointer.c",
-      location: { start_line: 7, start_column: 6 },
-      message: "Null pointer dereference: q",
-      links: [],
-      object: {
-        severity: "error", verbose: nil, inconclusive: false, cwe: "476", location_info: "Calling function f, 1st argument is null"
-      },
-      git_blame_info: {
-        commit: :_, line_hash: "26d62c425999f29ac2a500ca5913cd47d409d642", original_line: 7, final_line: 7
-      }
-    },
-    {
       id: "invalidContainer",
       path: "src/erase.cpp",
       location: { start_line: 4, start_column: 22 },
@@ -354,19 +315,6 @@ s.add_test(
       git_blame_info: {
         commit: :_, line_hash: "90556cd318a1aaf1aa004d2b6c37189d79f5d3a0", original_line: 4, final_line: 4
       }
-    },
-    {
-      id: "unusedFunction",
-      path: "bad.c",
-      location: { start_line: 1, start_column: 0 },
-      message: "The function 'foo' is never used.",
-      links: [],
-      object: {
-        severity: "style", verbose: nil, inconclusive: false, cwe: "561", location_info: nil
-      },
-      git_blame_info: {
-        commit: :_, line_hash: "aba21ca7df06967d62bb367398a9d2f826c398f9", original_line: 1, final_line: 1
-      }
     }
   ],
   analyzer: { name: "Cppcheck", version: default_version }
@@ -398,6 +346,19 @@ s.add_test(
   "project",
   type: "success",
   issues: [
+    {
+      id: "arrayIndexOutOfBounds",
+      path: "arrayIndexOutOfBounds.c",
+      location: { start_line: 7, start_column: 6 },
+      message: "Array 'a[2]' accessed at index 2, which is out of bounds.",
+      links: [],
+      object: {
+        severity: "error", verbose: nil, inconclusive: false, cwe: "788", location_info: "Array index out of bounds"
+      },
+      git_blame_info: {
+        commit: :_, line_hash: "0385494c4c5930cf676a075a1eff5644b391b1c8", original_line: 7, final_line: 7
+      }
+    },
     {
       id: "zerodiv",
       path: "main.c",
@@ -824,6 +785,19 @@ s.add_test(
     },
     {
       id: "bughuntingDivByZero",
+      path: "src/cpp_sample_2.c++",
+      location: { start_line: 9, start_column: 15 },
+      message: "There is division, cannot determine that there can't be a division by zero.",
+      links: [],
+      object: {
+        severity: "error", verbose: nil, inconclusive: false, cwe: "369", location_info: nil
+      },
+      git_blame_info: {
+        commit: :_, line_hash: "74cc2eab823e61f73b1c85432ea4ecca95512c49", original_line: 9, final_line: 9
+      }
+    },
+    {
+      id: "bughuntingDivByZero",
       path: "src/cpp_sample_3.c++",
       location: { start_line: 11, start_column: 15 },
       message: "There is division, cannot determine that there can't be a division by zero.",
@@ -846,6 +820,19 @@ s.add_test(
       },
       git_blame_info: {
         commit: :_, line_hash: "fe526b59f18512f140fb71bea18d10db1d4b0c61", original_line: 20, final_line: 20
+      }
+    },
+    {
+      id: "bughuntingDivByZeroFloat",
+      path: "src/cpp_sample_2.c++",
+      location: { start_line: 22, start_column: 14 },
+      message: "There is division, cannot determine that there can't be a division by zero.",
+      links: [],
+      object: {
+        severity: "error", verbose: nil, inconclusive: false, cwe: "369", location_info: nil
+      },
+      git_blame_info: {
+        commit: :_, line_hash: "fe526b59f18512f140fb71bea18d10db1d4b0c61", original_line: 22, final_line: 22
       }
     },
     {
@@ -885,6 +872,32 @@ s.add_test(
       },
       git_blame_info: {
         commit: :_, line_hash: "acf5ddfa8e7109366a023a35caed04623817c40d", original_line: 21, final_line: 21
+      }
+    },
+    {
+      id: "bughuntingUninit",
+      path: "src/cpp_sample_2.c++",
+      location: { start_line: 20, start_column: 12 },
+      message: "Cannot determine that 'dz' is initialized",
+      links: [],
+      object: {
+        severity: "error", verbose: nil, inconclusive: false, cwe: "457", location_info: nil
+      },
+      git_blame_info: {
+        commit: :_, line_hash: "d1dc81b8c917189f68cc5bec2965b205d13162d5", original_line: 20, final_line: 20
+      }
+    },
+    {
+      id: "bughuntingUninit",
+      path: "src/cpp_sample_2.c++",
+      location: { start_line: 23, start_column: 16 },
+      message: "Cannot determine that 'dz' is initialized",
+      links: [],
+      object: {
+        severity: "error", verbose: nil, inconclusive: false, cwe: "457", location_info: nil
+      },
+      git_blame_info: {
+        commit: :_, line_hash: "acf5ddfa8e7109366a023a35caed04623817c40d", original_line: 23, final_line: 23
       }
     },
     {
@@ -937,6 +950,32 @@ s.add_test(
       },
       git_blame_info: {
         commit: :_, line_hash: "acf5ddfa8e7109366a023a35caed04623817c40d", original_line: 21, final_line: 21
+      }
+    },
+    {
+      id: "uninitvar",
+      path: "src/cpp_sample_2.c++",
+      location: { start_line: 20, start_column: 12 },
+      message: "Uninitialized variable: dz",
+      links: [],
+      object: {
+        severity: "error", verbose: nil, inconclusive: false, cwe: "457", location_info: nil
+      },
+      git_blame_info: {
+        commit: :_, line_hash: "d1dc81b8c917189f68cc5bec2965b205d13162d5", original_line: 20, final_line: 20
+      }
+    },
+    {
+      id: "uninitvar",
+      path: "src/cpp_sample_2.c++",
+      location: { start_line: 23, start_column: 16 },
+      message: "Uninitialized variable: dz",
+      links: [],
+      object: {
+        severity: "error", verbose: nil, inconclusive: false, cwe: "457", location_info: nil
+      },
+      git_blame_info: {
+        commit: :_, line_hash: "acf5ddfa8e7109366a023a35caed04623817c40d", original_line: 23, final_line: 23
       }
     },
     {

--- a/test/smokes/cppcheck/parallel/bad.c
+++ b/test/smokes/cppcheck/parallel/bad.c
@@ -1,0 +1,6 @@
+void foo(FILE*& f) {
+    f = fopen(name, "a");
+    fwrite(buffer, 5, 6, f);
+    rewind(f);
+    fread(buffer, 5, 6, f);
+}

--- a/test/smokes/cppcheck/parallel/sider.yml
+++ b/test/smokes/cppcheck/parallel/sider.yml
@@ -1,4 +1,4 @@
 linter:
   cppcheck:
     enable: "warning,unusedFunction"
-    parallel: false
+    parallel: true

--- a/test/smokes/cppcheck/project/sider.yml
+++ b/test/smokes/cppcheck/project/sider.yml
@@ -1,3 +1,4 @@
 linter:
   cppcheck:
+    parallel: true
     project: "helloworld.vcxproj"


### PR DESCRIPTION
Use the multi-threading `-j` option to improve analysis time.

Related to #1458

> Check the following items (please remove needless items).

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
- [x] Write smoke test cases. E.g. all options, successful end, warnings, errors, etc.
