### PR TITLE
Remove ignoring strong_json from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,6 @@ updates:
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
     versioning-strategy: increase
-    ignore:
-      # TODO: Steep is broken by the update. See https://github.com/sider/runners/pull/1135
-      - dependency-name: strong_json
-        versions:
-          - ">= 0"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The latest version of `strong_json` works well.

> Link related issues or pull requests.

Related to #1573
