### PR TITLE
[RuboCop] Use `--parallel` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Use `GIT_SSH_COMMAND` instead of `GIT_SSH` [#1648](https://github.com/sider/runners/pull/1648)
 - **PHP_CodeSniffer** Allow array for `extensions` and `ignore` options [#1650](https://github.com/sider/runners/pull/1650)
+- **RuboCop** Use `--parallel` option [#1654](https://github.com/sider/runners/pull/1654)
 
 ## 0.37.2
 

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -76,6 +76,8 @@ module Runners
       "rubocop" => [">= 0.61.0", "< 2.0.0"]
     }.freeze
 
+    DEFAULT_CONFIG_FILE = (Pathname(Dir.home) / "default_rubocop.yml").to_path.freeze
+
     def default_gem_specs
       super.tap do |gems|
         if setup_default_config
@@ -100,8 +102,7 @@ module Runners
     end
 
     def analyze(_)
-      options = ["--display-style-guide", "--cache=false", "--no-display-cop-names", rails_option, config_file, safe].compact
-      run_analyzer(options)
+      run_analyzer
     end
 
     private
@@ -141,7 +142,7 @@ module Runners
       return false if path.exist?
 
       path.parent.mkpath
-      FileUtils.cp (Pathname(Dir.home) / "default_rubocop.yml"), path
+      FileUtils.copy_file DEFAULT_CONFIG_FILE, path
       trace_writer.message "Setup the default RuboCop configuration file."
       true
     end
@@ -177,12 +178,28 @@ module Runners
       warnings.each { |msg, file| add_warning(msg, file: file) }
     end
 
-    def run_analyzer(options)
-      # NOTE: `--out` option must be after `--format` option.
-      #
-      # @see https://docs.rubocop.org/en/stable/formatters
-      options << "--format=json"
-      options << "--out=#{report_file}"
+    def run_analyzer
+      options = [
+        "--display-style-guide",
+        "--no-display-cop-names",
+
+        # NOTE: `--parallel` requires a cache.
+        #
+        # @see https://github.com/rubocop-hq/rubocop/blob/v1.3.1/lib/rubocop/options.rb#L353-L355
+        "--parallel",
+        "--cache=true",
+        *cache_root,
+
+        # NOTE: `--out` option must be after `--format` option.
+        #
+        # @see https://docs.rubocop.org/rubocop/1.3/formatters.html
+        "--format=json",
+        "--out=#{report_file}",
+
+        *rails_option,
+        *config_file,
+        *safe,
+      ]
 
       _, stderr, status = capture3(*ruby_analyzer_bin, *options)
       check_rubocop_yml_warning(stderr)
@@ -286,6 +303,15 @@ module Runners
     # @see https://github.com/rubocop-hq/rubocop/blob/v0.72.0/CHANGELOG.md
     def rails_cops_removed?
       Gem::Version.create(analyzer_version) >= Gem::Version.create("0.72.0")
+    end
+
+    def cache_root
+      # @see https://github.com/rubocop-hq/rubocop/blob/v0.91.0/CHANGELOG.md
+      if Gem::Version.create(analyzer_version) >= Gem::Version.create("0.91.0")
+        "--cache-root=#{File.join(Dir.tmpdir, 'rubocop-cache')}"
+      else
+        nil
+      end
     end
   end
 end

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -159,7 +159,7 @@ module Runners
         /An error occurred while .+ inspecting (?<file>.+):.+:/,
       ]
 
-      warnings = Set[]
+      warnings = []
 
       stderr.each_line(chomp: true) do |message|
         patterns.each do |pattern|
@@ -175,6 +175,8 @@ module Runners
         end
       end
 
+      warnings.uniq!
+      warnings.sort_by! { |_, file| file ? file : "" } # 1. no file, 2. filename
       warnings.each { |msg, file| add_warning(msg, file: file) }
     end
 

--- a/sig/runners/processor.rbs
+++ b/sig/runners/processor.rbs
@@ -19,7 +19,7 @@ module Runners
 
     attr_reader config: untyped
 
-    attr_reader shell: untyped
+    attr_reader shell: Shell
 
     def self.register_config_schema: (**untyped args) -> untyped
 
@@ -27,6 +27,8 @@ module Runners
     RemovedGoToolSchema: untyped
 
     def initialize: (guid: untyped guid, working_dir: untyped working_dir, config: untyped config, git_ssh_path: untyped git_ssh_path, trace_writer: untyped trace_writer) -> untyped
+
+    def current_dir: () -> Pathname
 
     def relative_path: (untyped original, ?from: untyped from) -> untyped
 

--- a/sig/runners/processor/rubocop.rbs
+++ b/sig/runners/processor/rubocop.rbs
@@ -4,42 +4,38 @@ module Runners
 
     Schema: untyped
 
-    # The followings are maintained by RuboCop Headquarters.
-    # @see https://github.com/rubocop-hq
-    OFFICIAL_RUBOCOP_PLUGINS: untyped
+    OFFICIAL_RUBOCOP_PLUGINS: Array[Ruby::GemInstaller::Spec]
 
-    OPTIONAL_GEMS: untyped
+    OPTIONAL_GEMS: Array[Ruby::GemInstaller::Spec]
 
-    CONSTRAINTS: untyped
+    CONSTRAINTS: Hash[String, Array[String]]
 
-    def default_gem_specs: () -> untyped
+    DEFAULT_CONFIG_FILE: String
 
-    def setup: () { () -> untyped } -> untyped
+    private
 
-    def analyze: (untyped _) -> untyped
+    def rails_option: () -> String?
 
-    def rails_option: () -> untyped
+    def config_file: () -> String?
 
-    def config_file: () -> untyped
+    def safe: () -> String?
 
-    def safe: () -> untyped
+    def setup_default_config: () -> bool
 
-    def setup_default_config: () -> (::FalseClass | ::TrueClass)
+    def check_rubocop_yml_warning: (String) -> void
 
-    def check_rubocop_yml_warning: (untyped stderr) -> untyped
+    def run_analyzer: () -> untyped
 
-    def run_analyzer: (untyped options) -> untyped
+    def extract_links: (String) -> Array[String]
 
-    # @see https://github.com/rubocop-hq/rubocop/blob/v0.76.0/lib/rubocop/cop/message_annotator.rb#L62-L63
-    def extract_links: (untyped original_message) -> untyped
+    def build_cop_links: (String) -> Array[String]
 
-    def build_cop_links: (untyped cop_name) -> (::Array[::String] | ::Array[untyped])
+    def department_to_gem_name: () -> Hash[String, String]
 
-    def department_to_gem_name: () -> untyped
+    def normalize_message: (String, Array[String], String) -> String
 
-    def normalize_message: (untyped original_message, untyped links, untyped cop_name) -> untyped
+    def rails_cops_removed?: () -> bool
 
-    # @see https://github.com/rubocop-hq/rubocop/blob/v0.72.0/CHANGELOG.md
-    def rails_cops_removed?: () -> untyped
+    def cache_root: () -> String?
   end
 end

--- a/sig/uri.rbs
+++ b/sig/uri.rbs
@@ -1,4 +1,5 @@
 module URI
   def self.parse: (String) -> URI::Generic
   def self.join: (*String) -> URI::Generic
+  def self.extract: (String, ?Array[String]) -> Array[String]
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change uses the `--parallel` option to speed up a RuboCop analysis.
Note that we need to use the `--cache=true` option for the parallel mode.
(see <https://github.com/rubocop-hq/rubocop/blob/v1.3.1/lib/rubocop/options.rb#L353-L355>)

Also, this change refactors and improves the type coverage.

> Link related issues or pull requests.

Fix #1636

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
