### PR TITLE
Split test from build workflow on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,29 +21,6 @@ jobs:
           ${{ toJson(github.event) }}
           MESSAGE
 
-  test:
-    runs-on: ubuntu-latest
-    needs: check_skip
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-      - run: bundle exec rake test
-        env:
-          TESTOPTS: --verbose
-      - run: bundle exec rake readme:generate
-
-  timeout_test:
-    runs-on: ubuntu-latest
-    needs: check_skip
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-      - run: bundle exec rake docker:timeout_test
-
   build:
     runs-on: ubuntu-latest
     needs: check_skip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches: ["master"]
+    tags: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec rake test
+        env:
+          TESTOPTS: --verbose
+      - run: bundle exec rake readme:generate
+      - run: bundle exec rake docker:timeout_test


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to allow us to retry only the "Test" workflow.
(The "Build" workflow is slow because of including smoke tests)

> Link related issues or pull requests.

None.
