### PR TITLE
Generate missing `.rbs` files

### DIFF
--- a/sig/runners.rbs
+++ b/sig/runners.rbs
@@ -1,3 +1,2 @@
 module Runners
-  VERSION: String
 end

--- a/sig/runners/analyzer.rbs
+++ b/sig/runners/analyzer.rbs
@@ -1,8 +1,11 @@
-class Runners::Analyzer
-  attr_reader name: String
-  attr_reader version: String
+module Runners
+  class Analyzer
+    attr_reader name: String
+    attr_reader version: String
 
-  def initialize: (name: String, version: String) -> untyped
-  def valid?: () -> bool
-  def as_json: () -> { name: String, version: String }
+    def initialize: (name: String, version: String) -> void
+
+    def valid?: () -> bool
+    def as_json: () -> { name: String, version: String }
+  end
 end

--- a/sig/runners/analyzers.rbs
+++ b/sig/runners/analyzers.rbs
@@ -1,0 +1,15 @@
+module Runners
+  class Analyzers
+    def name: (untyped id) -> untyped
+
+    def github: (untyped id) -> untyped
+
+    def doc: (untyped id) -> untyped
+
+    def deprecated?: (untyped id) -> untyped
+
+    def content: () -> untyped
+
+    def analyzer: (untyped id) -> untyped
+  end
+end

--- a/sig/runners/changes.rbs
+++ b/sig/runners/changes.rbs
@@ -1,0 +1,23 @@
+module Runners
+  class Changes
+    attr_reader changed_paths: untyped
+
+    attr_reader unchanged_paths: untyped
+
+    attr_reader patches: untyped
+
+    def initialize: (changed_paths: untyped changed_paths, unchanged_paths: untyped unchanged_paths, patches: untyped patches) -> untyped
+
+    def delete_unchanged: (dir: untyped dir, ?except: untyped except, ?only: untyped only) -> untyped
+
+    def deletable?: (untyped dir, untyped file, untyped except, untyped only) -> (untyped | ::FalseClass)
+
+    def include?: (untyped issue) -> untyped
+
+    def self.calculate: (working_dir: untyped working_dir) -> untyped
+
+    def self.calculate_by_patches: (working_dir: untyped working_dir, patches: untyped patches) -> untyped
+
+    def self.all_files_in: (untyped basedir) -> untyped
+  end
+end

--- a/sig/runners/cli.rbs
+++ b/sig/runners/cli.rbs
@@ -9,7 +9,8 @@ module Runners
     attr_reader options: Options
 
     def initialize: (argv: Array[String], stdout: ::IO, stderr: ::IO, options_json: String) -> void
-    def with_working_dir: [X] { (Pathname) -> X } -> X
+
+    def with_working_dir: [X] () { (Pathname) -> X } -> X
     def processor_class: () -> Class
     def run: () -> untyped
     def io: () -> Runners::IO

--- a/sig/runners/config.rbs
+++ b/sig/runners/config.rbs
@@ -1,33 +1,45 @@
-class Runners::Config
-  attr_reader working_dir: Pathname
-  attr_reader raw_content: String?
-  attr_reader content: Hash[Symbol, untyped]
+module Runners
+  class Config
+    class Error < UserError
+      attr_reader raw_content: untyped
 
-  def initialize: (Pathname working_dir) -> void
-  def raw_content!: () -> String
-  def path_name: () -> String
-  def path_exist?: () -> bool
-  def ignore_patterns: () -> Array[String]
-  def linter: (String) -> Hash[Symbol, untyped]
-  def linter?: (String) -> bool
+      def initialize: (untyped message, untyped raw_content) -> untyped
+    end
 
-  private
-  def path: () -> Pathname?
-  def parse_yaml: () -> String?
-  def check_schema: (String? object) -> Hash[Symbol, untyped]
+    class BrokenYAML < Error
+    end
+
+    class InvalidConfiguration < Error
+    end
+
+    CONFIG_FILE_NAME: untyped
+
+    OLD_CONFIG_FILE_NAME: untyped
+
+    attr_reader working_dir: untyped
+
+    attr_reader raw_content: untyped
+
+    attr_reader content: untyped
+
+    def initialize: (untyped working_dir) -> untyped
+
+    def raw_content!: () -> untyped
+
+    def path_name: () -> untyped
+
+    def path_exist?: () -> untyped
+
+    def ignore_patterns: () -> untyped
+
+    def linter: (untyped id) -> untyped
+
+    def linter?: (untyped id) -> untyped
+
+    def path: () -> untyped
+
+    def parse_yaml: () -> untyped
+
+    def check_schema: (untyped object) -> untyped
+  end
 end
-
-class Runners::Config::Error < Runners::UserError
-  attr_reader raw_content: String
-
-  def initialize: (String message, String raw_content) -> void
-end
-
-class Runners::Config::BrokenYAML < Runners::Config::Error
-end
-
-class Runners::Config::InvalidConfiguration < Runners::Config::Error
-end
-
-Runners::Config::CONFIG_FILE_NAME: String
-Runners::Config::OLD_CONFIG_FILE_NAME: String

--- a/sig/runners/cplusplus.rbs
+++ b/sig/runners/cplusplus.rbs
@@ -1,0 +1,17 @@
+module Runners
+  module CPlusPlus
+    # @see https://github.com/github/linguist/blob/775b07d40c04ef6e0051a541886a8f1e30a892f4/lib/linguist/languages.yml#L532-L535
+    # @see https://github.com/github/linguist/blob/775b07d40c04ef6e0051a541886a8f1e30a892f4/lib/linguist/languages.yml#L568-L584
+    CPP_SOURCES_GLOB: untyped
+
+    CPP_HEADERS_GLOB: untyped
+
+    def config_include_path: () -> untyped
+
+    def cpp_file?: (untyped path) -> untyped
+
+    def install_apt_packages: () -> untyped
+
+    def find_paths_containing_headers: () -> untyped
+  end
+end

--- a/sig/runners/errors.rbs
+++ b/sig/runners/errors.rbs
@@ -1,8 +1,10 @@
-class Runners::Error < StandardError
-end
+module Runners
+  class Error < StandardError
+  end
 
-class Runners::UserError < Runners::Error
-end
+  class UserError < Error
+  end
 
-class Runners::SystemError < Runners::Error
+  class SystemError < Error
+  end
 end

--- a/sig/runners/git_blame_info.rbs
+++ b/sig/runners/git_blame_info.rbs
@@ -1,0 +1,23 @@
+module Runners
+  class GitBlameInfo
+    # @param porcelain_output [String] The output of git-blame(1) with -p option
+    # @see https://www.git-scm.com/docs/git-blame#_the_porcelain_format
+    def self.parse: (untyped porcelain_output) -> untyped
+
+    attr_reader commit: untyped
+
+    attr_reader original_line: untyped
+
+    attr_reader final_line: untyped
+
+    attr_reader line_hash: untyped
+
+    def initialize: (commit: untyped commit, original_line: untyped original_line, final_line: untyped final_line, line_hash: untyped line_hash) -> untyped
+
+    def ==: (untyped other) -> untyped
+
+    def hash: () -> untyped
+
+    def as_json: () -> { commit: untyped, original_line: untyped, final_line: untyped, line_hash: untyped }
+  end
+end

--- a/sig/runners/go.rbs
+++ b/sig/runners/go.rbs
@@ -1,0 +1,5 @@
+module Runners
+  module Go
+    def show_runtime_versions: () -> untyped
+  end
+end

--- a/sig/runners/harness.rbs
+++ b/sig/runners/harness.rbs
@@ -4,6 +4,7 @@ module Runners
 
     class InvalidResult < SystemError
       attr_reader result: untyped
+
       def initialize: (result: untyped) -> void
     end
 
@@ -20,11 +21,12 @@ module Runners
                      options: Options,
                      working_dir: Pathname,
                      trace_writer: TraceWriter) -> void
+
     def run: () -> untyped
 
     private
     def ensure_result: () { () -> untyped } -> untyped
-    def handle_error: (Exception exn) -> void
-    def exclude_special_dirs: [X] { () -> X } -> X
+    def handle_error: (Exception) -> void
+    def exclude_special_dirs: [X] () { () -> X } -> X
   end
 end

--- a/sig/runners/ignoring.rbs
+++ b/sig/runners/ignoring.rbs
@@ -4,6 +4,7 @@ module Runners
     attr_reader ignore_patterns: Array[String]
 
     def initialize: (workspace: Workspace, ignore_patterns: Array[String]) -> void
+
     def delete_ignored_files!: () -> Array[String]
   end
 end

--- a/sig/runners/io.rbs
+++ b/sig/runners/io.rbs
@@ -1,8 +1,11 @@
-class Runners::IO
-  attr_reader ios: Array[::IO]
+module Runners
+  class IO
+    attr_reader ios: Array[::IO]
 
-  def initialize: (*::IO ios) -> void
-  def write: (*_ToS) -> void
-  def flush: () -> void
-  def flush!: () -> void
+    def initialize: (*::IO) -> void
+
+    def write: (*_ToS) -> void
+    def flush: () -> void
+    def flush!: () -> void
+  end
 end

