### PR TITLE
[RuboCop] Add `standard` to optional gem list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Updated tools:
 Misc:
 
 - **Cppcheck** Run multiple threads with the `-j` option [#1462](https://github.com/sider/runners/pull/1462)
+- **RuboCop** Add `standard` to optional gem list [#1479](https://github.com/sider/runners/pull/1479)
 - Replace ENTRYPOINT with docker-entrypoint.sh [#1463](https://github.com/sider/runners/pull/1463)
 
 ## 0.34.1

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -60,6 +60,7 @@ module Runners
       GemInstaller::Spec.new(name: "rubocop-thread_safety", version: []),
       GemInstaller::Spec.new(name: "salsify_rubocop", version: []),
       GemInstaller::Spec.new(name: "sanelint", version: []),
+      GemInstaller::Spec.new(name: "standard", version: []),
       GemInstaller::Spec.new(name: "unasukecop", version: []),
       GemInstaller::Spec.new(name: "unifacop", version: []),
       GemInstaller::Spec.new(name: "ws-style", version: []),


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change adds the [`standard`](https://github.com/testdouble/standard) gem to the optional gem list for our RuboCop runner.
Now the `standard` gem has over 1K GitHub stars and is active for development.

I think this gem has a value to be added to the list. 💪 

> Link related issues or pull requests.

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
