### PR TITLE
[RuboCop] Fix CI failure

### DIFF
--- a/test/smokes/rubocop/sandbox_rails/sideci.yml
+++ b/test/smokes/rubocop/sandbox_rails/sideci.yml
@@ -1,5 +1,0 @@
-linter:
-  eslint:
-    root_dir: 'frontend'
-    options:
-      ext: 'js,jsx'

--- a/test/smokes/rubocop/sandbox_rails/sider.yml
+++ b/test/smokes/rubocop/sandbox_rails/sider.yml
@@ -1,0 +1,7 @@
+linter:
+  rubocop:
+    gems:
+      - name: rubocop
+        version: "1.0.0"
+      - name: meowcop
+        version: "< 3.0.0"


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The cause is due to the release of MeowCop 3.0.0.
This change fixes the used gems' version.

See <https://github.com/sider/runners/runs/1416577718?check_suite_focus=true#step:7:355>

> Link related issues or pull requests.

None.