--- a/sig/runners/io/aws_s3.rbs
+++ b/sig/runners/io/aws_s3.rbs
@@ -1,0 +1,39 @@
+module Runners
+  # This class expects AWS credentials set with environment variables or an instance profile.
+  # So, before using this, make sure AWS credentials available.
+  # Also, prepare the S3 bucket and allow this instance to upload an S3 object.
+  class IO::AwsS3
+    # @type const BUFFER_SIZE: Integer
+    BUFFER_SIZE: ::Integer
+
+    # Only for test
+    # @see https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ClientStubs.html
+    def self.stub?: () -> ::FalseClass
+
+    attr_reader uri: untyped
+
+    attr_reader bucket_name: untyped
+
+    attr_reader object_name: untyped
+
+    attr_reader tempfile: untyped
+
+    attr_reader written_items: untyped
+
+    attr_reader client: untyped
+
+    def initialize: (untyped uri, ?endpoint: untyped? endpoint) -> untyped
+
+    def write: (*untyped args) -> untyped
+
+    def flush: () -> untyped
+
+    def should_flush?: () -> untyped
+
+    def flush!: () -> untyped
+
+    def parse_s3_uri: (untyped s3_uri) -> untyped
+
+    def flush_to_s3!: () -> untyped
+  end
+end

--- a/sig/runners/issue.rbs
+++ b/sig/runners/issue.rbs
@@ -1,0 +1,29 @@
+module Runners
+  class Issue
+    attr_reader path: untyped
+
+    attr_reader location: untyped
+
+    attr_reader id: untyped
+
+    attr_reader message: untyped
+
+    attr_reader links: untyped
+
+    attr_reader object: untyped
+
+    attr_reader git_blame_info: untyped
+
+    def initialize: (path: untyped path, location: untyped location, id: untyped id, message: untyped message, ?links: untyped links, ?object: untyped? object, ?schema: untyped? schema) -> untyped
+
+    def missing_id?: () -> untyped
+
+    def ==: (untyped other) -> untyped
+
+    def hash: () -> untyped
+
+    def as_json: () -> untyped
+
+    def add_git_blame_info: (untyped workspace) -> untyped
+  end
+end

--- a/sig/runners/java.rbs
+++ b/sig/runners/java.rbs
@@ -1,0 +1,18 @@
+module Runners
+  module Java
+    class InvalidDependency < UserError
+    end
+
+    def show_runtime_versions: () -> untyped
+
+    def install_jvm_deps: () -> (nil | untyped)
+
+    def jvm_deps_dir: () -> untyped
+
+    def fetch_deps_via_gradle!: () -> untyped
+
+    def config_jvm_deps: () -> untyped
+
+    def generate_jvm_deps_file: () -> untyped
+  end
+end

--- a/sig/runners/kotlin.rbs
+++ b/sig/runners/kotlin.rbs
@@ -1,0 +1,6 @@
+module Runners
+  module Kotlin
+    # @see https://github.com/github/linguist/blob/b24ff11d9cf60dd996156a718f83024c9436e5ea/lib/linguist/languages.yml#L2698-L2701
+    def kotlin_file_extensions: () -> ::Array[".kt" | ".ktm" | ".kts"]
+  end
+end

--- a/sig/runners/location.rbs
+++ b/sig/runners/location.rbs
@@ -1,0 +1,21 @@
+module Runners
+  class Location
+    attr_reader start_line: untyped
+
+    attr_reader start_column: untyped
+
+    attr_reader end_line: untyped
+
+    attr_reader end_column: untyped
+
+    def initialize: (start_line: untyped start_line, ?start_column: untyped? start_column, ?end_line: untyped? end_line, ?end_column: untyped? end_column) -> untyped
+
+    def ==: (untyped other) -> untyped
+
+    def hash: () -> untyped
+
+    def as_json: () -> untyped
+
+    def to_s: () -> ::String
+  end
+end

--- a/sig/runners/nodejs.rbs
+++ b/sig/runners/nodejs.rbs
@@ -1,0 +1,71 @@
+module Runners
+  module Nodejs
+    class InvalidNodeVersion < SystemError
+    end
+
+    class InvalidNpmVersion < SystemError
+    end
+
+    class InvalidYarnVersion < SystemError
+    end
+
+    class ConstraintsNotSatisfied < UserError
+    end
+
+    class NpmInstallFailed < UserError
+    end
+
+    class YarnInstallFailed < UserError
+    end
+
+    INSTALL_OPTION_NONE: bool
+
+    INSTALL_OPTION_ALL: bool
+
+    INSTALL_OPTION_PRODUCTION: ::String
+
+    INSTALL_OPTION_DEVELOPMENT: ::String
+
+    # Return the locally installed analyzer command.
+    def nodejs_analyzer_local_command: () -> ::String
+
+    # Return the analyzer command which will actually be ran.
+    def nodejs_analyzer_bin: () -> untyped
+
+    def analyzer_version: () -> untyped
+
+    # Return the actual file path of `package.json`.
+    def package_json_path: () -> untyped
+
+    # Return the `Hash` content of `package.json`.
+    def package_json: () -> untyped
+
+    # Return the actual file path of `package-lock.json`.
+    def package_lock_json_path: () -> untyped
+
+    # Return the actual file path of `yarn.lock`.
+    def yarn_lock_path: () -> untyped
+
+    # Install Node.js dependencies by using given parameters.
+    def install_nodejs_deps: (constraints: untyped constraints, install_option: untyped install_option) -> (nil | untyped)
+
+    def show_runtime_versions: () -> untyped
+
+    def nodejs_analyzer_locally_installed?: () -> untyped
+
+    def nodejs_analyzer_global_version: () -> untyped
+
+    def nodejs_analyzer_local_version: () -> untyped
+
+    # @see https://docs.npmjs.com/cli/install
+    # @see https://docs.npmjs.com/cli/ci
+    def npm_install: (untyped option) -> (nil | untyped)
+
+    # @see https://yarnpkg.com/en/docs/cli/install
+    def yarn_install: (untyped option) -> (nil | untyped)
+
+    def list_installed_nodejs_deps: (?only: untyped only, ?chdir: untyped? chdir) -> (::Hash[untyped, untyped] | untyped)
+
+    def check_installed_nodejs_deps: (untyped constraints) -> (nil | untyped)
+  end
+end

--- a/sig/runners/nodejs/constraint.rbs
+++ b/sig/runners/nodejs/constraint.rbs
@@ -1,0 +1,13 @@
+module Runners
+  module Nodejs
+    class Constraint
+      def initialize: (untyped version, *untyped versions) -> untyped
+
+      def to_s: () -> untyped
+
+      def satisfied_by?: (untyped dependency) -> untyped
+
+      def unsatisfied_by?: (untyped dependency) -> untyped
+    end
+  end
+end

--- a/sig/runners/nodejs/dependency.rbs
+++ b/sig/runners/nodejs/dependency.rbs
@@ -1,0 +1,13 @@
+module Runners
+  module Nodejs
+    class Dependency
+      attr_reader name: untyped
+
+      attr_reader version: untyped
+
+      def initialize: (name: untyped name, version: untyped version) -> untyped
+
+      def to_s: () -> ::String
+    end
+  end
+end

--- a/sig/runners/options.rbs
+++ b/sig/runners/options.rbs
@@ -1,24 +1,28 @@
-class Runners::Options
-  attr_reader stdout: ::IO
-  attr_reader stderr: ::IO
-  attr_reader source: GitSource
-  attr_reader ssh_key: String?
-  attr_reader io: Runners::IO
+module Runners
+  class Options
+    class GitSource
+      attr_reader head: String
+      attr_reader base: String?
+      attr_reader git_url: String
+      attr_reader git_url_userinfo: String?
+      attr_reader refspec: (Array[String] | String)?
 
-  def initialize: (String, ::IO stdout, ::IO stderr) -> void
-  def parse_options: (String) -> Hash[Symbol, untyped]
-end
+      def initialize: (head: String,
+                       ?base: String?,
+                       git_url: String,
+                       ?git_url_userinfo: String?,
+                       ?refspec: (Array[String] | String)?) -> void
+    end
 
-class Runners::Options::GitSource
-  attr_reader head: String
-  attr_reader base: String?
-  attr_reader git_url: String
-  attr_reader git_url_userinfo: String?
-  attr_reader refspec: (Array[String] | String)?
+    attr_reader stdout: ::IO
+    attr_reader stderr: ::IO
+    attr_reader source: GitSource
+    attr_reader ssh_key: String?
+    attr_reader io: Runners::IO
 
-  def initialize: (head: String,
-                   ?base: String?,
-                   git_url: String,
-                   ?git_url_userinfo: String?,
-                   ?refspec: (Array[String] | String)?) -> void
+    def initialize: (String json, ::IO stdout, ::IO stderr) -> void
+
+    private
+    def parse_options: (String json) -> Hash[Symbol, untyped]
+  end
 end

--- a/sig/runners/php.rbs
+++ b/sig/runners/php.rbs
@@ -1,0 +1,5 @@
+module Runners
+  module PHP
+    def show_runtime_versions: () -> untyped
+  end
+end

--- a/sig/runners/processor.rbs
+++ b/sig/runners/processor.rbs
@@ -1,3 +1,102 @@
-class Runners::Processor
+module Runners
+  class Processor
+    extend Forwardable
 
