### PR TITLE
Reformat smoke tests

### DIFF
--- a/test/smokes/clang_tidy/expectations.rb
+++ b/test/smokes/clang_tidy/expectations.rb
@@ -34,7 +34,7 @@ s.add_test(
       id: "clang-analyzer-deadcode.DeadStores",
       message: "Value stored to 't' during its initialization is never read",
       links: [],
-      object: {       severity: "warning" },
+      object: { severity: "warning" },
       git_blame_info: {
         commit: :_, line_hash: "325e902bbf21dcb5f6ba2e272378d9fa08242c39", original_line: 5, final_line: 5
       }
@@ -53,7 +53,7 @@ s.add_test(
       id: "clang-analyzer-core.CallAndMessage",
       message: "2nd function call argument is an uninitialized value",
       links: [],
-      object: {       severity: "warning" },
+      object: { severity: "warning" },
       git_blame_info: {
         commit: :_, line_hash: "325712945c407d3c9e9c806676bacebe5948046e", original_line: 6, final_line: 6
       }
@@ -75,7 +75,7 @@ s.add_test(
       id: "clang-analyzer-deadcode.DeadStores",
       message: "Value stored to 't' during its initialization is never read",
       links: [],
-      object: {       severity: "warning" },
+      object: { severity: "warning" },
       git_blame_info: {
         commit: :_, line_hash: "325e902bbf21dcb5f6ba2e272378d9fa08242c39", original_line: 5, final_line: 5
       }
@@ -94,7 +94,7 @@ s.add_test(
       id: "clang-analyzer-core.uninitialized.Assign",
       message: "Assigned value is garbage or undefined",
       links: [],
-      object: {       severity: "warning" },
+      object: { severity: "warning" },
       git_blame_info: {
         commit: :_, line_hash: "325e902bbf21dcb5f6ba2e272378d9fa08242c39", original_line: 6, final_line: 6
       }

--- a/test/smokes/cppcheck/expectations.rb
+++ b/test/smokes/cppcheck/expectations.rb
@@ -199,7 +199,7 @@ s.add_test(
       message: "Possible null pointer dereference: q",
       links: [],
       object: {
-        severity: "warning", verbose: nil, inconclusive: false, cwe: "476",       location_info: "Calling function 'f', 1st argument 'a' value is 0"
+        severity: "warning", verbose: nil, inconclusive: false, cwe: "476", location_info: "Calling function 'f', 1st argument 'a' value is 0"
       },
       git_blame_info: {
         commit: :_, line_hash: "26d62c425999f29ac2a500ca5913cd47d409d642", original_line: 7, final_line: 7

--- a/test/smokes/jshint/expectations.rb
+++ b/test/smokes/jshint/expectations.rb
@@ -14,7 +14,7 @@ s.add_test(
       links: [],
       object: nil,
       git_blame_info: {
-        commit: :_,   line_hash: "b419b61355f047cf4b8d3bcceacb6f671bcdd5b1", original_line: 3, final_line: 3
+        commit: :_, line_hash: "b419b61355f047cf4b8d3bcceacb6f671bcdd5b1", original_line: 3, final_line: 3
       }
     }
   ],
@@ -33,7 +33,7 @@ s.add_test(
       links: [],
       object: nil,
       git_blame_info: {
-        commit: :_,   line_hash: "89b72153bd7e6390415ba25b9b5fbe750e6e16d5", original_line: 1, final_line: 1
+        commit: :_, line_hash: "89b72153bd7e6390415ba25b9b5fbe750e6e16d5", original_line: 1, final_line: 1
       }
     },
     {
@@ -44,7 +44,7 @@ s.add_test(
       links: [],
       object: nil,
       git_blame_info: {
-        commit: :_,   line_hash: "4fcccde0e9f839fae12b97b5e3e6064fa5a60bc6", original_line: 9, final_line: 9
+        commit: :_, line_hash: "4fcccde0e9f839fae12b97b5e3e6064fa5a60bc6", original_line: 9, final_line: 9
       }
     },
     {
@@ -55,7 +55,7 @@ s.add_test(
       links: [],
       object: nil,
       git_blame_info: {
-        commit: :_,   line_hash: "9c73ee33849055aae0cbc3e48e46a1d8851db037", original_line: 16, final_line: 16
+        commit: :_, line_hash: "9c73ee33849055aae0cbc3e48e46a1d8851db037", original_line: 16, final_line: 16
       }
     }
   ],
@@ -74,7 +74,7 @@ s.add_test(
       links: [],
       object: nil,
       git_blame_info: {
-        commit: :_,   line_hash: "b419b61355f047cf4b8d3bcceacb6f671bcdd5b1", original_line: 3, final_line: 3
+        commit: :_, line_hash: "b419b61355f047cf4b8d3bcceacb6f671bcdd5b1", original_line: 3, final_line: 3
       }
     }
   ],
@@ -100,7 +100,7 @@ s.add_test(
       location: { start_line: 3, start_column: 1 },
       object: nil,
       git_blame_info: {
-        commit: :_,   line_hash: "b419b61355f047cf4b8d3bcceacb6f671bcdd5b1", original_line: 3, final_line: 3
+        commit: :_, line_hash: "b419b61355f047cf4b8d3bcceacb6f671bcdd5b1", original_line: 3, final_line: 3
       }
     }
   ],


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

[`Layout/ExtraSpacing`](https://docs.rubocop.org/rubocop/cops_layout.html#layoutextraspacing) did not work unexpectedly. (I cannot know the reason... 🤷 )
So, I've fixed them manually in this pull request.

> Link related issues or pull requests, e.g. `Fix #123`, `Related to #456`, or `None`.

None.
