### PR TITLE
Cleanup unused Prettier settings

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-test/smokes/**/*.rb
-!test/smokes/**/expectations.rb

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,5 +1,0 @@
-overrides:
-  - files: "**/*.rb"
-    options:
-      preferSingleQuotes: false
-      printWidth: 120

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ See also another related project, called [devon_rex](https://github.com/sider/de
 
 ## Supported analyzers
 
-<!-- prettier-ignore-start -->
 <!-- AUTO-GENERATED-CONTENT:START (analyzers) -->
 All 36 analyzers are provided as a Docker image:
 
@@ -49,7 +48,6 @@ All 36 analyzers are provided as a Docker image:
 | TSLint | [docker](https://hub.docker.com/r/sider/runner_tslint), [source](https://github.com/palantir/tslint), [doc](https://help.sider.review/tools/javascript/tslint) | ✅ |
 | TyScan | [docker](https://hub.docker.com/r/sider/runner_tyscan), [source](https://github.com/sider/TyScan), [doc](https://help.sider.review/tools/javascript/tyscan) | ✅ |
 <!-- AUTO-GENERATED-CONTENT:END (analyzers) -->
-<!-- prettier-ignore-end -->
 
 ## Developer guide
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change is just an internal refactoring. We have no longer used Prettier already.

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

See also #1114
