### PR TITLE
Write issues per each line when `new_issue_schema` is `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Add the new option `new_issue_schema` [#1674](https://github.com/sider/runners/pull/1674)
+- Write issues per each line when `new_issue_schema` is `true` [#1677](https://github.com/sider/runners/pull/1677)
 
 [Full diff](https://github.com/sider/runners/compare/0.38.0...HEAD)
 

--- a/lib/runners/results.rb
+++ b/lib/runners/results.rb
@@ -10,7 +10,7 @@ module Runners
         @timestamp = Time.now
       end
 
-      def as_json
+      def as_json(with_issues: true)
         {
           guid: guid,
           timestamp: timestamp.utc.iso8601
@@ -35,19 +35,21 @@ module Runners
         @analyzer = analyzer
       end
 
-      def as_json
+      def as_json(with_issues: true)
         super.tap do |json|
           json[:type] = 'success'
-          json[:issues] = issues.map(&:as_json).sort_by! do |issue|
-            [
-              issue[:id] || "",
-              issue[:path] || "",
-              issue.dig(:location, :start_line) || 0,
-              issue.dig(:location, :start_column) || 0,
-              issue.dig(:location, :end_line) || 0,
-              issue.dig(:location, :end_column) || 0,
-              issue[:message] || "",
-            ]
+          if with_issues
+            json[:issues] = issues.map(&:as_json).sort_by! do |issue|
+              [
+                issue[:id] || "",
+                issue[:path] || "",
+                issue.dig(:location, :start_line) || 0,
+                issue.dig(:location, :start_column) || 0,
+                issue.dig(:location, :end_line) || 0,
+                issue.dig(:location, :end_column) || 0,
+                issue[:message] || "",
+              ]
+            end
           end
           json[:analyzer] = analyzer.as_json
         end
@@ -102,7 +104,7 @@ module Runners
         @analyzer = analyzer
       end
 
-      def as_json
+      def as_json(with_issues: true)
         super.tap do |json|
           json[:type] = 'failure'
           json[:message] = message
@@ -127,7 +129,7 @@ module Runners
         @analyzer = analyzer
       end
 
-      def as_json
+      def as_json(with_issues: true)
         super.tap do |json|
           json[:type] = 'error'
           json[:class] = exception.class.name

--- a/lib/runners/schema/result.rb
+++ b/lib/runners/schema/result.rb
@@ -19,7 +19,8 @@ module Runners
       let :warning, object(message: string, file: string?)
       let :analyzer, object(name: string, version: string)
 
-      let :success, object(guid: string, timestamp: string, type: literal("success"), issues: array(Issue.issue), analyzer: analyzer)
+      let :success, enum(object(guid: string, timestamp: string, type: literal("success"), issues: array(Issue.issue), analyzer: analyzer),
+                         object(guid: string, timestamp: string, type: literal("success"), analyzer: analyzer))
       let :failure, object(guid: string, timestamp: string, type: literal("failure"), message: string, analyzer: optional(analyzer))
       let :error, object(guid: string, timestamp: string, type: literal("error"), class: string, backtrace: array(string), inspect: string, analyzer: optional(analyzer))
 

--- a/lib/runners/schema/trace.rb
+++ b/lib/runners/schema/trace.rb
@@ -14,7 +14,8 @@ module Runners
       let :warning, object(trace: literal(:warning), message: string, file: string?, recorded_at: string)
       let :ci_config, object(trace: literal(:ci_config), content: any, raw_content: string, file: string, recorded_at: string)
       let :error, object(trace: literal(:error), message: string, recorded_at: string, truncated: boolean)
-      let :anything, enum(command_line, status, stdout, stderr, message, header, warning, ci_config, error)
+      let :issues, object(issues: object(position: enum(literal(:begin), literal(:end)), length: number), recorded_at: string)
+      let :anything, enum(command_line, status, stdout, stderr, message, header, warning, ci_config, error, issues)
     end
   end
 end

--- a/lib/runners/trace_writer.rb
+++ b/lib/runners/trace_writer.rb
@@ -82,6 +82,10 @@ module Runners
       end
     end
 
+    def issues(position, length, recorded_at: now)
+      self << { issues: { position: position, length: length }, recorded_at: recorded_at }
+    end
+
     def <<(object)
       recorded_at = object[:recorded_at]
       object = object.merge(recorded_at: recorded_at.utc.iso8601(3)) if recorded_at

--- a/sig/runners/results.rbs
+++ b/sig/runners/results.rbs
@@ -8,7 +8,7 @@ module Runners
 
       def initialize: (guid: untyped guid) -> untyped
 
-      def as_json: () -> { guid: untyped, timestamp: untyped }
+      def as_json: (?with_issues: bool with_issues) -> untyped
 
       def valid?: () -> untyped
     end
@@ -23,7 +23,7 @@ module Runners
 
       def initialize: (guid: untyped guid, analyzer: untyped analyzer, ?issues: untyped issues) -> untyped
 
-      def as_json: () -> untyped
+      def as_json: (?with_issues: bool with_issues) -> untyped
 
       def valid?: () -> untyped
 
@@ -48,7 +48,7 @@ module Runners
 
       def initialize: (guid: untyped guid, ?message: untyped message, ?analyzer: untyped? analyzer) -> untyped
 
-      def as_json: () -> untyped
+      def as_json: (?with_issues: bool with_issues) -> untyped
 
       def valid?: () -> untyped
     end
@@ -64,7 +64,7 @@ module Runners
 
       def initialize: (guid: untyped guid, exception: untyped exception, analyzer: untyped analyzer) -> untyped
 
-      def as_json: () -> untyped
+      def as_json: (?with_issues: bool with_issues) -> untyped
 
       def valid?: () -> untyped
     end

--- a/sig/runners/trace_writer.rbs
+++ b/sig/runners/trace_writer.rbs
@@ -14,6 +14,7 @@ module Runners
     def warning: (String, ?file: String?, ?recorded_at: Time) -> void
     def ci_config: (Hash[Symbol, untyped], raw_content: String, file: String, ?recorded_at: Time) -> void
     def error: (String, ?recorded_at: Time, ?max_length: Integer) -> void
+    def issues: (:begin | :end, Integer, ?recorded_at: Time) -> void
     def <<: (Hash[Symbol, untyped]) -> void
 
     private

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -209,6 +209,20 @@ class ResultTest < Minitest::Test
     assert_equal [issue1, issue2], result.issues
   end
 
+  def test_success_as_json_without_issues
+    result = Results::Success.new(guid: SecureRandom.uuid, analyzer: Analyzer.new(name: "RuboCop", version: "1.0.0"))
+    issue = Issue.new(path: Pathname("foo.rb"), location: nil, id: "aaa", message: "bbb")
+    result.add_issue(issue)
+    assert_equal [issue], result.issues
+    assert_unifiable(result.as_json(with_issues: false),
+                     {
+                       guid: result.guid,
+                       timestamp: result.timestamp.utc.iso8601,
+                       type: 'success',
+                       analyzer: { name: "RuboCop", version: "1.0.0" }
+                     })
+  end
+
   def test_add_git_blame_info
     result = Results::Success.new(guid: SecureRandom.uuid, analyzer: Analyzer.new(name: "RuboCop", version: "1.3.2pre"))
     result.add_issue Issue.new(

--- a/test/trace_writer_test.rb
+++ b/test/trace_writer_test.rb
@@ -89,6 +89,15 @@ class TraceWriterTest < Minitest::Test
     assert_equal [{ trace: :error, message: 'hoge error', recorded_at: "2017-08-01T22:34:51.200Z", truncated: false }], writer.writer
   end
 
+  def test_issues
+    writer.issues(:begin, 23, recorded_at: now)
+    writer.issues(:end, 23, recorded_at: now)
+    assert_equal [
+                   { issues: { position: :begin, length: 23}, recorded_at: "2017-08-01T22:34:51.200Z" },
+                   { issues: { position: :end, length: 23}, recorded_at: "2017-08-01T22:34:51.200Z" },
+                 ], writer.writer
+  end
+
   def test_masked_string
     writer.command_line(%w[cat https://user:secret@github.com], recorded_at: now)
     writer.stdout("user:secret in stdout", recorded_at: now)


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change makes Runners write issues per each line with `new_issue_schema`. This will reduce the size of the `result`'s line but make the log longer and bigger.

I tried to remain the class `Runners::Results::Base` and its descendants as possible as I could, and `#as_json` has been changed to receive the `with_issues` argument. In order to avoid updating each `Processor`, I wanted Runners to control the presence of `issues` in the `result` schema at generating JSON.

> Link related issues or pull requests.

Close #1672

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