+    include Tmpdir
+
+    class CIConfigBroken < UserError
+    end
+
+    attr_reader guid: untyped
+
+    attr_reader working_dir: untyped
+
+    attr_reader git_ssh_path: untyped
+
+    attr_reader trace_writer: untyped
+
+    attr_reader warnings: untyped
+
+    attr_reader config: untyped
+
+    attr_reader shell: untyped
+
+    def self.register_config_schema: (**untyped args) -> untyped
+
+    # TODO: Keep the following schemas for the backward compatibility.
+    RemovedGoToolSchema: untyped
+
+    def initialize: (guid: untyped guid, working_dir: untyped working_dir, config: untyped config, git_ssh_path: untyped git_ssh_path, trace_writer: untyped trace_writer) -> untyped
+
+    def relative_path: (untyped original, ?from: untyped from) -> untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def analyzers: () -> untyped
+
+    def analyzer_name: () -> untyped
+
+    def analyzer_doc: () -> untyped
+
+    def analyzer_github: () -> untyped
+
+    def analyzer: () -> untyped
+
+    def analyzer_bin: () -> untyped
+
+    def analyzer_version: () -> untyped
+
+    def extract_version_option: () -> "--version"
+
+    def extract_version!: (untyped command, ?untyped version_option, ?pattern: untyped pattern) -> untyped
+
+    def config_linter: () -> untyped
+
+    def check_root_dir_exist: () -> (nil | untyped)
+
+    def in_root_dir: () { () -> untyped } -> untyped
+
+    def root_dir: () -> untyped
+
+    def missing_config_file_result: (untyped file) -> untyped
+
+    # Returns e.g. "linter.rubocop.gems"
+    def config_field_path: (*untyped fields) -> ::String
+
+    def delete_unchanged_files: (untyped changes, ?except: untyped except, ?only: untyped only) -> untyped
+
+    def add_warning: (untyped message, ?file: untyped? file) -> untyped
+
+    def add_warning_if_deprecated_version: (minimum: untyped minimum, ?file: untyped? file, ?deadline: untyped? deadline) -> untyped
+
+    def add_warning_if_deprecated_options: () -> (nil | untyped)
+
+    def add_warning_for_deprecated_option: (untyped name, to: untyped to) -> (nil | untyped)
+
+    def add_warning_for_deprecated_linter: (alternative: untyped alternative, ref: untyped ref, ?deadline: untyped? deadline) -> untyped
+
+    # Prohibit directory traversal attack, e.g.
+    # - '../../etc/passwd'
+    # - 'config/../../../etc/passwd'
+    def directory_traversal_attack?: (untyped path) -> untyped
+
+    def show_runtime_versions: () -> nil
+
+    def report_file: () -> untyped
+
+    def report_file_exist?: () -> untyped
+
+    def read_report_file: (?untyped file_path) -> untyped
+
+    class InvalidXML < SystemError
+    end
+
+    def read_report_xml: (?untyped file_path) -> untyped
+
+    def read_report_json: (?untyped file_path) { () -> untyped } -> untyped
+
+    def comma_separated_list: (untyped value) -> untyped
+  end
 end

--- a/sig/runners/processor/brakeman.rbs
+++ b/sig/runners/processor/brakeman.rbs
@@ -1,0 +1,13 @@
+module Runners
+  class Processor::Brakeman < Processor
+    include Ruby
+
+    Schema: untyped
+
+    CONSTRAINTS: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+  end
+end

--- a/sig/runners/processor/checkstyle.rbs
+++ b/sig/runners/processor/checkstyle.rbs
@@ -1,0 +1,27 @@
+module Runners
+  class Processor::Checkstyle < Processor
+    include Java
+
+    Schema: untyped
+
+    DEFAULT_TARGET: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def checkstyle_args: () -> untyped
+
+    def construct_result: (untyped xml_root) { (untyped) -> untyped } -> untyped
+
+    OFFICIAL_RULE_NAMESPACE: ::String
+
+    def normalize_id: (untyped rule_id) -> untyped
+
+    def build_links: (untyped rule_id) -> (::Array[untyped] | ::Array[::String])
+
+    def config_file: () -> untyped
+
+    def excluded_directories: () -> untyped
+  end
+end

--- a/sig/runners/processor/clang_tidy.rbs
+++ b/sig/runners/processor/clang_tidy.rbs
@@ -1,0 +1,15 @@
+module Runners
+  class Processor::ClangTidy < Processor
+    include CPlusPlus
+
+    Schema: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyzer_bin: () -> "clang-tidy"
+
+    def analyze: (untyped changes) -> untyped
+
+    def construct_result: (untyped stdout) { (untyped) -> untyped } -> untyped
+  end
+end

--- a/sig/runners/processor/code_sniffer.rbs
+++ b/sig/runners/processor/code_sniffer.rbs
@@ -1,0 +1,29 @@
+module Runners
+  class Processor::CodeSniffer < Processor
+    include PHP
+
+    Schema: untyped
+
+    def analyzer_bin: () -> "phpcs"
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def additional_options: () -> untyped
+
+    def standard_option: () -> ::String
+
+    def extensions_option: () -> ::String
+
+    def encoding_option: () -> untyped
+
+    def ignore_option: () -> untyped
+
+    def directory: () -> untyped
+
+    def default_options: () -> untyped
+
+    def php_framework: () -> (:CakePHP | :Symfony | nil)
+  end
+end

--- a/sig/runners/processor/coffeelint.rbs
+++ b/sig/runners/processor/coffeelint.rbs
@@ -1,0 +1,15 @@
+module Runners
+  class Processor::Coffeelint < Processor
+    include Nodejs
+
+    Schema: untyped
+
+    CONSTRAINTS: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped _changes) -> untyped
+
+    def config_file: () -> untyped
+  end
+end

--- a/sig/runners/processor/cppcheck.rbs
+++ b/sig/runners/processor/cppcheck.rbs
@@ -1,0 +1,39 @@
+module Runners
+  class Processor::Cppcheck < Processor
+    include CPlusPlus
+
+    class NoTargetFiles < SystemError
+    end
+
+    Schema: untyped
+
+    DEFAULT_TARGET: untyped
+
+    DEFAULT_IGNORE: untyped
+
+    def analyze: (untyped _changes) -> untyped
+
+    def target: () -> untyped
+
+    def ignore: () -> untyped
+
+    def addon: () -> untyped
+
+    def enable: () -> untyped
+
+    def std: () -> untyped
+
+    def project: () -> untyped
+
+    def language: () -> untyped
+
+    def jobs: () -> untyped
+
+    def run_analyzer: () -> untyped
+
+    def step_analyzer: (*untyped args) -> untyped
+
+    # @see https://github.com/danmar/cppcheck/blob/master/man/manual.md#xml-output
+    def parse_result: (untyped xml_root) { (untyped) -> untyped } -> untyped
+  end
+end

--- a/sig/runners/processor/cpplint.rbs
+++ b/sig/runners/processor/cpplint.rbs
@@ -1,0 +1,29 @@
+module Runners
+  class Processor::Cpplint < Processor
+    include RecommendedConfig
+
+    Schema: untyped
+
+    DEFAULT_TARGET: untyped
+
+    CONFIG_FILE_NAME: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def analyzer_options: () -> untyped
+
+    # Output format:
+    #
+    #     {line}: {message} [{category}] [{confidence}]
+    #
+    # Example:
+    #
+    #     3: Tab found; better to use spaces [whitespace/tab] [1]
+    #
+    # @see https://github.com/cpplint/cpplint/blob/1.5.2/cpplint.py#L1396
+    # @see https://github.com/cpplint/cpplint/blob/1.5.2/cpplint.py#L1686-L1693
+    def parse_result: (untyped xml_root) -> untyped
+  end
+end

--- a/sig/runners/processor/detekt.rbs
+++ b/sig/runners/processor/detekt.rbs
@@ -1,0 +1,31 @@
+module Runners
+  class Processor::Detekt < Processor
+    include Java
+
+    include Kotlin
+
+    Schema: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def cli_baseline: () -> untyped
+
+    def cli_config: () -> untyped
+
+    def cli_config_resource: () -> untyped
+
+    def cli_disable_default_rulesets: () -> untyped
+
+    def cli_excludes: () -> untyped
+
+    def cli_includes: () -> untyped
+
+    def cli_input: () -> untyped
+
+    def cli_report: () -> ::Array["--report" | ::String]
+
+    def parse_output: () -> untyped
+  end
+end

--- a/sig/runners/processor/eslint.rbs
+++ b/sig/runners/processor/eslint.rbs
@@ -1,0 +1,49 @@
+module Runners
+  class Processor::Eslint < Processor
+    include Nodejs
+
+    Schema: untyped
+
+    CONSTRAINTS: untyped
+
+    CUSTOM_FORMATTER: untyped
+
+    DEFAULT_ESLINT_CONFIG: untyped
+
+    DEFAULT_TARGET: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped _changes) -> untyped
+
+    def target: () -> untyped
+
+    def eslint_config: () -> untyped
+
+    def ext: () -> untyped
+
+    def ignore_path: () -> untyped
+
+    def ignore_pattern: () -> untyped
+
+    def no_ignore: () -> untyped
+
+    def global: () -> untyped
+
+    def quiet: () -> untyped
+
+    # @see https://eslint.org/docs/user-guide/configuring#configuring-rules
+    def normalize_severity: (untyped severity) -> untyped
+
+    # @see https://eslint.org/docs/developer-guide/working-with-custom-formatters#the-results-object
+    def parse_result: (untyped result) { (untyped) -> untyped } -> untyped
+
+    def run_analyzer: (?config: untyped? config) -> untyped
+
+    # NOTE: Linting nonexistent files is a fatal error since v5.0.0.
+    # @see https://eslint.org/docs/user-guide/migrating-to-5.0.0#-linting-nonexistent-files-from-the-command-line-is-now-a-fatal-error
+    def no_linting_files?: (untyped stderr) -> untyped
+
+    def no_eslint_config?: (untyped stderr) -> untyped
+  end
+end

