### PR TITLE
[stylelint] Add `stylelint-config-recommended-scss`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.36.1...HEAD)
 
 - Bump Ruby from 2.7.1 to 2.7.2 [#1538](https://github.com/sider/runners/pull/1538)
+- **stylelint** Add `stylelint-config-recommended-scss` [#1557](https://github.com/sider/runners/pull/1557)
 
 ## 0.36.1
 

--- a/images/stylelint/package.json
+++ b/images/stylelint/package.json
@@ -4,6 +4,7 @@
     "stylelint": "13.7.1",
     "stylelint-config-prettier": "8.0.2",
     "stylelint-config-recommended": "3.0.0",
+    "stylelint-config-recommended-scss": "^4.2.0",
     "stylelint-config-standard": "20.0.0",
     "stylelint-order": "4.1.0",
     "stylelint-prettier": "1.1.2",


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

`stylelint-config-recommended-scss` is a popular stylelint shareable configuration.
(GitHub stars: 136)
And, it is created and maintained by the same owner of `stylelint-scss`.

See also:
- https://github.com/kristerkari/stylelint-config-recommended-scss
- https://github.com/kristerkari/stylelint-scss

> Link related issues or pull requests.

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.

