### PR TITLE
[Misspell] Allow `string` type for `target` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.36.0...HEAD)
 
+- **Misspell** Allow `string` type for `target` option [#1536](https://github.com/sider/runners/pull/1536)
+
 ## 0.36.0
 
 [Full diff](https://github.com/sider/runners/compare/0.35.0...0.36.0)

--- a/lib/runners/processor/misspell.rb
+++ b/lib/runners/processor/misspell.rb
@@ -5,7 +5,7 @@ module Runners
         fields.merge!({
                         exclude: array?(string),
                         targets: array?(string),
-                        target: array?(string),
+                        target: enum?(string, array(string)),
                         locale: enum?(literal('US'), literal('UK')),
                         ignore: enum?(string, array(string)),
                         # DO NOT ADD ANY OPTIONS under `options`.


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

I think it useful that the `target` option allows also the `string` type.

> Link related issues or pull requests.

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