--- a/sig/runners/processor/flake8.rbs
+++ b/sig/runners/processor/flake8.rbs
@@ -1,0 +1,33 @@
+module Runners
+  class Processor::Flake8 < Processor
+    include Python
+
+    Schema: untyped
+
+    # Output example:
+    #
+    # E999:::app1/views.py:::6:::12:::IndentationError: unexpected indent
+    #
+    # `:::` is a separater
+    #
+    OUTPUT_FORMAT: untyped
+
+    OUTPUT_PATTERN: untyped
+
+    DEFAULT_TARGET: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def prepare_config: () -> untyped
+
+    def prepare_plugins: () -> untyped
+
+    def ignored_config_path: () -> untyped
+
+    def parse_result: (untyped output) { (untyped) -> untyped } -> untyped
+
+    def run_analyzer: () -> untyped
+  end
+end

--- a/sig/runners/processor/fxcop.rbs
+++ b/sig/runners/processor/fxcop.rbs
@@ -1,0 +1,11 @@
+module Runners
+  class Processor::FxCop < Processor
+    Schema: untyped
+
+    def analyzer_version: () -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def construct_result: (untyped result, untyped json) -> untyped
+  end
+end

--- a/sig/runners/processor/golangci_lint.rbs
+++ b/sig/runners/processor/golangci_lint.rbs
@@ -1,0 +1,42 @@
+module Runners
+  class Processor::GolangCiLint < Processor
+    include Go
+
+    Schema: untyped
+
+    DEFAULT_TARGET: untyped
+
+    DEFAULT_CONFIG_FILE: untyped
+
+    # @see https://golangci-lint.run/usage/configuration/#config-file
+    SUPPORTED_CONFIG_FILES: untyped
+
+    def analyzer_bin: () -> "golangci-lint"
+
+    def analyze: (untyped _changes) -> untyped
+
+    def run_analyzer: () -> untyped
+
+    def analyzer_options: () -> untyped
+
+    def path_to_config: () -> (untyped | nil)
+
+    def analysis_targets: () -> untyped
+
+    # Output format:
+    #
+    #      ["{"Issues":[{"FromLinter":"govet","Text":"printf: Printf call has arguments but no formatting directives",
+    #      "SourceLines":["\tfmt.Printf(\\\"text\\\", awesome_text)\"],\"Replacement\":null,
+    #      \"Pos\":{\"Filename\":\"test/smokes/golangci_lint/success/main.go\",\"Offset\":85,\"Line\":7,\"Column\":12}}],
+    #      \"Report\":{\"Linters\":[{\"Name\":\"govet\",\"Enabled\":true,\"EnabledByDefault\":true},
+    #      {\"Name\":\"bodyclose\"}...
+    #
+    # Example:
+    #
+    #     {:FromLinter=>"govet", :Text=>"printf: Printf call has arguments but no formatting directives",
+    #     :SourceLines=>["\tfmt.Printf(\"text\", awesome_text)"], :Replacement=>nil,
+    #     :Pos=>{:Filename=>"test/smokes/golangci_lint/success/main.go", :Offset=>85, :Line=>7, :Column=>12}}
+    #
+    def parse_result: (untyped output) { (untyped) -> untyped } -> untyped
+  end
+end

--- a/sig/runners/processor/goodcheck.rbs
+++ b/sig/runners/processor/goodcheck.rbs
@@ -1,0 +1,23 @@
+module Runners
+  class Processor::Goodcheck < Processor
+    include Ruby
+
+    Schema: untyped
+
+    CONSTRAINTS: untyped
+
+    DEFAULT_TARGET: untyped
+
+    DEFAULT_CONFIG_FILE: untyped
+
+    def extract_version_option: () -> "version"
+
+    def goodcheck_test: () -> untyped
+
+    def goodcheck_check: () -> untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+  end
+end

--- a/sig/runners/processor/hadolint.rbs
+++ b/sig/runners/processor/hadolint.rbs
@@ -1,0 +1,31 @@
+module Runners
+  class Processor::Hadolint < Processor
+    Schema: untyped
+
+    DEFAULT_TARGET: untyped
+
+    DEFAULT_TARGET_EXCLUDED: untyped
+
+    def analyze: (untyped _changes) -> untyped
+
+    def analyzer_options: () -> untyped
+
+    def analysis_target: () -> untyped
+
+    def run_analyzer: () -> untyped
+
+    # Output format:
+    #
+    #     { line: number, code: rule, message: description, column: number, file: filepath, level: level }
+    #
+    # Example:
+    #
+    #     {"line":14,"code":"DL3003","message":"Use WORKDIR to switch to a directory","column":1,"file":"images/hadolint/Dockerfile","level":"warning"}
+    #
+    # @see https://github.com/hadolint/hadolint#rules
+    # @param stdout [String]
+    def parse_result: (untyped stdout) -> untyped
+
+    def link_to_wiki: (untyped id) -> untyped
+  end
+end

--- a/sig/runners/processor/haml_lint.rbs
+++ b/sig/runners/processor/haml_lint.rbs
@@ -1,0 +1,51 @@
+module Runners
+  class Processor::HamlLint < Processor
+    include Ruby
+
+    Schema: untyped
+
+    OPTIONAL_GEMS: untyped
+
+    DEFAULT_GEMS: untyped
+
+    CONSTRAINTS: untyped
+
+    DEFAULT_TARGET: untyped
+
+    DEFAULT_RUBOCOP_CONFIG: untyped
+
+    def analyzer_bin: () -> "haml-lint"
+
+    def default_gem_specs: () -> untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped _changes) -> untyped
+
+    def setup_default_rubocop_config: () -> (nil | untyped)
+
+    def target: () -> untyped
+
+    def include_linter: () -> untyped
+
+    def exclude_linter: () -> untyped
+
+    def exclude: () -> untyped
+
+    def haml_lint_config: () -> untyped
+
+    def config_parallel: () -> untyped
+
+    def parse_result: (untyped output) -> untyped
+
+    def build_links: (untyped issue_id) -> (::Array[untyped] | ::Array[::String])
+
+    def run_analyzer: () -> untyped
+
+    # NOTE: HAML-Lint exits successfully even if RuboCop fails.
+    #       The version 0.35.0 fixed the issue, but we continue to support older versions.
+    #
+    # @see https://github.com/sds/haml-lint/issues/317
+    def add_rubocop_warnings_if_exists: (untyped stderr) -> untyped
+  end
+end

--- a/sig/runners/processor/javasee.rbs
+++ b/sig/runners/processor/javasee.rbs
@@ -1,0 +1,17 @@
+module Runners
+  class Processor::Javasee < Processor
+    include Java
+
+    Schema: untyped
+
+    DEFAULT_CONFIG_FILE: untyped
+
+    def extract_version_option: () -> "version"
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def construct_result: (untyped result, untyped stdout, untyped stderr) -> untyped
+  end
+end

--- a/sig/runners/processor/jshint.rbs
+++ b/sig/runners/processor/jshint.rbs
@@ -1,0 +1,21 @@
+module Runners
+  class Processor::Jshint < Processor
+    include Nodejs
+
+    Schema: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def prepare_config: () -> (nil | untyped)
+
+    def jshintrc_exist?: () -> (::TrueClass | ::FalseClass)
+
+    def config_path: () -> untyped
+
+    def parse_result: (untyped output) { (untyped) -> untyped } -> untyped
+
+    def run_analyzer: () -> untyped
+  end
+end

--- a/sig/runners/processor/ktlint.rbs
+++ b/sig/runners/processor/ktlint.rbs
@@ -1,0 +1,15 @@
+module Runners
+  class Processor::Ktlint < Processor
+    include Java
+
+    include Kotlin
+
+    Schema: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def parse_json_output: (untyped output) { (untyped) -> untyped } -> untyped
+  end
+end

