### PR TITLE
Add `issue_count` to the result schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.38.0...HEAD)
 
+- Add `issue_count` to the result schema [#1688](https://github.com/sider/runners/pull/1688)
+
 ## 0.38.0
 
 [Full diff](https://github.com/sider/runners/compare/0.37.2...0.38.0)

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -113,7 +113,6 @@ module Runners
     end
 
     def exclude_special_dirs
-      # @type var saved: Hash<Pathname, Pathname>
       saved = [".git"].filter_map do |dir|
         src = working_dir / dir
         if src.directory?

--- a/lib/runners/schema/result.rb
+++ b/lib/runners/schema/result.rb
@@ -19,7 +19,7 @@ module Runners
       let :warning, object(message: string, file: string?)
       let :analyzer, object(name: string, version: string)
 
-      let :success, object(guid: string, timestamp: string, type: literal("success"), issues: array(Issue.issue), analyzer: analyzer)
+      let :success, object(guid: string, timestamp: string, type: literal("success"), issue_count: integer, issues: array(Issue.issue), analyzer: analyzer)
       let :failure, object(guid: string, timestamp: string, type: literal("failure"), message: string, analyzer: optional(analyzer))
       let :error, object(guid: string, timestamp: string, type: literal("error"), class: string, backtrace: array(string), inspect: string, analyzer: optional(analyzer))
 

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -298,6 +298,7 @@ module Runners
             type: type,
             guid: guid,
             timestamp: timestamp,
+            issue_count: issues&.size,
             issues: issues,
             message: message,
             analyzer: analyzer,

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -298,7 +298,7 @@ module Runners
             type: type,
             guid: guid,
             timestamp: timestamp,
-            issue_count: issues&.size,
+            issue_count: issues == :_ ? :_ : issues&.size,
             issues: issues,
             message: message,
             analyzer: analyzer,

--- a/sig/runners/analyzer.rbs
+++ b/sig/runners/analyzer.rbs
@@ -6,6 +6,6 @@ module Runners
     def initialize: (name: String, version: String) -> void
 
     def valid?: () -> bool
-    def as_json: () -> { name: String, version: String }
+    def as_json: () -> Hash[Symbol, String]
   end
 end

--- a/sig/runners/harness.rbs
+++ b/sig/runners/harness.rbs
@@ -16,6 +16,8 @@ module Runners
     attr_reader warnings: Array[String]
     attr_reader config: Config?
 
+    @analyzer: Analyzer?
+
     def initialize: (guid: String,
                      processor_class: untyped,
                      options: Options,

--- a/sig/runners/results.rbs
+++ b/sig/runners/results.rbs
@@ -1,72 +1,51 @@
 module Runners
   module Results
     class Base
-      # @dynamic guid, timestamp
-      attr_reader guid: untyped
+      attr_reader guid: String
+      attr_reader timestamp: Time
 
-      attr_reader timestamp: untyped
+      def initialize: (guid: String) -> void
 
-      def initialize: (guid: untyped guid) -> untyped
+      def as_json: () -> Hash[Symbol, String | Integer | Array[untyped] | Hash[Symbol, untyped] | nil]
 
-      def as_json: () -> { guid: untyped, timestamp: untyped }
-
-      def valid?: () -> untyped
+      def valid?: () -> bool
     end
 
     # Result to indicate that processing finished successfully
     # Client programs may return this result.
     class Success < Base
-      # @dynamic issues, analyzer
-      attr_reader issues: untyped
+      attr_reader issues: Array[Issue]
+      attr_reader analyzer: Analyzer
 
-      attr_reader analyzer: untyped
+      def initialize: (guid: String, analyzer: Analyzer, ?issues: Array[Issue]) -> void
 
-      def initialize: (guid: untyped guid, analyzer: untyped analyzer, ?issues: untyped issues) -> untyped
+      def add_issue: (*Issue) -> void
 
-      def as_json: () -> untyped
+      def filter_issues: (Changes) -> void
 
-      def valid?: () -> untyped
+      def add_git_blame_info: (Workspace) -> void
 
-      def add_issue: (*untyped issue) -> untyped
-
-      def filter_issues: (untyped changes) -> untyped
-
-      def add_git_blame_info: (untyped workspace) -> untyped
-
-      def each_missing_id_warning: () { (untyped) -> untyped } -> untyped
+      def each_missing_id_warning: () { (String) -> void } -> void
     end
 
     # Result to indicate that processing failed by some error.
     # Client programs may return this result.
     class Failure < Base
-      DEFAULT_MESSAGE: untyped
+      DEFAULT_MESSAGE: String
 
-      # @dynamic message, analyzer
-      attr_reader message: untyped
+      attr_reader message: String
+      attr_reader analyzer: Analyzer?
 
-      attr_reader analyzer: untyped
-
-      def initialize: (guid: untyped guid, ?message: untyped message, ?analyzer: untyped? analyzer) -> untyped
-
-      def as_json: () -> untyped
-
-      def valid?: () -> untyped
+      def initialize: (guid: String, ?message: String, ?analyzer: Analyzer?) -> void
     end
 
     # Result to indicate that processor raises an exception.
     # Client programs should not return this result.
     class Error < Base
-      # @dynamic exception, analyzer
-      attr_reader exception: untyped
+      attr_reader exception: Exception
+      attr_reader analyzer: Analyzer?
 
-      # @dynamic exception, analyzer
-      attr_reader analyzer: untyped
-
-      def initialize: (guid: untyped guid, exception: untyped exception, analyzer: untyped analyzer) -> untyped
-
-      def as_json: () -> untyped
-
-      def valid?: () -> untyped
+      def initialize: (guid: String, exception: Exception, analyzer: Analyzer?) -> void
     end
   end
 end

--- a/sig/time.rbs
+++ b/sig/time.rbs
@@ -1,3 +1,3 @@
 class Time
-  def iso8601: () -> Time
+  def iso8601: () -> String
 end

--- a/test/results_test.rb
+++ b/test/results_test.rb
@@ -37,6 +37,7 @@ class ResultsTest < Minitest::Test
                        guid: result.guid,
                        timestamp: result.timestamp.utc.iso8601,
                        type: 'success',
+                       issue_count: 2,
                        issues: [
                          {
                            path: "foo/bar/baz.rb",
@@ -95,6 +96,7 @@ class ResultsTest < Minitest::Test
                        guid: result.guid,
                        timestamp: result.timestamp.utc.iso8601,
                        type: 'success',
+                       issue_count: 1,
                        issues: [
                          {
                            path: "foo/bar/xxx.rb",
@@ -166,6 +168,7 @@ class ResultsTest < Minitest::Test
                        guid: result.guid,
                        timestamp: result.timestamp.utc.iso8601,
                        type: 'success',
+                       issue_count: 2,
                        issues: [
                          {
                            path: "a.py",
@@ -236,6 +239,7 @@ class ResultsTest < Minitest::Test
                        guid: result.guid,
                        timestamp: result.timestamp.utc.iso8601,
                        type: 'success',
+                       issue_count: 1,
                        issues: [
                          {
                            path: "foo/bar/baz.rb",
@@ -274,6 +278,7 @@ class ResultsTest < Minitest::Test
                        guid: result.guid,
                        timestamp: result.timestamp.utc.iso8601,
                        type: 'success',
+                       issue_count: 1,
                        issues: [
                          {
                            path: "foo/bar/baz.rb",

--- a/test/results_test.rb
+++ b/test/results_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ResultTest < Minitest::Test
+class ResultsTest < Minitest::Test
   include TestHelper
 
   Results = Runners::Results


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

A JSONSEQ parser can get the number of issues before evaluating an `issues` array.
(See #1679)

This change also improves the RBS errors.

> Link related issues or pull requests.

Related to #1679

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
