### PR TITLE
Remove needless `bundle install` for ruby/setup-ruby

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bundle install
       - run: bundle exec rake test
         env:
           TESTOPTS: --verbose
@@ -43,7 +42,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bundle install
       - run: bundle exec rake docker:timeout_test
 
   build:
@@ -94,7 +92,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bundle install
       - name: Define variables
         id: define_vars
         # See https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html

--- a/.github/workflows/bump_analyzers.yml
+++ b/.github/workflows/bump_analyzers.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bundle install
       - uses: tibdex/github-app-token@v1
         id: generate_token
         with:

--- a/.github/workflows/steep.yml
+++ b/.github/workflows/steep.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bundle install
       - run: |
           bundle exec steep check | ruby -pe 'sub(/^(.+):(\d+):(\d+): (.+)$/, %q{::error file=\1,line=\2,col=\3::\4})'
         shell: bash

--- a/.github/workflows/steep_old.yml
+++ b/.github/workflows/steep_old.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bundle install
       - run: |
           bundle exec rake typecheck | ruby -pe 'sub(/^(.+):(\d+):(\d+): (.+)$/, %q{::error file=\1,line=\2,col=\3::\4})'
         shell: bash


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The document says:

> This action provides a way to automatically run `bundle install` and cache the result:

https://github.com/ruby/setup-ruby#caching-bundle-install-automatically

> Link related issues or pull requests.

Related to #1537 
