### PR TITLE
Remove fixed version of `strong_json` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'strong_json', '2.1.0'
+gem 'strong_json'
 gem 'jsonseq'
 gem 'retryable'
 gem 'bundler', '>= 1.12', '< 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ DEPENDENCIES
   rexml (>= 3.2, < 4.0)
   rubocop
   steep
-  strong_json (= 2.1.0)
+  strong_json
   unification_assertion
 
 BUNDLED WITH


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

`Gemfile` and `Gemfile.lock` point to the same version (`2.1.0`).

> Link related issues or pull requests.

None.