--- a/sig/runners/processor/languagetool.rbs
+++ b/sig/runners/processor/languagetool.rbs
@@ -1,0 +1,60 @@
+module Runners
+  class Processor::LanguageTool < Processor
+    include Java
+
+    Schema: untyped
+
+    DEFAULT_TARGET: untyped
+
+    DEFAULT_EXT: untyped
+
+    DEFAULT_EXCLUDE: untyped
+
+    DEFAULT_LANGUAGE: untyped
+
+    # NOTE: Need a variant for spell checking
+    DEFAULT_ENCODING: untyped
+
+    DEFAULT_DISABLE: untyped
+
+    DEFAULT_ENABLE: untyped
+
+    DEFAULT_DISABLECATEGORIES: untyped
+
+    DEFAULT_ENABLECATEGORIES: untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def delete_files_except_targets: () -> untyped
+
+    def config_target: () -> untyped
+
+    def config_ext: () -> untyped
+
+    def config_exclude: () -> untyped
+
+    def config_language: () -> untyped
+
+    def config_encoding: () -> untyped
+
+    def cli_comma_separated_list: (untyped config_option, untyped default_value, untyped cli_option) -> untyped
+
+    def cli_disable: () -> untyped
+
+    def cli_enable: () -> untyped
+
+    def cli_enabledonly: () -> untyped
+
+    def cli_disablecategories: () -> untyped
+
+    def cli_enablecategories: () -> untyped
+
+    def cli_args: () -> untyped
+
+    def run_analyzer: () -> untyped
+
+    def parse_output: (untyped output) { (untyped, untyped) -> untyped } -> (nil | untyped)
+
+    def offset_ranges_per_line: (untyped lines) -> untyped
+  end
+end

--- a/sig/runners/processor/misspell.rbs
+++ b/sig/runners/processor/misspell.rbs
@@ -1,0 +1,25 @@
+module Runners
+  class Processor::Misspell < Processor
+    Schema: untyped
+
+    DEFAULT_TARGET: untyped
+
+    def extract_version_option: () -> "-v"
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped _changes) -> untyped
+
+    def run_analyzer: () -> untyped
+
+    def cli_args: () -> untyped
+
+    def locale: () -> untyped
+
+    def ignore: () -> untyped
+
+    def analysis_targets: () -> untyped
+
+    def delete_targets: () -> (nil | untyped)
+  end
+end

--- a/sig/runners/processor/phinder.rbs
+++ b/sig/runners/processor/phinder.rbs
@@ -1,0 +1,17 @@
+module Runners
+  class Processor::Phinder < Processor
+    include PHP
+
+    Schema: untyped
+
+    DEFAULT_RULE_FILE: untyped
+
+    def test_phinder_config: () -> untyped
+
+    def run_phinder: () -> untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+  end
+end

--- a/sig/runners/processor/phpmd.rbs
+++ b/sig/runners/processor/phpmd.rbs
@@ -1,0 +1,31 @@
+module Runners
+  class Processor::Phpmd < Processor
+    include PHP
+
+    Schema: untyped
+
+    DEFAULT_TARGET: untyped
+
+    DEFAULT_CONFIG_FILE: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def target_files: () -> untyped
+
+    def rule: () -> untyped
+
+    def target_dirs: () -> untyped
+
+    def minimumpriority: () -> untyped
+
+    def suffixes: () -> untyped
+
+    def exclude: () -> untyped
+
+    def strict: () -> untyped
+
+    def run_analyzer: (untyped changes) -> untyped
+  end
+end

--- a/sig/runners/processor/pmd_cpd.rbs
+++ b/sig/runners/processor/pmd_cpd.rbs
@@ -1,0 +1,57 @@
+module Runners
+  class Processor::PmdCpd < Processor
+    include Java
+
+    Schema: untyped
+
+    DEFAULT_MINIMUM_TOKENS: ::Integer
+
+    DEFAULT_FILES: untyped
+
+    DEFAULT_LANGUAGE: untyped
+
+    def analyzer_version: () -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def run_analyzer: () -> untyped
+
+    def raise_warnings: (untyped stderr) -> untyped
+
+    def construct_result: (untyped stdout) { (untyped) -> untyped } -> untyped
+
+    def to_fileinfo: (untyped elem_file) -> { id: untyped, path: untyped, location: untyped }
+
+    def create_issue_object: (untyped elem_dupli, untyped files) -> { lines: untyped, tokens: untyped, files: untyped, codefragment: untyped }
+
+    def option_files: () -> untyped
+
+    def option_encoding: () -> untyped
+
+    def option_minimum_tokens: () -> untyped
+
+    def languages: () -> untyped
+
+    def option_language: (untyped v) -> ::Array["--language" | untyped]
+
+    def option_skip_duplicate_files: () -> untyped
+
+    def option_non_recursive: () -> untyped
+
+    def option_skip_lexical_errors: () -> untyped
+
+    def option_ignore_annotations: () -> untyped
+
+    def option_ignore_identifiers: () -> untyped
+
+    def option_ignore_literals: () -> untyped
+
+    def option_ignore_usings: () -> untyped
+
+    def option_no_skip_blocks: () -> untyped
+
+    def option_skip_blocks_pattern: () -> untyped
+
+    def cli_options: (untyped language) -> untyped
+  end
+end

--- a/sig/runners/processor/pmd_java.rbs
+++ b/sig/runners/processor/pmd_java.rbs
@@ -1,0 +1,33 @@
+module Runners
+  class Processor::PmdJava < Processor
+    include Java
+
+    Schema: untyped
+
+    DEFAULT_RULESET: untyped
+
+    DEFAULT_DIR: untyped
+
+    def analyzer_version: () -> untyped
+
+    def analyzer_bin: () -> "pmd"
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def cli_args: () -> untyped
+
+    def run_analyzer: () -> untyped
+
+    def construct_result: (untyped xml) { (untyped) -> untyped } -> untyped
+
+    def rulesets: () -> untyped
+
+    def dir: () -> untyped
+
+    def encoding: () -> untyped
+
+    def min_priority: () -> untyped
+  end
+end

--- a/sig/runners/processor/pylint.rbs
+++ b/sig/runners/processor/pylint.rbs
@@ -1,0 +1,23 @@
+module Runners
+  class Processor::Pylint < Processor
+    include Python
+
+    Schema: untyped
+
+    DEFAULT_TARGET: untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def rcfile: () -> untyped
+
+    def ignore: () -> untyped
+
+    def erros_only: () -> untyped
+
+    def analyzed_files: () -> untyped
+
+    def parse_result: (untyped output) { (untyped) -> untyped } -> untyped
+
+    def run_analyzer: () -> untyped
+  end
+end

--- a/sig/runners/processor/querly.rbs
+++ b/sig/runners/processor/querly.rbs
@@ -1,0 +1,27 @@
+module Runners
+  class Processor::Querly < Processor
+    include Ruby
+
+    Schema: untyped
+
+    OPTIONAL_GEMS: untyped
+
+    CONSTRAINTS: untyped
+
+    CONFIG_FILE: untyped
+
+    CONFIG_FILES_GLOB: untyped
+
+    def extract_version_option: () -> "version"
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def config_file: () -> untyped
+
+    def default_config_file: () -> untyped
+
+    def test_config_file: () -> untyped
+  end
+end

--- a/sig/runners/processor/rails_best_practices.rbs
+++ b/sig/runners/processor/rails_best_practices.rbs
@@ -1,0 +1,33 @@
+module Runners
+  class Processor::RailsBestPractices < Processor
+    include Ruby
+
+    Schema: untyped
+
+    OPTIONAL_GEMS: untyped
+
+    CONSTRAINTS: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped _changes) -> untyped
+
+    def vendor: () -> untyped
+
+    def spec: () -> untyped
+
+    def test: () -> untyped
+
+    def features: () -> untyped
+
+    def exclude: () -> untyped
+
+    def only: () -> untyped
+
+    def config_option: () -> untyped
+
+    def prepare_config: () -> (nil | untyped)
+
+    def run_analyzer: (untyped options) -> untyped
+  end
+end

--- a/sig/runners/processor/reek.rbs
+++ b/sig/runners/processor/reek.rbs
@@ -1,0 +1,23 @@
+module Runners
+  class Processor::Reek < Processor
+    include Ruby
+
+    Schema: untyped
+
+    CONSTRAINTS: untyped
+
+    DEFAULT_TARGET: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def analysis_targets: () -> untyped
+
+    def cli_args: () -> untyped
+
+    def v4?: () -> untyped
+
+    def raise_warnings: (untyped stderr) -> untyped
+  end
+end

--- a/sig/runners/processor/remark_lint.rbs
+++ b/sig/runners/processor/remark_lint.rbs
@@ -1,0 +1,49 @@
+module Runners
+  class Processor::RemarkLint < Processor
+    include Nodejs
+
+    Schema: untyped
+
+    CONSTRAINTS: untyped
+
+    DEFAULT_TARGET: untyped
+
+    DEFAULT_PRESET: untyped
+
+    def analyzer_bin: () -> "remark"
+
+    def extract_version!: (untyped command, ?::String version_option, ?pattern: untyped pattern) -> untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped _changes) -> untyped
+
+    def remark_lint_version!: (?global: bool global) -> untyped
+
+    def analysis_target: () -> untyped
+
+    def option_ext: () -> untyped
+
+    def option_rc_path: () -> untyped
+
+    def option_ignore_path: () -> untyped
+
+    def option_use: () -> untyped
+
+    # @see https://github.com/unifiedjs/unified-engine/blob/master/doc/configure.md
+    def no_rc_files?: () -> untyped
+
+    # @see https://github.com/unifiedjs/unified-engine/blob/master/doc/configure.md
+    def no_config_in_package_json?: () -> untyped
+
+    def use_default_preset?: () -> untyped
+
+    def default_preset: () -> untyped
+
+    def cli_options: () -> untyped
+
+    def run_analyzer: () -> untyped
+
+    def parse_result: (untyped output) -> ::Array[untyped]
+  end
+end

