### PR TITLE
Run update-ca-certificates(8) before analyzing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Misc:
 - **RuboCop** Improve warning messages [#1480](https://github.com/sider/runners/pull/1480)
 - Replace ENTRYPOINT with docker-entrypoint.sh [#1463](https://github.com/sider/runners/pull/1463)
 - Make generated `Gemfile` content log valid as Ruby [#1485](https://github.com/sider/runners/pull/1485)
+- Run update-ca-certificates(8) before analyzing [#1489](https://github.com/sider/runners/pull/1489)
 
 ## 0.34.1
 

--- a/images/docker-entrypoint.sh
+++ b/images/docker-entrypoint.sh
@@ -6,6 +6,12 @@ if [[ "$DEBUG" == "true" ]]; then
   set -x
 fi
 
+if [[ -n "$EXTRA_CERTIFICATE" ]]; then
+  echo "Run update-ca-certificates(8) to add the specified certificate" >&2
+  echo "$EXTRA_CERTIFICATE" | base64 --decode > /usr/local/share/ca-certificates/extra-cert.crt
+  sudo update-ca-certificates
+fi
+
 RUNNERS_TIMEOUT=${RUNNERS_TIMEOUT:-30m}
 args=()
 

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -241,7 +241,7 @@ module Runners
         cert.add_extension(extension.create_extension("basicConstraints", "CA:TRUE", true))
         cert.add_extension(extension.create_extension("subjectKeyIdentifier", "hash", false))
         cert.add_extension(extension.create_extension("authorityKeyIdentifier", "keyid:always", false))
-        cert.sign(key, OpenSSL::Digest::SHA256.new)
+        cert.sign(key, OpenSSL::Digest.new('SHA256'))
         Base64.strict_encode64(cert.to_s)
       end
 

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -3,6 +3,7 @@ require "unification_assertion"
 require 'parallel'
 require "amazing_print"
 require "rainbow"
+require "openssl"
 
 module Runners
   module Testing

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -162,6 +162,7 @@ module Runners
         commands << "--env" << "RUNNERS_OPTIONS=#{runners_options}"
         commands << "--env" << "RUNNERS_TIMEOUT=#{runners_timeout}" if runners_timeout
         commands << "--env" << "DEBUG=true" if debug?
+        commands << "--env" << "EXTRA_CERTIFICATE=#{extra_certificate}" # Test update-ca-certificates(8)
         commands << "--network=none" if params.offline
         commands << docker_image
         commands << params.pattern.dig(:result, :guid)
@@ -222,6 +223,26 @@ module Runners
 
       def colored_pretty_inspect(obj, multiline: false)
         obj.awesome_inspect(indent: 2, index: false, multiline: multiline)
+      end
+
+      def extra_certificate
+        key = OpenSSL::PKey::RSA.new(4096)
+        extension = OpenSSL::X509::ExtensionFactory.new
+        cert = OpenSSL::X509::Certificate.new
+        cert.subject = OpenSSL::X509::Name.parse 'CN=test.example.com'
+        cert.issuer = OpenSSL::X509::Name.parse 'CN=test.example.com'
+        cert.not_before = Time.now
+        cert.not_after = Time.now + (60 * 60 * 24)
+        cert.version = 2
+        cert.serial = 1
+        cert.public_key = key.public_key
+        extension.subject_certificate = cert
+        extension.issuer_certificate = cert
+        cert.add_extension(extension.create_extension("basicConstraints", "CA:TRUE", true))
+        cert.add_extension(extension.create_extension("subjectKeyIdentifier", "hash", false))
+        cert.add_extension(extension.create_extension("authorityKeyIdentifier", "keyid:always", false))
+        cert.sign(key, OpenSSL::Digest::SHA256.new)
+        Base64.strict_encode64(cert.to_s)
       end
 
       @tests = []


### PR DESCRIPTION
From this change, Runners supports the environment variable `EXTRA_CERTIFICATE`, and it adds the certificate when the variable is set. Then, the specified certificate will be registered by calling update-ca-certificates(8).

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
