### PR TITLE
[RuboCop] Update constraint for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.36.1...HEAD)
 
+- **RuboCop** Update constraint for v1.0.0 [#1580](https://github.com/sider/runners/pull/1580)
+
 ## 0.36.1
 
 [Full diff](https://github.com/sider/runners/compare/0.36.0...0.36.1)

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -73,7 +73,7 @@ module Runners
     ].freeze
 
     CONSTRAINTS = {
-      "rubocop" => [">= 0.61.0", "< 1.0.0"]
+      "rubocop" => [">= 0.61.0", "< 2.0.0"]
     }.freeze
 
     def default_gem_specs

--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -445,7 +445,7 @@ s.add_test(
     {
       message: <<~MSG.strip,
         `rubocop #{default_version}` is installed instead of `0.60.0` in your `Gemfile.lock`.
-        Because `0.60.0` does not satisfy our constraints `>= 0.61.0, < 1.0.0`.
+        Because `0.60.0` does not satisfy our constraints `>= 0.61.0, < 2.0.0`.
 
         If you want to use a different version of `rubocop`, please do either:
         - Update your `Gemfile.lock` to satisfy the constraint
@@ -509,4 +509,23 @@ s.add_test(
       file: "lib/backtrace_silencers2.rb"
     }
   ]
+)
+
+s.add_test(
+  "v1.0.0",
+  type: "success",
+  issues: [
+    {
+      path: "Gemfile",
+      location: { start_line: 1, start_column: 18, end_line: 1, end_column: 35 },
+      id: "Lint/RedundantCopEnableDirective",
+      message: "Unnecessary enabling of Bundler/GemComment.",
+      links: %w[https://docs.rubocop.org/rubocop/cops_lint.html#lintredundantcopenabledirective],
+      object: { severity: "warning", corrected: false },
+      git_blame_info: {
+        commit: :_, line_hash: "2b6492d28753891a9c883b6043f89234caf80d53", original_line: 1, final_line: 1
+      }
+    }
+  ],
+  analyzer: { name: "RuboCop", version: "1.0.0" }
 )

--- a/test/smokes/rubocop/v1.0.0/Gemfile
+++ b/test/smokes/rubocop/v1.0.0/Gemfile
@@ -1,0 +1,5 @@
+# rubocop:enable Bundler/GemComment
+
+source "https://rubygems.org"
+
+gem "rubocop", "1.0.0"


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

RuboCop 1.0.0 has been released!
https://github.com/rubocop-hq/rubocop/releases/tag/v1.0.0

**Note that this PR will be released as Runners 0.36.2**.

> Link related issues or pull requests.

See also #1576

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