--- a/sig/runners/processor/rubocop.rbs
+++ b/sig/runners/processor/rubocop.rbs
@@ -1,0 +1,45 @@
+module Runners
+  class Processor::RuboCop < Processor
+    include Ruby
+
+    Schema: untyped
+
+    # The followings are maintained by RuboCop Headquarters.
+    # @see https://github.com/rubocop-hq
+    OFFICIAL_RUBOCOP_PLUGINS: untyped
+
+    OPTIONAL_GEMS: untyped
+
+    CONSTRAINTS: untyped
+
+    def default_gem_specs: () -> untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped _) -> untyped
+
+    def rails_option: () -> untyped
+
+    def config_file: () -> untyped
+
+    def safe: () -> untyped
+
+    def setup_default_config: () -> (::FalseClass | ::TrueClass)
+
+    def check_rubocop_yml_warning: (untyped stderr) -> untyped
+
+    def run_analyzer: (untyped options) -> untyped
+
+    # @see https://github.com/rubocop-hq/rubocop/blob/v0.76.0/lib/rubocop/cop/message_annotator.rb#L62-L63
+    def extract_links: (untyped original_message) -> untyped
+
+    def build_cop_links: (untyped cop_name) -> (::Array[::String] | ::Array[untyped])
+
+    def department_to_gem_name: () -> untyped
+
+    def normalize_message: (untyped original_message, untyped links, untyped cop_name) -> untyped
+
+    # @see https://github.com/rubocop-hq/rubocop/blob/v0.72.0/CHANGELOG.md
+    def rails_cops_removed?: () -> untyped
+  end
+end

--- a/sig/runners/processor/scss_lint.rbs
+++ b/sig/runners/processor/scss_lint.rbs
@@ -1,0 +1,25 @@
+module Runners
+  class Processor::ScssLint < Processor
+    include Ruby
+
+    Schema: untyped
+
+    # https://github.com/brigade/scss-lint#exit-status-codes
+    EXIT_CODE_FILES_NOT_EXIST: ::Integer
+
+    def analyzer_bin: () -> "scss-lint"
+
+    def analyzer_version: () -> untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped _changes) -> untyped
+
+    def scss_lint_config: () -> untyped
+
+    # @param stdout [String]
+    def parse_result: (untyped stdout) -> untyped
+
+    def run_analyzer: (untyped options) -> untyped
+  end
+end

--- a/sig/runners/processor/shellcheck.rbs
+++ b/sig/runners/processor/shellcheck.rbs
@@ -1,0 +1,26 @@
+module Runners
+  class Processor::ShellCheck < Processor
+    Schema: untyped
+
+    DEFAULT_TARGET: untyped
+
+    # NOTE: Follow file(1) format.
+    #
+    # @see https://linux.die.net/man/1/file
+    SHELL_SCRIPT_SHEBANG_PATTERN: untyped
+
+    def analyze: (untyped _changes) -> untyped
+
+    def find_files_with_shebang: () -> untyped
+
+    def analyzed_files: () -> untyped
+
+    def option_values: (untyped name, untyped sep) -> untyped
+
+    def analyzer_options: () -> untyped
+
+    def run_analyzer: () -> untyped
+
+    def parse_result: (untyped output) { (untyped) -> untyped } -> untyped
+  end
+end

--- a/sig/runners/processor/stylelint.rbs
+++ b/sig/runners/processor/stylelint.rbs
@@ -1,0 +1,58 @@
+module Runners
+  class Processor::Stylelint < Processor
+    include Nodejs
+
+    Schema: untyped
+
+    CONSTRAINTS: untyped
+
+    DEFAULT_TARGET_FILES: untyped
+
+    DEFAULT_GLOB: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def glob: () -> untyped
+
+    def stylelint_config: () -> untyped
+
+    def syntax: () -> untyped
+
+    def ignore_path: () -> untyped
+
+    def ignore_disables: () -> untyped
+
+    def report_needless_disables: () -> untyped
+
+    def quiet: () -> untyped
+
+    # @param stdout [String]
+    def parse_result: (untyped stdout) -> untyped
+
+    # @see https://github.com/stylelint/stylelint/blob/11.1.1/lib/formatters/stringFormatter.js#L120
+    def normalize_message: (untyped id, untyped message) -> untyped
+
+    # @see https://github.com/stylelint/stylelint/blob/11.1.1/lib/formatters/stringFormatter.js#L120
+    def rule_doc_urls: () -> untyped
+
+    def prepare_config_file: () -> (nil | untyped)
+
+    def prepare_ignore_file: () -> (nil | untyped)
+
+    # returns available config file path. If the file doesn't exist, it returns nil.
+    def config_file_path: () -> untyped
+
+    # Save warnings written by stylelint.
+    # stylelint writes "deprecations" flags in each file, so we cannot conduct naive implementations.
+    # Without this method, if we write a warning when the "deprecations" appear,
+    # the same number of duplicated warnings as files will appear.
+    # We use `Set` to avoid it.
+    #
+    # @param deprecations [Array<Hash>]
+    def check_warning: (untyped deprecations) -> untyped
+
+    def run_analyzer: (untyped glob, untyped additional_options) -> untyped
+  end
+end

--- a/sig/runners/processor/swiftlint.rbs
+++ b/sig/runners/processor/swiftlint.rbs
@@ -1,0 +1,27 @@
+module Runners
+  class Processor::Swiftlint < Processor
+    include Swift
+
+    Schema: untyped
+
+    def extract_version_option: () -> "version"
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped changes) -> untyped
+
+    def ignore_warnings?: () -> untyped
+
+    def cli_path: () -> untyped
+
+    def cli_config: () -> untyped
+
+    def cli_lenient: () -> untyped
+
+    def cli_enable_all_rules: () -> untyped
+
+    def parse_result: (untyped output) -> untyped
+
+    def run_analyzer: () -> untyped
+  end
+end

--- a/sig/runners/processor/tslint.rbs
+++ b/sig/runners/processor/tslint.rbs
@@ -1,0 +1,27 @@
+module Runners
+  class Processor::Tslint < Processor
+    include Nodejs
+
+    Schema: untyped
+
+    CONSTRAINTS: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped _changes) -> untyped
+
+    def target_glob: () -> untyped
+
+    def tslint_config: () -> untyped
+
+    def exclude: () -> untyped
+
+    def project: () -> untyped
+
+    def rules_dir: () -> untyped
+
+    def type_check: () -> untyped
+
+    def run_analyzer: (untyped target, untyped options) -> untyped
+  end
+end

--- a/sig/runners/processor/tyscan.rbs
+++ b/sig/runners/processor/tyscan.rbs
@@ -1,0 +1,20 @@
+module Runners
+  class Processor::Tyscan < Processor
+    include Nodejs
+
+    # Define schema in sider.yml
+    Schema: untyped
+
+    CONSTRAINTS: untyped
+
+    DEFAULT_CONFIG_FILE: untyped
+
+    def setup: () { () -> untyped } -> untyped
+
+    def analyze: (untyped _) -> untyped
+
+    def tyscan_test: () -> untyped
+
+    def tyscan_scan: () -> untyped
+  end
+end

--- a/sig/runners/python.rbs
+++ b/sig/runners/python.rbs
@@ -1,0 +1,5 @@
+module Runners
+  module Python
+    def show_runtime_versions: () -> untyped
+  end
+end

--- a/sig/runners/recommended_config.rbs
+++ b/sig/runners/recommended_config.rbs
@@ -1,0 +1,9 @@
+module Runners
+  module RecommendedConfig
+    def warn_recommended_config_file_release: (untyped config_filename, untyped deadline) -> (nil | untyped)
+
+    def deploy_recommended_config_file: (untyped config_filename) -> (nil | untyped)
+
+    def exists_in_repository?: (untyped config_filename) -> untyped
+  end
+end

--- a/sig/runners/results.rbs
+++ b/sig/runners/results.rbs
@@ -1,0 +1,72 @@
+module Runners
+  module Results
+    class Base
+      # @dynamic guid, timestamp
+      attr_reader guid: untyped
+
+      attr_reader timestamp: untyped
+
+      def initialize: (guid: untyped guid) -> untyped
+
+      def as_json: () -> { guid: untyped, timestamp: untyped }
+
+      def valid?: () -> untyped
+    end
+
+    # Result to indicate that processing finished successfully
+    # Client programs may return this result.
+    class Success < Base
+      # @dynamic issues, analyzer
+      attr_reader issues: untyped
+
+      attr_reader analyzer: untyped
+
+      def initialize: (guid: untyped guid, analyzer: untyped analyzer, ?issues: untyped issues) -> untyped
+
+      def as_json: () -> untyped
+
+      def valid?: () -> untyped
+
+      def add_issue: (*untyped issue) -> untyped
+
+      def filter_issues: (untyped changes) -> untyped
+
+      def add_git_blame_info: (untyped workspace) -> untyped
+
+      def each_missing_id_warning: () { (untyped) -> untyped } -> untyped
+    end
+
+    # Result to indicate that processing failed by some error.
+    # Client programs may return this result.
+    class Failure < Base
+      DEFAULT_MESSAGE: untyped
+
+      # @dynamic message, analyzer
+      attr_reader message: untyped
+
+      attr_reader analyzer: untyped
+
+      def initialize: (guid: untyped guid, ?message: untyped message, ?analyzer: untyped? analyzer) -> untyped
+
+      def as_json: () -> untyped
+
+      def valid?: () -> untyped
+    end
+
+    # Result to indicate that processor raises an exception.
+    # Client programs should not return this result.
+    class Error < Base
+      # @dynamic exception, analyzer
+      attr_reader exception: untyped
+
+      # @dynamic exception, analyzer
+      attr_reader analyzer: untyped
+
+      def initialize: (guid: untyped guid, exception: untyped exception, analyzer: untyped analyzer) -> untyped
+
+      def as_json: () -> untyped
+
+      def valid?: () -> untyped
+    end
+  end
+end

