### PR TITLE
[PHPCS] Use XML reporter instead of JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Optimize `Runners::Changes#include?` [#1633](https://github.com/sider/runners/pull/1633)
 - Reduce log for git-blame(1) [#1632](https://github.com/sider/runners/pull/1632)
+- **PHP_CodeSniffer** Use XML reporter instead of JSON [#1635](https://github.com/sider/runners/pull/1635)
 
 ## 0.37.1
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Rarely, JSON strings that PHP_CodeSniffer outputs are broken.
I think the reason is due to the JSON reporter's implementation.
It is by string concatenation, not using a library.

So, this change uses the XML reporter instead of the JSON one.

See also:
- https://github.com/squizlabs/PHP_CodeSniffer/wiki/Reporting#printing-an-xml-report
- https://github.com/squizlabs/PHP_CodeSniffer/blob/3.5.8/src/Reports/Xml.php
- https://github.com/squizlabs/PHP_CodeSniffer/blob/3.5.8/src/Reports/Json.php

> Link related issues or pull requests.

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
