### PR TITLE
Bump typescript-eslint from 3.9.1 to 4.1.0

### DIFF
--- a/images/eslint/package.json
+++ b/images/eslint/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "3.9.1",
-    "@typescript-eslint/parser": "3.9.1",
+    "@typescript-eslint/eslint-plugin": "4.1.0",
+    "@typescript-eslint/parser": "4.1.0",
     "eslint": "7.7.0",
     "eslint-config-airbnb": "18.2.0",
     "eslint-config-prettier": "6.11.0",

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -417,7 +417,7 @@ s.add_test(
       id: "@typescript-eslint/no-unused-vars",
       message: "'x' is assigned a value but never used.",
       links: %w[
-        https://github.com/typescript-eslint/typescript-eslint/blob/v3.9.1/packages/eslint-plugin/docs/rules/no-unused-vars.md
+        https://github.com/typescript-eslint/typescript-eslint/blob/v4.1.0/packages/eslint-plugin/docs/rules/no-unused-vars.md
       ],
       path: "index.ts",
       location: { start_line: 1, start_column: 7, end_line: 1, end_column: 8 },


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- https://github.com/typescript-eslint/typescript-eslint/compare/v3.9.1...v4.1.0
- https://github.com/typescript-eslint/typescript-eslint/releases/tag/v4.1.0
- https://github.com/typescript-eslint/typescript-eslint/releases/tag/v4.0.0

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

Close #1440 
Close #1455 
