### PR TITLE
Reduce log for git-blame(1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.37.1...HEAD)
 
+- Reduce log for git-blame(1) [#1632](https://github.com/sider/runners/pull/1632)
+
 ## 0.37.1
 
 [Full diff](https://github.com/sider/runners/compare/0.37.0...0.37.1)

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -4,14 +4,14 @@ module Runners
     class CheckoutFailed < SystemError; end
     class BlameFailed < SystemError; end
 
-    def range_git_blame_info(path_string, start_line, end_line)
+    def range_git_blame_info(path_string, start_line, end_line, trace: false)
       @git_blame_cache ||= {}
       cache_key = "#{path_string}\t#{start_line}\t#{end_line}"
       cache_value = @git_blame_cache[cache_key]
       return cache_value if cache_value
 
       stdout, _ = shell.capture3!("git", "blame", "-p", "-L", "#{start_line},#{end_line}", git_source.head, "--", path_string,
-                                  trace_stdout: false, trace_stderr: false, trace_command_line: false)
+                                  trace_stdout: trace, trace_stderr: trace, trace_command_line: trace)
       GitBlameInfo.parse(stdout).tap do |result|
         @git_blame_cache[cache_key] = result
       end

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -11,7 +11,7 @@ module Runners
       return cache_value if cache_value
 
       stdout, _ = shell.capture3!("git", "blame", "-p", "-L", "#{start_line},#{end_line}", git_source.head, "--", path_string,
-                                  trace_stdout: false, trace_stderr: true)
+                                  trace_stdout: false, trace_stderr: false, trace_command_line: false)
       GitBlameInfo.parse(stdout).tap do |result|
         @git_blame_cache[cache_key] = result
       end

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -6,7 +6,7 @@ module Runners
 
     def range_git_blame_info(path_string, start_line, end_line, trace: false)
       @git_blame_cache ||= {}
-      cache_key = "#{path_string}\t#{start_line}\t#{end_line}"
+      cache_key = :"#{path_string}\t#{start_line}\t#{end_line}"
       cache_value = @git_blame_cache[cache_key]
       return cache_value if cache_value
 

--- a/sig/runners/workspace/git.rbs
+++ b/sig/runners/workspace/git.rbs
@@ -9,7 +9,7 @@ module Runners
     class BlameFailed < SystemError
     end
 
-    def range_git_blame_info: (untyped path_string, untyped start_line, untyped end_line) -> untyped
+    def range_git_blame_info: (String, Integer, Integer, ?trace: bool) -> GitBlameInfo
 
     def prepare_head_source: () -> untyped
 

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -107,7 +107,7 @@ class WorkspaceGitTest < Minitest::Test
   def test_git_blame_info
     with_workspace(head: "330716dcd50a7a2c7d8ff79d74035c05453528b4", base: "cd33ab59ef3d75e54e6d49c000bc8f141d94d356") do |workspace|
       workspace.prepare_head_source
-      actual = workspace.range_git_blame_info("README.md", 1, 2)
+      actual = workspace.range_git_blame_info("README.md", 1, 2, trace: true)
       expected = [
         GitBlameInfo.new(commit: "cd33ab59ef3d75e54e6d49c000bc8f141d94d356", original_line: 1, final_line: 1, line_hash: "82c89d4ea306d31642e44c10609b686671e485dc"),
         GitBlameInfo.new(commit: "330716dcd50a7a2c7d8ff79d74035c05453528b4", original_line: 2, final_line: 2, line_hash: "da39a3ee5e6b4b0d3255bfef95601890afd80709"),
@@ -115,7 +115,7 @@ class WorkspaceGitTest < Minitest::Test
       assert_equal expected, actual
 
       # Using cache
-      actual = workspace.range_git_blame_info("README.md", 1, 2)
+      actual = workspace.range_git_blame_info("README.md", 1, 2, trace: true)
       assert_equal expected, actual
       assert_equal 1, workspace.trace_writer.writer.count { _1[:command_line]&.slice(0, 2) == %w[git blame] }
     end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

When too many issues are found, git-blame(1) is called per issue.
This can cause too many log entries.

> Link related issues or pull requests.

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
