### PR TITLE
[ESLint] Add `eslint-plugin-vue` to default package list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.35.0...HEAD)
 
+- **ESLint** Add `eslint-plugin-vue` to default package list [#1521](https://github.com/sider/runners/pull/1521)
 - **RuboCop** Update optional gem list [#1506](https://github.com/sider/runners/pull/1506)
 - Delete environment variables after used [#1520](https://github.com/sider/runners/pull/1520)
 

--- a/images/eslint/package.json
+++ b/images/eslint/package.json
@@ -13,6 +13,7 @@
     "eslint-plugin-prettier": "3.1.4",
     "eslint-plugin-react": "7.21.2",
     "eslint-plugin-react-hooks": "4.1.2",
+    "eslint-plugin-vue": "7.0.0",
     "prettier": "2.1.2",
     "typescript": "4.0.3"
   }


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

`eslint-plugin-vue` is an official ESLint plugin for Vue.js. The new version **7.0.0** is released today!
https://github.com/vuejs/eslint-plugin-vue/releases/tag/v7.0.0

> Link related issues or pull requests.

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
