### PR TITLE
Remove `pull_request.body` from CI skipping targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   check_skip:
     runs-on: ubuntu-latest
     if: |
-      !contains(format('{0} {1} {2}', github.event.head_commit.message, github.event.pull_request.title, github.event.pull_request.body), '[skip ci]')
+      !contains(format('{0} {1} {2}', github.event.head_commit.message, github.event.pull_request.title), '[skip ci]')
     steps:
       - run: |
           cat <<'MESSAGE'


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Dependabot's pull requests can include `[skip ci]` in the body. Because the body includes commit messages of an update.

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

See https://github.com/sider/runners/pull/1471#issuecomment-691765216
