### PR TITLE
Use cat(1) with heredoc for `github.event` to prevent `'` matching error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - run: |
           echo 'github.event_name: ${{ github.event_name }}'
           echo 'github.event:'
-          cat <<EOD
+          cat <<'EOD'
           ${{ toJson(github.event) }}
           EOD
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,9 @@ jobs:
       - run: |
           echo 'github.event_name: ${{ github.event_name }}'
           echo 'github.event:'
-          echo '${{ toJson(github.event) }}'
+          cat <<EOD
+          ${{ toJson(github.event) }}
+          EOD
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - run: |
           echo 'github.event_name: ${{ github.event_name }}'
           echo 'github.event:'
-          cat <<EOD
+          cat <<'EOD'
           ${{ toJson(github.event) }}
           EOD
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,9 @@ jobs:
       - run: |
           echo 'github.event_name: ${{ github.event_name }}'
           echo 'github.event:'
-          echo '${{ toJson(github.event) }}'
+          cat <<EOD
+          ${{ toJson(github.event) }}
+          EOD
   test:
     needs: check_skip
     runs-on: ubuntu-latest


### PR DESCRIPTION
We've got this error, and I guess this is caused by quoting mismatch.

https://github.com/sider/runners/pull/1619/checks?check_run_id=1452492596