--- a/sig/runners/ruby.rbs
+++ b/sig/runners/ruby.rbs
@@ -1,0 +1,24 @@
+module Runners
+  module Ruby
+    class InstallGemsFailure < UserError
+    end
+
+    def install_gems: (untyped default_specs, constraints: untyped constraints, ?optionals: untyped optionals) { () -> untyped } -> untyped
+
+    def default_specs: (untyped specs, untyped constraints, untyped lockfile) -> untyped
+
+    def optional_specs: (untyped specs, untyped lockfile) -> untyped
+
+    def user_specs: (untyped specs, untyped lockfile) -> untyped
+
+    def show_runtime_versions: () -> untyped
+
+    def ruby_analyzer_bin: () -> ::Array["bundle" | "exec" | untyped]
+
+    def analyzer_version: () -> untyped
+
+    def installed_gem_versions: (untyped gem_name, *untyped gem_names, ?exception: bool exception) -> untyped
+
+    def default_gem_specs: (?untyped gem_name, *untyped gem_names) -> untyped
+  end
+end

--- a/sig/runners/ruby/gem_installer.rbs
+++ b/sig/runners/ruby/gem_installer.rbs
@@ -1,0 +1,38 @@
+module Runners
+  module Ruby
+    class GemInstaller
+      class InstallationFailure < InstallGemsFailure
+      end
+
+      attr_reader gem_home: untyped
+
+      attr_reader specs: untyped
+
+      attr_reader trace_writer: untyped
+
+      attr_reader shell: untyped
+
+      attr_reader constraints: untyped
+
+      attr_reader config_path_name: untyped
+
+      attr_reader use_local: untyped
+
+      def initialize: (shell: untyped shell, home: untyped home, config_path_name: untyped config_path_name, specs: untyped specs, constraints: untyped constraints, trace_writer: untyped trace_writer, use_local: untyped use_local) -> untyped
+
+      def gemfile_path: () -> untyped
+
+      def lockfile_path: () -> untyped
+
+      def install!: () { (untyped) -> untyped } -> untyped
+
+      def gemfile_content: () -> untyped
+
+      def group_specs: () -> untyped
+
+      def gem: (untyped spec, untyped constraints) -> untyped
+
+      def gem_constraints: (untyped spec, untyped source) -> (::Array[untyped] | untyped)
+    end
+  end
+end

--- a/sig/runners/ruby/gem_installer/source.rbs
+++ b/sig/runners/ruby/gem_installer/source.rbs
@@ -1,0 +1,59 @@
+module Runners
+  class Ruby::GemInstaller
+    class Source
+      DEFAULT: untyped
+
+      def self.default: () -> untyped
+
+      def self.rubygems: (untyped source) -> untyped
+
+      def self.git: (untyped repo, **untyped options) -> untyped
+
+      def self.create: (untyped gems_item) -> untyped
+
+      def rubygems?: () -> ::FalseClass
+
+      def git?: () -> ::FalseClass
+
+      def default?: () -> ::FalseClass
+
+      # @see https://bundler.io/man/gemfile.5.html#SOURCE
+      class Rubygems < Source
+        attr_reader source: untyped
+
+        def initialize: (untyped source) -> untyped
+
+        def rubygems?: () -> ::TrueClass
+
+        def default?: () -> untyped
+
+        def ==: (untyped other) -> untyped
+
+        def hash: () -> untyped
+
+        def to_s: () -> ::String
+      end
+
+      # @see https://bundler.io/man/gemfile.5.html#GIT
+      class Git < Source
+        attr_reader repo: untyped
+
+        attr_reader ref: untyped
+
+        attr_reader branch: untyped
+
+        attr_reader tag: untyped
+
+        def initialize: (untyped repo, ?ref: untyped? ref, ?branch: untyped? branch, ?tag: untyped? tag) -> untyped
+
+        def git?: () -> ::TrueClass
+
+        def ==: (untyped other) -> untyped
+
+        def hash: () -> untyped
+
+        def to_s: () -> untyped
+      end
+    end
+  end
+end

--- a/sig/runners/ruby/gem_installer/spec.rbs
+++ b/sig/runners/ruby/gem_installer/spec.rbs
@@ -1,0 +1,25 @@
+module Runners
+  module Ruby
+    class GemInstaller
+      class Spec
+        attr_reader name: untyped
+
+        attr_reader version: untyped
+
+        attr_reader source: untyped
+
+        def initialize: (name: untyped name, version: untyped version, ?source: untyped source) -> untyped
+
+        def ==: (untyped other) -> untyped
+
+        def hash: () -> untyped
+
+        def override_by_lockfile: (untyped lockfile) -> untyped
+
+        def self.from_gems: (untyped gems_items) -> untyped
+
+        def self.merge: (untyped default_gems, untyped user_gems) -> untyped
+      end
+    end
+  end
+end

--- a/sig/runners/ruby/lockfile_loader.rbs
+++ b/sig/runners/ruby/lockfile_loader.rbs
@@ -1,0 +1,24 @@
+module Runners
+  module Ruby
+    class LockfileLoader
+      include Tmpdir
+
+      class InvalidGemfileLock < InstallGemsFailure
+      end
+
+      attr_reader root_dir: untyped
+
+      attr_reader shell: untyped
+
+      def initialize: (root_dir: untyped root_dir, shell: untyped shell) -> untyped
+
+      def ensure_lockfile: () { (untyped) -> untyped } -> untyped
+
+      def gemfile_path: () -> untyped
+
+      def gemfile_lock_path: () -> untyped
+
+      def generate_lockfile: (untyped lockfile_path) -> (untyped | nil)
+    end
+  end
+end

--- a/sig/runners/ruby/lockfile_loader/lockfile.rbs
+++ b/sig/runners/ruby/lockfile_loader/lockfile.rbs
@@ -1,0 +1,21 @@
+module Runners
+  module Ruby
+    class LockfileLoader
+      class Lockfile
+        attr_reader specs: untyped
+
+        def initialize: (untyped lockfile_content) -> untyped
+
+        def spec_exists?: (untyped spec) -> untyped
+
+        def locked_version: (untyped spec) -> untyped
+
+        def locked_version!: (untyped spec) -> untyped
+
+        def satisfied_by?: (untyped spec, untyped constraints) -> untyped
+
+        def find_spec: (untyped spec) -> untyped
+      end
+    end
+  end
+end

--- a/sig/runners/ruby/lockfile_parser.rbs
+++ b/sig/runners/ruby/lockfile_parser.rbs
@@ -1,0 +1,12 @@
+module Runners
+  module Ruby
+    module LockfileParser
+      # HACK: This wrapper method aims to prevent the `Bundler::GemfileNotFound` error.
+      #       Because Bundler assumes that the `Gemfile` file exists.
+      #
+      # @see https://github.com/bundler/bundler/blob/ebe0b853d8f2ac93f9c69768ee6af2c18fbc9d87/lib/bundler/shared_helpers.rb#L13-L17
+      # @see https://github.com/bundler/bundler/blob/ebe0b853d8f2ac93f9c69768ee6af2c18fbc9d87/lib/bundler/shared_helpers.rb#L242-L246
+      def parse: (untyped content) -> untyped
+    end
+  end
+end

--- a/sig/runners/schema.rbs
+++ b/sig/runners/schema.rbs
@@ -1,2 +1,0 @@
-module Runners::Schema
-end

--- a/sig/runners/schema/config.rbs
+++ b/sig/runners/schema/config.rbs
@@ -1,0 +1,7 @@
+module Runners
+  module Schema
+    BaseConfig: untyped
+
+    Config: untyped
+  end
+end

--- a/sig/runners/schema/options.rbs
+++ b/sig/runners/schema/options.rbs
@@ -1,0 +1,5 @@
+module Runners
+  module Schema
+    Options: untyped
+  end
+end

--- a/sig/runners/schema/result.rbs
+++ b/sig/runners/schema/result.rbs
@@ -1,3 +1,7 @@
-class Runners::Schema::Result
-  def self.envelope: () -> untyped
+module Runners
+  module Schema
+    Issue: untyped
+
+    Result: untyped
+  end
 end

--- a/sig/runners/schema/trace.rbs
+++ b/sig/runners/schema/trace.rbs
@@ -1,0 +1,5 @@
+module Runners
+  module Schema
+    Trace: untyped
+  end
+end

--- a/sig/runners/sensitive_filter.rbs
+++ b/sig/runners/sensitive_filter.rbs
@@ -5,6 +5,7 @@ module Runners
     @options: Options
 
     def initialize: (options: Options) -> void
