### PR TITLE
Add the new option `new_issue_schema`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Add the new option `new_issue_schema` [#1674](https://github.com/sider/runners/pull/1674)
+
 [Full diff](https://github.com/sider/runners/compare/0.38.0...HEAD)
 
 ## 0.38.0

--- a/lib/runners/options.rb
+++ b/lib/runners/options.rb
@@ -13,7 +13,7 @@ module Runners
     end
     private_constant :GitSource
 
-    attr_reader :stdout, :stderr, :source, :ssh_key, :io
+    attr_reader :stdout, :stderr, :source, :ssh_key, :io, :new_issue_schema
 
     def initialize(json, stdout, stderr)
       @stdout = stdout
@@ -40,6 +40,7 @@ module Runners
               end
               Runners::IO.new(*ios)
             end
+      @new_issue_schema = options[:new_issue_schema]
     end
 
     private

--- a/lib/runners/schema/options.rb
+++ b/lib/runners/schema/options.rb
@@ -16,6 +16,7 @@ module Runners
         outputs: array?(string),
         ssh_key: string?,
         s3: object?(endpoint: string),
+        new_issue_schema: boolean?,
       )
     end
   end

--- a/sig/runners/options.rbs
+++ b/sig/runners/options.rbs
@@ -19,6 +19,7 @@ module Runners
     attr_reader source: GitSource
     attr_reader ssh_key: String?
     attr_reader io: Runners::IO
+    attr_reader new_issue_schema: bool?
 
     def initialize: (String json, ::IO stdout, ::IO stderr) -> void
 

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -84,6 +84,12 @@ class OptionsTest < Minitest::Test
     assert_equal 'Invalid output option: `"foo"`', error.message
   end
 
+  def test_new_issue_schema
+    assert_nil Runners::Options.new(options_json(source: source_params), stdout, stderr).new_issue_schema
+    assert_equal true, Runners::Options.new(options_json(source: source_params, new_issue_schema: true), stdout, stderr).new_issue_schema
+    assert_equal false, Runners::Options.new(options_json(source: source_params, new_issue_schema: false), stdout, stderr).new_issue_schema
+  end
+
   private
 
   def stdout


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

We considered changing the result schema here, but the change could have
a big impact on developers.

https://github.com/sider/runners/issues/1672

So, before implementing the above issue, I want to introduce the new
option `new_issue_schema` to let developers choose a schema.

> Link related issues or pull requests.

This is a part of #1672 

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
