### PR TITLE
Refactor `ruby/setup-ruby` configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: .ruby-version
-      - name: Install gems
-        run: |
-          gem install bundler --no-document
-          bundle config set --local path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
+      - run: bundle install
       - run: bundle exec rake test
         env:
           TESTOPTS: --verbose
@@ -46,12 +42,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: .ruby-version
-      - name: Install gems
-        run: |
-          gem install bundler --no-document
-          bundle config set --local path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
+      - run: bundle install
       - run: bundle exec rake docker:timeout_test
 
   build:
@@ -101,12 +93,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: .ruby-version
-      - name: Install gems
-        run: |
-          gem install bundler --no-document
-          bundle config set --local path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
+      - run: bundle install
       - name: Define variables
         id: define_vars
         # See https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html

--- a/.github/workflows/bump_analyzers.yml
+++ b/.github/workflows/bump_analyzers.yml
@@ -13,11 +13,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: .ruby-version
-      - run: |
-          gem install bundler --no-document
-          bundle config set path vendor/bundle
-          bundle install --jobs=4 --retry=3
+          bundler-cache: true
+      - run: bundle install
       - uses: tibdex/github-app-token@v1
         id: generate_token
         with:

--- a/.github/workflows/steep.yml
+++ b/.github/workflows/steep.yml
@@ -18,11 +18,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: .ruby-version
-      - run: |
-          gem install bundler --no-document
-          bundle config set --local path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
+      - run: bundle install
       - run: |
           bundle exec steep check | ruby -pe 'sub(/^(.+):(\d+):(\d+): (.+)$/, %q{::error file=\1,line=\2,col=\3::\4})'
         shell: bash

--- a/.github/workflows/steep_old.yml
+++ b/.github/workflows/steep_old.yml
@@ -18,11 +18,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: .ruby-version
-      - run: |
-          gem install bundler --no-document
-          bundle config set --local path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
+      - run: bundle install
       - run: |
           bundle exec rake typecheck | ruby -pe 'sub(/^(.+):(\d+):(\d+): (.+)$/, %q{::error file=\1,line=\2,col=\3::\4})'
         shell: bash


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- Remove needless `ruby-version: .ruby-version` (automatically loaded)
- Simplify `bundle install` (automatically the latest version used)
- Set `bundler-cache: true`

See <https://github.com/ruby/setup-ruby>

> Link related issues or pull requests.

None.
