### PR TITLE
Check if `master` tag of devon_rex is used on release

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ require_relative "lib/tasks/readme/generate"
 
 ENV["DOCKER_BUILDKIT"] = "1"
 
-Aufgaben::Release.new do |t|
+Aufgaben::Release.new(:release) do |t|
   t.files = ["lib/runners/version.rb"]
 end
 
@@ -83,10 +83,25 @@ namespace :dockerfile do
 
   desc 'Verify Dockerfile is committed'
   task :verify do
-    system('git diff --exit-code') or
-      abort "\nError: Run `bundle exec rake dockerfile:generate` and include the changes in commit"
+    sh 'git', 'diff', '--exit-code' do |ok|
+      unless ok
+        abort "\nError: Run `bundle exec rake dockerfile:generate` and include the changes in commit"
+      end
+    end
+  end
+
+  desc 'Verify the devon_rex image tag'
+  task :verify_devon_rex do
+    disallowed_tag = 'master'
+    sh 'git', 'grep', '--quiet', "/devon_rex_.+:#{disallowed_tag}", 'images/' do |found|
+      if found
+        abort "\nError: Disallow to release with the `#{disallowed_tag}` tag of the devon_rex images."
+      end
+    end
   end
 end
+
+task :release => "dockerfile:verify_devon_rex"
 
 namespace :docker do
   def image_name(t = tag)


### PR DESCRIPTION
For example:

```console
$ bundle exec rake release'[0.36.1]' DRY_RUN=1
git grep --quiet /devon_rex_.+:master images/

Error: Disallow to release with the `master` tag of the devon_rex images.
```

> Explain a summary, purpose, or background for this change.

The `master` tag of the devon_rex Docker images are changeable. This means the instability of analysis.

> Link related issues or pull requests.

On PR #1538, devon_rex image tags were updated.

