### PR TITLE
Set tag instead of commit sha in releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,15 @@ on:
     tags: ["**"]
 
 jobs:
-  run:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+        id: get_tag
       - uses: softprops/action-gh-release@v1
         with:
           body: |
-            See the [changelog](https://github.com/${{ github.repository }}/blob/${{ github.sha }}/CHANGELOG.md) for more details.
+            See the [changelog](https://github.com/${{ github.repository }}/blob/${{ steps.get_tag.outputs.tag }}/CHANGELOG.md) for more details.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

For example, the [v0.34.1 release](https://github.com/sider/runners/releases/tag/0.34.1) has the link <https://github.com/sider/runners/blob/5e9edc19e917166f13eb1ea2892a812ddf425903/CHANGELOG.md>, but <https://github.com/sider/runners/blob/0.34.1/CHANGELOG.md> is more understandable for users.

> Link related issues or pull requests.

None.