+
     def mask: (String) -> String
 
     private

--- a/sig/runners/shell.rbs
+++ b/sig/runners/shell.rbs
@@ -14,25 +14,20 @@ module Runners
                        stderr_str: String,
                        status: Process::Status,
                        dir: Pathname) -> void
-      def bugsnag_meta_data: () -> {
-        details: {
-          args: Array[String],
-          stdout: String,
-          stderr: String,
-          status: Integer?
-        }
-      }
+
+      def bugsnag_meta_data: () -> { details: { args: Array[String], stdout: String, stderr: String, status: Integer? } }
     end
 
-    @current_dir: Pathname
+    SIGUSR2: Integer
 
     attr_reader trace_writer: TraceWriter
     attr_reader current_dir: Pathname
     attr_reader env_hash_stack: Array[Hash[String, String?]]
 
     def initialize: (current_dir: Pathname,
-                     env_hash: Hash[String, String?],
-                     trace_writer: TraceWriter) -> void
+                     trace_writer: TraceWriter,
+                     env_hash: Hash[String, String?]) -> void
+
     def chdir: [X] (Pathname) { (Pathname) -> X } -> X
     def push_env_hash: [X] (Hash[String, String?]) { () -> X } -> X
     def env_hash: () -> Hash[String, String?]

--- a/sig/runners/swift.rbs
+++ b/sig/runners/swift.rbs
@@ -1,0 +1,5 @@
+module Runners
+  module Swift
+    def show_runtime_versions: () -> untyped
+  end
+end

--- a/sig/runners/testing/smoke.rbs
+++ b/sig/runners/testing/smoke.rbs
@@ -1,0 +1,64 @@
+module Runners
+  module Testing
+    class Smoke
+      include Minitest::Assertions
+
+      class TestParams
+        attr_reader name: untyped
+
+        attr_reader pattern: untyped
+
+        attr_reader offline: untyped
+
+        def initialize: (name: untyped name, pattern: untyped pattern, offline: untyped offline) -> untyped
+
+        def ==: (untyped other) -> untyped
+
+        def hash: () -> untyped
+      end
+
+      attr_reader argv: untyped
+
+      def docker_image: () -> untyped
+
+      def entrypoint: () -> untyped
+
+      def expectations: () -> untyped
+
+      def initialize: (untyped argv) -> untyped
+
+      def run: () -> untyped
+
+      def run_test: (untyped params, untyped `out`) -> untyped
+
+      def unify_result: (untyped result, untyped pattern, untyped `out`) -> untyped
+
+      def command_line: (params: untyped params, repo_dir: untyped repo_dir, base: untyped base, head: untyped head) -> untyped
+
+      def prepare_git_repository: (workdir: untyped workdir, smoke_target: untyped smoke_target, out: untyped `out`) -> untyped
+
+      def debug?: () -> untyped
+
+      def debug_trace?: () -> untyped
+
+      def sh!: (*untyped command, out: untyped `out`, ?exception: bool exception) -> ::Array[untyped]
+
+      def colored_pretty_inspect: (untyped obj, ?multiline: bool multiline) -> untyped
+
+      def extra_certificate: () -> untyped
+
+      def self.tests: () -> untyped
+
+      # Comma-separated value is also available.
+      def self.only?: (untyped name) -> untyped
+
+      def self.add_test: (untyped name, **untyped pattern) -> untyped
+
+      def self.add_offline_test: (untyped name, **untyped pattern) -> untyped
+
+      def self.add_test_helper: (untyped test) -> (nil | untyped)
+
+      def self.build_pattern: (type: untyped `type`, ?guid: ::String guid, ?timestamp: ::Symbol timestamp, ?issues: untyped? issues, ?message: untyped? message, ?analyzer: untyped? analyzer, ?class: untyped? `class`, ?backtrace: untyped? backtrace, ?inspect: untyped? inspect, ?warnings: untyped warnings, ?ci_config: ::Symbol ci_config, ?config_file: ::Symbol config_file, ?version: ::Symbol version) -> { result: untyped, warnings: untyped, ci_config: untyped, config_file: untyped, version: untyped }
+    end
+  end
+end

--- a/sig/runners/tmpdir.rbs
+++ b/sig/runners/tmpdir.rbs
@@ -1,6 +1,6 @@
-module Runners::Tmpdir
-  include Kernel
-
-  def mktmpdir: [X] { (Pathname) -> X } -> X
-  def mktmpdir_as_pathname: -> Pathname
+module Runners
+  module Tmpdir
+    def mktmpdir: [X] () { (Pathname) -> X } -> X
+    def mktmpdir_as_pathname: () -> Pathname
+  end
 end

--- a/sig/runners/trace_writer.rbs
+++ b/sig/runners/trace_writer.rbs
@@ -4,19 +4,20 @@ module Runners
     attr_reader filter: SensitiveFilter
 
     def initialize: (writer: JSONSEQ::Writer, filter: SensitiveFilter) -> void
-    def command_line: (Array[String] command_line, ?recorded_at: Time) -> void
-    def status: (Process::Status status, ?recorded_at: Time) -> untyped
-    def stdout: (String string, ?recorded_at: Time, ?max_length: Integer) -> void
-    def stderr: (String string, ?recorded_at: Time, ?max_length: Integer) -> void
-    def message: (String message, ?recorded_at: Time, ?max_length: Integer, ?limit: Integer, ?omission: String) ?{ () -> untyped } -> untyped
-    def header: (String message, ?recorded_at: Time) -> void
-    def warning: (String message, ?file: String?, ?recorded_at: Time) -> void
-    def ci_config: (Hash[Symbol, untyped] content, raw_content: String, file: String, ?recorded_at: Time) -> void
-    def error: (String message, ?recorded_at: Time, ?max_length: Integer) -> void
-    def <<: (Hash[Symbol, untyped] object) -> void
+
+    def command_line: (Array[String], ?recorded_at: Time) -> void
+    def status: (Process::Status status, ?recorded_at: Time) -> void
+    def stdout: (String, ?recorded_at: Time, ?max_length: Integer) -> void
+    def stderr: (String, ?recorded_at: Time, ?max_length: Integer) -> void
+    def message: (String, ?recorded_at: Time, ?max_length: Integer, ?limit: Integer, ?omission: String) { () -> void } -> void
+    def header: (String, ?recorded_at: Time) -> void
+    def warning: (String, ?file: String?, ?recorded_at: Time) -> void
+    def ci_config: (Hash[Symbol, untyped], raw_content: String, file: String, ?recorded_at: Time) -> void
+    def error: (String, ?recorded_at: Time, ?max_length: Integer) -> void
+    def <<: (Hash[Symbol, untyped]) -> void
 
     private
-    def now: () -> untyped
-    def each_slice: (String string, size: Integer) { (String, bool) -> void } -> void
+    def now: () -> Time
+    def each_slice: (String, size: Integer) { (String, bool) -> void } -> void
   end
 end

--- a/sig/runners/version.rbs
+++ b/sig/runners/version.rbs
@@ -1,0 +1,3 @@
+module Runners
+  VERSION: String
+end

--- a/sig/runners/workspace.rbs
+++ b/sig/runners/workspace.rbs
@@ -1,2 +1,27 @@
-class Runners::Workspace
+module Runners
+  class Workspace
+    include Tmpdir
+
+    def self.prepare: (options: untyped options, working_dir: untyped working_dir, trace_writer: untyped trace_writer) -> untyped
+
+    attr_reader options: untyped
+
+    attr_reader working_dir: untyped
+
+    attr_reader trace_writer: untyped
+
+    attr_reader shell: untyped
+
+    def initialize: (options: untyped options, working_dir: untyped working_dir, trace_writer: untyped trace_writer) -> untyped
+
+    def open: () { (untyped, untyped) -> untyped } -> untyped
+
+    def range_git_blame_info: (untyped path_string, untyped start_line, untyped end_line) -> ::Array[untyped]
+
+    def prepare_head_source: () -> untyped
+
+    def patches: () -> untyped
+
+    def prepare_ssh: () { (untyped) -> untyped } -> untyped
+  end
 end

--- a/sig/runners/workspace/git.rbs
+++ b/sig/runners/workspace/git.rbs
@@ -1,0 +1,30 @@
+module Runners
+  class Workspace::Git < Workspace
+    class FetchFailed < SystemError
+    end
+
+    class CheckoutFailed < SystemError
+    end
+
+    class BlameFailed < SystemError
+    end
+
+    def range_git_blame_info: (untyped path_string, untyped start_line, untyped end_line) -> untyped
+
+    def prepare_head_source: () -> untyped
+
+    def git_source: () -> untyped
+
+    # for testing
+    def try_count: () -> 10
+
+    # for testing
+    def sleep_lambda: () -> untyped
+
+    def remote_url: () -> untyped
+
+    def git_fetch_args: () -> untyped
+
+    def patches: () -> untyped
+  end
+end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change generates missing `.rbs` files via the following script:

```ruby
Dir["lib/runners/**/*.rb"].sort.each do |file|
  file_rbs = file.sub("lib/", "sig/").sub(".rb", ".rbs")
  Pathname(file_rbs).parent.mkpath
  system "bundle exec rbs prototype rb '#{file}' > '#{file_rbs}'"
end
```

> Link related issues or pull requests.

This is a part of #877.
