### PR TITLE
Use the exact version for `stylelint-config-recommended-scss`

### DIFF
--- a/images/stylelint/package.json
+++ b/images/stylelint/package.json
@@ -4,7 +4,7 @@
     "stylelint": "13.7.1",
     "stylelint-config-prettier": "8.0.2",
     "stylelint-config-recommended": "3.0.0",
-    "stylelint-config-recommended-scss": "^4.2.0",
+    "stylelint-config-recommended-scss": "4.2.0",
     "stylelint-config-standard": "20.0.0",
     "stylelint-order": "4.1.0",
     "stylelint-prettier": "1.1.2",


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

We should no use the version requirement `^x.y.z`. Instead, we should use `x.y.z`.
Because `^x.y.z` can be changeable at runtime.

> Link related issues or pull requests.

Follow-up of #1557
