### PR TITLE
Remove needless RBS of `ObjectSpace` polyfill

### DIFF
--- a/sig/objspace.rbs
+++ b/sig/objspace.rbs
@@ -1,3 +1,0 @@
-module ObjectSpace
-  def self.each_object: (untyped) -> Enumerator[untyped, untyped]
-end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

RBS 0.20.1 has the definition:
https://github.com/ruby/rbs/blob/v0.20.1/core/object_space.rbs

> Link related issues or pull requests.

Related to #877
