### PR TITLE
[RuboCop] Improve warning messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Updated tools:
 Misc:
 
 - **Cppcheck** Run multiple threads with the `-j` option [#1462](https://github.com/sider/runners/pull/1462)
+- **RuboCop** Improve warning messages [#1480](https://github.com/sider/runners/pull/1480)
 - Replace ENTRYPOINT with docker-entrypoint.sh [#1463](https://github.com/sider/runners/pull/1463)
 
 ## 0.34.1

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -140,28 +140,34 @@ module Runners
     end
 
     def check_rubocop_yml_warning(stderr)
-      error_occurred = false
-      stderr.each_line do |line|
-        case line
-        when /(.+): (.+has the wrong namespace - should be.+$)/
-          file = $1
-          msg = $2
-          add_warning(msg, file: relative_path(file).to_s)
-        when /Rails cops will be removed from RuboCop 0.72/
-          add_warning(<<~WARNING)
-            Rails cops were removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.
-          WARNING
-        when /^\d+ errors? occurred:$/
-          # NOTE: "An error occurred... is displayed twice, "when an error happens", and "at the end of RuboCop runtime".
-          #       So, we handle "at the end of RuboCop runtime" only.
-          error_occurred = true
-        when /^(An error occurred while \S+ cop) was inspecting (.+):\d+:\d+\.$/
-          next unless error_occurred
-          file = $2
-          msg = $1
-          add_warning("RuboCop crashes: #{msg}", file: relative_path(file).to_s)
+      patterns = [
+        # @see https://github.com/rubocop-hq/rubocop/blob/v0.89.1/lib/rubocop/cop/registry.rb#L263
+        /(?<file>.+): .+ has the wrong namespace/,
+
+        # @see https://github.com/rubocop-hq/rubocop/blob/v0.71.0/lib/rubocop/runner.rb#L30
+        /Rails cops will be removed from RuboCop 0.72/,
+
+        # @see https://github.com/rubocop-hq/rubocop/blob/v0.89.1/lib/rubocop/cop/team.rb#L244
+        /An error occurred while .+ inspecting (?<file>.+):.+:/,
+      ]
+
+      warnings = Set[]
+
+      stderr.each_line(chomp: true) do |message|
+        patterns.each do |pattern|
+          message.match(pattern) do |match|
+            file = match.named_captures["file"]
+            if file
+              rel_file = relative_path(file).to_path
+              message.sub!(file, rel_file)
+              file = rel_file
+            end
+            warnings << [message, file]
+          end
         end
       end
+
+      warnings.each { |msg, file| add_warning(msg, file: file) }
     end
 
     def run_analyzer(options)

--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -163,7 +163,7 @@ s.add_test(
     }
   ],
   analyzer: { name: "RuboCop", version: "0.79.0" },
-  warnings: [{ message: "Style/Tab has the wrong namespace - should be Layout", file: ".rubocop.yml" }]
+  warnings: [{ message: ".rubocop.yml: Style/Tab has the wrong namespace - should be Layout", file: ".rubocop.yml" }]
 )
 
 s.add_test(
@@ -255,7 +255,10 @@ s.add_test(
       message: /The `linter.rubocop.options` option is deprecated/,
       file: "sideci.yml"
     },
-    { message: "Metrics/LineLength has the wrong namespace - should be Layout", file: "my.rubocop.yml" }
+    {
+      message: "my.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout",
+      file: "my.rubocop.yml"
+    }
   ]
 )
 
@@ -281,7 +284,7 @@ s.add_test(
   analyzer: { name: "RuboCop", version: "0.71.0" },
   warnings: [
     {
-      message: "Rails cops were removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.",
+      message: "`-R/--rails` option and Rails cops will be removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.",
       file: nil
     }
   ]
@@ -489,4 +492,21 @@ s.add_test(
     }
   ],
   analyzer: { name: "RuboCop", version: default_version }
+)
+
+s.add_test(
+  "unexpected_error",
+  type: "success",
+  issues: [],
+  analyzer: { name: "RuboCop", version: "0.90.0" },
+  warnings: [
+    {
+      message: "An error occurred while Layout/EmptyLineAfterMultilineCondition cop was inspecting backtrace_silencers.rb:3:0.",
+      file: "backtrace_silencers.rb"
+    },
+    {
+      message: "An error occurred while Layout/EmptyLineAfterMultilineCondition cop was inspecting lib/backtrace_silencers2.rb:1:0.",
+      file: "lib/backtrace_silencers2.rb"
+    }
+  ]
 )

--- a/test/smokes/rubocop/unexpected_error/.rubocop.yml
+++ b/test/smokes/rubocop/unexpected_error/.rubocop.yml
@@ -1,0 +1,5 @@
+AllCops:
+  DisabledByDefault: true
+
+Layout/EmptyLineAfterMultilineCondition:
+  Enabled: true

--- a/test/smokes/rubocop/unexpected_error/Gemfile
+++ b/test/smokes/rubocop/unexpected_error/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "rubocop", "0.90.0"

--- a/test/smokes/rubocop/unexpected_error/backtrace_silencers.rb
+++ b/test/smokes/rubocop/unexpected_error/backtrace_silencers.rb
@@ -1,0 +1,3 @@
+# https://github.com/rubocop-hq/rubocop/issues/8674
+
+Rails.backtrace_cleaner.remove_silencers! if ENV['CI']

--- a/test/smokes/rubocop/unexpected_error/lib/backtrace_silencers2.rb
+++ b/test/smokes/rubocop/unexpected_error/lib/backtrace_silencers2.rb
@@ -1,0 +1,1 @@
+Rails.backtrace_cleaner.remove_silencers! if ENV['CI']


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to use a rawer RuboCop warning message, instead of processing it excessively.
Because a rawer message is easier to search by Google or GitHub.

> Link related issues or pull requests.

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
