### PR TITLE
[TSLint] Stop updating deps by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,14 +114,6 @@ updates:
     open-pull-requests-limit: 10
     versioning-strategy: increase
   - package-ecosystem: npm
-    directory: "/images/tslint"
-    schedule:
-      interval: weekly
-      time: "09:00"
-      timezone: Asia/Tokyo
-    open-pull-requests-limit: 10
-    versioning-strategy: increase
-  - package-ecosystem: npm
     directory: "/images/tyscan"
     schedule:
       interval: weekly


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

TSLint is deprecated. We don't need to update the dependencies.

> Link related issues or pull requests.

Related to #1663

