### PR TITLE
[HAML-Lint] Add `parallel` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Updated tools:
 
 Misc:
 
+- **HAML-Lint** Add `parallel` option [#1582](https://github.com/sider/runners/pull/1582)
 - **stylelint** Add `stylelint-config-recommended-scss` [#1557](https://github.com/sider/runners/pull/1557)
 
 ## 0.36.1

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -13,6 +13,7 @@ module Runners
                         exclude_linter: enum?(string, array(string)),
                         exclude: enum?(string, array(string)),
                         config: string?,
+                        parallel: boolean?,
                         # DO NOT ADD ANY OPTION in `options` option.
                         options: object?(
                           file: string?,
@@ -109,6 +110,10 @@ module Runners
       config ? ["--config", config] : []
     end
 
+    def config_parallel
+      config_linter[:parallel] ? ["--parallel"] : []
+    end
+
     def parse_result(output)
       JSON.parse(output, symbolize_names: true).fetch(:files).flat_map do |file|
         path = file.fetch(:path)
@@ -147,6 +152,7 @@ module Runners
         *exclude_linter,
         *exclude,
         *haml_lint_config,
+        *config_parallel,
         *target,
       )
 

--- a/test/smokes/haml_lint/expectations.rb
+++ b/test/smokes/haml_lint/expectations.rb
@@ -286,3 +286,33 @@ s.add_test(
   ],
   analyzer: { name: "HAML-Lint", version: default_version }
 )
+
+s.add_test(
+  "option_parallel",
+  type: "success",
+  issues: [
+    {
+      message: "Avoid defining `class` in attributes hash for static class names",
+      links: %W[https://github.com/sds/haml-lint/blob/v#{default_version}/lib/haml_lint/linter#classattributewithstaticvalue],
+      id: "ClassAttributeWithStaticValue",
+      path: "1.haml",
+      location: { start_line: 1 },
+      object: { severity: "warning" },
+      git_blame_info: {
+        commit: :_, line_hash: "2f024a2bdf291a1ab61e026140f7e709028266a8", original_line: 1, final_line: 1
+      }
+    },
+    {
+      message: "Avoid defining `class` in attributes hash for static class names",
+      links: %W[https://github.com/sds/haml-lint/blob/v#{default_version}/lib/haml_lint/linter#classattributewithstaticvalue],
+      id: "ClassAttributeWithStaticValue",
+      path: "2.haml",
+      location: { start_line: 1 },
+      object: { severity: "warning" },
+      git_blame_info: {
+        commit: :_, line_hash: "2f024a2bdf291a1ab61e026140f7e709028266a8", original_line: 1, final_line: 1
+      }
+    }
+  ],
+  analyzer: { name: "HAML-Lint", version: default_version }
+)

--- a/test/smokes/haml_lint/option_parallel/1.haml
+++ b/test/smokes/haml_lint/option_parallel/1.haml
@@ -1,0 +1,1 @@
+%tag{ class: 'my-class' }

--- a/test/smokes/haml_lint/option_parallel/2.haml
+++ b/test/smokes/haml_lint/option_parallel/2.haml
@@ -1,0 +1,1 @@
+%tag{ class: 'my-class' }

--- a/test/smokes/haml_lint/option_parallel/sider.yml
+++ b/test/smokes/haml_lint/option_parallel/sider.yml
@@ -1,0 +1,3 @@
+linter:
+  haml_lint:
+    parallel: true


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This PR adds the support of the `--parallel` option since HAML-Lint [0.36.0](https://github.com/sds/haml-lint/releases/tag/v0.36.0).
It is disabled by default.

> Link related issues or pull requests.

Fix #1572

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
