### PR TITLE
Use `GIT_SSH_COMMAND` instead of `GIT_SSH`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.37.2...HEAD)
 
-- Use `GIT_SSH_COMMAND` instead of `GIT_SSH [#1648](https://github.com/sider/runners/pull/1648)
+- Use `GIT_SSH_COMMAND` instead of `GIT_SSH` [#1648](https://github.com/sider/runners/pull/1648)
 
 ## 0.37.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.37.2...HEAD)
 
+- Use `GIT_SSH_COMMAND` instead of `GIT_SSH [#1648](https://github.com/sider/runners/pull/1648)
+
 ## 0.37.2
 
 [Full diff](https://github.com/sider/runners/compare/0.37.1...0.37.2)

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -39,7 +39,7 @@ module Runners
 
       hash = {
         "RUBYOPT" => nil,
-        "GIT_SSH" => git_ssh_path&.to_path,
+        "GIT_SSH_COMMAND" => git_ssh_path&.then { |path| "ssh -F '#{path}'" },
       }
       @shell = Shell.new(current_dir: working_dir,
                          env_hash: hash,

--- a/lib/runners/workspace.rb
+++ b/lib/runners/workspace.rb
@@ -77,14 +77,7 @@ module Runners
           SSH_CONFIG
           config_path.chmod 0600
 
-          script_path = dir / 'run.sh'
-          script_path.write <<~GIT_SSH
-            #!/bin/sh
-            ssh -F #{config_path} "$@"
-          GIT_SSH
-          script_path.chmod 0700
-
-          yield script_path
+          yield config_path
         end
       else
         yield nil

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -39,7 +39,7 @@ class ProcessorTest < Minitest::Test
 
       mock_capture3 = Minitest::Mock.new
       mock_capture3.expect :call, ["", "", mock_status], [
-        { "RUBYOPT" => nil, "GIT_SSH" => (workspace.working_dir / "id_rsa").to_s },
+        { "RUBYOPT" => nil, "GIT_SSH_COMMAND" => "ssh -F '#{workspace.working_dir / 'id_rsa'}'" },
         "ls",
         chdir: workspace.working_dir.to_s, stdin_data: nil
       ]
@@ -387,14 +387,14 @@ class ProcessorTest < Minitest::Test
     with_workspace do |workspace|
       processor = new_processor(workspace: workspace)
 
-      assert_equal({ "RUBYOPT" => nil, "GIT_SSH" => nil }, processor.env_hash)
+      assert_equal({ "RUBYOPT" => nil, "GIT_SSH_COMMAND" => nil }, processor.env_hash)
 
       processor.push_env_hash({ "RBENV_VERSION" => "2.5.0" }) do
-        assert_equal({ "RUBYOPT" => nil, "GIT_SSH" => nil, "RBENV_VERSION" => "2.5.0" },
+        assert_equal({ "RUBYOPT" => nil, "GIT_SSH_COMMAND" => nil, "RBENV_VERSION" => "2.5.0" },
                      processor.env_hash)
       end
 
-      assert_equal({ "RUBYOPT" => nil, "GIT_SSH" => nil }, processor.env_hash)
+      assert_equal({ "RUBYOPT" => nil, "GIT_SSH_COMMAND" => nil }, processor.env_hash)
     end
   end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The environment variable `GIT_SSH_COMMAND` has been added since Git 2.3.0:
https://github.com/git/git/blob/e31aba42fb12bdeb0f850829e008e1e3f43af500/Documentation/RelNotes/2.3.0.txt#L25-L27

We currently have used Git 2.8.0:
https://github.com/sider/devon_rex/blob/35bd73bdc3d31da140f41f29cf7b7cf86d17c68c/.env#L8

See also:
https://git-scm.com/docs/git-config#Documentation/git-config.txt-coresshCommand

> Link related issues or pull requests.

None.

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
