### PR TITLE
Remove the execution of adding /etc/sudoers.d/runner

### DIFF
--- a/images/clang_tidy/Dockerfile
+++ b/images/clang_tidy/Dockerfile
@@ -12,8 +12,7 @@ RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-get update && \
     grep -v "^\s*#" ${RUNNER_USER_HOME}/packages.list | xargs apt-get install -qq -y --no-install-recommends && \
     apt-get clean && \
-    update-alternatives --install /usr/local/bin/clang-tidy clang-tidy /usr/lib/llvm-10/bin/clang-tidy 20 && \
-    echo "${RUNNER_USER} ALL=NOPASSWD: /usr/bin/apt-get" > /etc/sudoers.d/runner
+    update-alternatives --install /usr/local/bin/clang-tidy clang-tidy /usr/lib/llvm-10/bin/clang-tidy 20
 USER $RUNNER_USER
 
 

--- a/images/clang_tidy/Dockerfile.erb
+++ b/images/clang_tidy/Dockerfile.erb
@@ -8,8 +8,7 @@ RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-get update && \
     grep -v "^\s*#" ${RUNNER_USER_HOME}/packages.list | xargs apt-get install -qq -y --no-install-recommends && \
     apt-get clean && \
-    update-alternatives --install /usr/local/bin/clang-tidy clang-tidy /usr/lib/llvm-10/bin/clang-tidy 20 && \
-    echo "${RUNNER_USER} ALL=NOPASSWD: /usr/bin/apt-get" > /etc/sudoers.d/runner
+    update-alternatives --install /usr/local/bin/clang-tidy clang-tidy /usr/lib/llvm-10/bin/clang-tidy 20
 USER $RUNNER_USER
 
 <%= render_erb 'images/Dockerfile.base.erb' %>


### PR DESCRIPTION
Thanks to https://github.com/sider/devon_rex/pull/272, we don't have to add `/etc/sudoers.d/runner`.

> - [ ] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.

I believe this is not worth explaining in CHANGELOG because it does not affect users' configuration.