### PR TITLE
Bump CoffeeLint from 1.16.0 to 4.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.38.1...HEAD)
 
+- **CoffeeLint** 1.16.0 -> 4.1.2 [#1690](https://github.com/sider/runners/pull/1690)
+
 ## 0.38.1
 
 [Full diff](https://github.com/sider/runners/compare/0.38.0...0.38.1)

--- a/images/coffeelint/package.json
+++ b/images/coffeelint/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "coffeelint": "1.16.0"
+    "@coffeelint/cli": "4.1.2"
   }
 }

--- a/lib/runners/processor/coffeelint.rb
+++ b/lib/runners/processor/coffeelint.rb
@@ -20,6 +20,7 @@ module Runners
 
     CONSTRAINTS = {
       "coffeelint" => Constraint.new(">= 1.16.0", "< 3.0.0"),
+      "@coffeelint/cli" => Constraint.new(">= 4.0.0", "< 5.0.0"),
     }.freeze
 
     def setup
@@ -30,6 +31,8 @@ module Runners
       rescue UserError => exn
         return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
       end
+
+      add_warning_if_deprecated_version minimum: "4.0.0"
 
       yield
     end

--- a/test/smokes/coffeelint/expectations.rb
+++ b/test/smokes/coffeelint/expectations.rb
@@ -1,6 +1,6 @@
 s = Runners::Testing::Smoke
 
-default_version = "1.16.0"
+default_version = "4.1.2"
 
 s.add_test(
   "success",
@@ -79,7 +79,11 @@ s.add_test(
       }
     },
     {
-      message: "[stdin]:1:7: error: unexpected <\n" + "foo = <%= something %>\n" + "      ^",
+      message: <<~MSG.strip,
+        [stdin]:1:7: error: unexpected <
+        foo = <%= something %>
+              ^
+      MSG
       links: [],
       id: "coffeescript_error",
       path: "er.coffee",
@@ -153,7 +157,8 @@ s.add_test(
       }
     }
   ],
-  analyzer: { name: "CoffeeLint", version: "2.0.6" }
+  analyzer: { name: "CoffeeLint", version: "2.0.6" },
+  warnings: [{ message: /The `2.0.6` and older versions are deprecated/, file: nil }]
 )
 
 s.add_test(
@@ -172,7 +177,8 @@ s.add_test(
       }
     }
   ],
-  analyzer: { name: "CoffeeLint", version: "2.0.3" }
+  analyzer: { name: "CoffeeLint", version: "2.0.3" },
+  warnings: [{ message: /The `2.0.3` and older versions are deprecated/, file: nil }]
 )
 
 s.add_test(
@@ -191,7 +197,8 @@ s.add_test(
       }
     }
   ],
-  analyzer: { name: "CoffeeLint", version: "1.16.2" }
+  analyzer: { name: "CoffeeLint", version: "1.16.2" },
+  warnings: [{ message: /The `1.16.2` and older versions are deprecated/, file: nil }]
 )
 
 s.add_test(
@@ -210,5 +217,6 @@ s.add_test(
       }
     }
   ],
-  analyzer: { name: "CoffeeLint", version: "2.0.5" }
+  analyzer: { name: "CoffeeLint", version: "2.0.5" },
+  warnings: [{ message: /The `2.0.5` and older versions are deprecated/, file: nil }]
 )

--- a/test/smokes/coffeelint/expectations.rb
+++ b/test/smokes/coffeelint/expectations.rb
@@ -161,7 +161,7 @@ s.add_test(
   warnings: [{ message: <<~MSG.strip, file: nil }]
     DEPRECATION WARNING!!!
     The `2.0.6` and older versions are deprecated, and these versions will be dropped in the near future.
-    Please consider upgrading to 4.0.0 or a newer version.
+    Please consider upgrading to `4.0.0` or a newer version.
   MSG
 )
 

--- a/test/smokes/coffeelint/expectations.rb
+++ b/test/smokes/coffeelint/expectations.rb
@@ -158,7 +158,11 @@ s.add_test(
     }
   ],
   analyzer: { name: "CoffeeLint", version: "2.0.6" },
-  warnings: [{ message: /The `2.0.6` and older versions are deprecated/, file: nil }]
+  warnings: [{ message: <<~MSG.strip, file: nil }]
+    DEPRECATION WARNING!!!
+    The `2.0.6` and older versions are deprecated, and these versions will be dropped in the near future.
+    Please consider upgrading to 4.0.0 or a newer version.
+  MSG
 )
 
 s.add_test(


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Package name changed: `coffeelint` → `@coffeelint/cli`

- https://www.npmjs.com/package/coffeelint (unmaintained)
- https://www.npmjs.com/package/@coffeelint/cli

This update recommends the new package `@coffeelint/cli`.
If users use the old package `coffeelint`, they will see the deprecation warning.

> Link related issues or pull requests.

Close #821

> Check the following items.

- [x] Add a new [changelog](https://github.com/sider/runners/blob/master/CHANGELOG.md) entry if this change is notable.
