### PR TITLE
Make generated `Gemfile` content log valid as Ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Misc:
 - **RuboCop** Add `standard` to optional gem list [#1479](https://github.com/sider/runners/pull/1479)
 - **RuboCop** Improve warning messages [#1480](https://github.com/sider/runners/pull/1480)
 - Replace ENTRYPOINT with docker-entrypoint.sh [#1463](https://github.com/sider/runners/pull/1463)
+- Make generated `Gemfile` content log valid as Ruby [#1485](https://github.com/sider/runners/pull/1485)
 
 ## 0.34.1
 

--- a/lib/runners/ruby/gem_installer.rb
+++ b/lib/runners/ruby/gem_installer.rb
@@ -76,9 +76,8 @@ module Runners
 
         (lines.join("\n") + "\n").tap do |content|
           trace_writer.message <<~MSG
-            ---
+            ### Auto-generated Gemfile ###
             #{content.chomp}
-            ---
           MSG
         end
       end

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -165,9 +165,8 @@ class RubyTest < Minitest::Test
         assert_equal "1.32.0", hash["rubocop-rspec"]
       end
 
-      messages = trace_writer.writer.select { |m| m[:trace] == :message }.map { |m| m[:message] }
-      assert_equal(["Generating optimized Gemfile...", <<~MSG.strip, "Installing gems..."], messages)
-        ---
+      gemfile_content_log = <<~RUBY.strip
+        ### Auto-generated Gemfile ###
         source "https://rubygems.org"
 
         gem "strong_json", "0.5.0", "<= 0.8.0"
@@ -175,8 +174,11 @@ class RubyTest < Minitest::Test
         git "https://github.com/rubocop-hq/rubocop-rspec.git", tag: "v1.32.0" do
           gem "rubocop-rspec"
         end
-        ---
-      MSG
+      RUBY
+      assert system("ruby", "-ce", gemfile_content_log)
+
+      messages = trace_writer.writer.select { |m| m[:trace] == :message }.map { |m| m[:message] }
+      assert_equal(["Generating optimized Gemfile...", gemfile_content_log, "Installing gems..."], messages)
     end
   end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

When analyzing a Ruby tool, a `Gemfile` file is auto-generated and the file content is output the log.

This change makes the content log text as a valid Ruby code.

> Link related issues or pull requests.

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
