### PR TITLE
Remove `olegtarasov/get-tag@v2` on GitHub Actions

### DIFF
--- a/.github/workflows/notify_build_to_bugsnag.yml
+++ b/.github/workflows/notify_build_to_bugsnag.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: olegtarasov/get-tag@v2
-        id: getTag
+      - run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+        id: get_tag
       - run: ./.github/workflows/notify_build_to_bugsnag.sh
         env:
           BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
-          APP_VERSION: ${{ steps.getTag.outputs.tag }}
+          APP_VERSION: ${{ steps.get_tag.outputs.tag }}
           SOURCE_REVISION: ${{ github.sha }}


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Fix the following error:

> Unable to process command '##[set-env name=GIT_TAG_NAME;]0.38.0' successfully.

https://github.com/sider/runners/actions/runs/371576159

> Link related issues or pull requests.

None.
