### PR TITLE
Fix RBS for modules included by `Runners::Processor`

### DIFF
--- a/lib/runners/ruby.rb
+++ b/lib/runners/ruby.rb
@@ -2,7 +2,7 @@ module Runners
   module Ruby
     class InstallGemsFailure < UserError; end
 
-    def install_gems(default_specs, optionals: [], constraints:, &block)
+    def install_gems(default_specs, constraints:, optionals: [], &block)
       original_default_specs = default_specs.dup
       user_specs = GemInstaller::Spec.from_gems(config_linter[:gems] || [])
 
@@ -26,7 +26,7 @@ module Runners
       end
     end
 
-    def default_specs(specs, constraints, lockfile)
+    private def default_specs(specs, constraints, lockfile)
       specs.map do |spec|
         if lockfile.spec_exists?(spec)
           if lockfile.satisfied_by?(spec, constraints)
@@ -40,7 +40,7 @@ module Runners
 
               If you want to use a different version of `#{spec.name}`, please do either:
               - Update your `Gemfile.lock` to satisfy the constraint
-              - Set the `#{config_field_path("gems")}` option in your `#{config.path_name}`
+              - Set the `#{config_field_path(:gems)}` option in your `#{config.path_name}`
             MESSAGE
             spec
           end
@@ -50,12 +50,12 @@ module Runners
       end
     end
 
-    def optional_specs(specs, lockfile)
+    private def optional_specs(specs, lockfile)
       specs.select { |spec| lockfile.spec_exists?(spec) }
            .map { |spec| spec.override_by_lockfile(lockfile) }
     end
 
-    def user_specs(specs, lockfile)
+    private def user_specs(specs, lockfile)
       specs.map do |spec|
         if spec.version.empty?
           spec.override_by_lockfile(lockfile)

--- a/sig/runners/php.rbs
+++ b/sig/runners/php.rbs
@@ -1,5 +1,4 @@
 module Runners
-  module PHP
-    def show_runtime_versions: () -> untyped
+  module PHP : Processor
   end
 end

--- a/sig/runners/python.rbs
+++ b/sig/runners/python.rbs
@@ -1,5 +1,4 @@
 module Runners
-  module Python
-    def show_runtime_versions: () -> untyped
+  module Python : Processor
   end
 end

--- a/sig/runners/ruby.rbs
+++ b/sig/runners/ruby.rbs
@@ -1,24 +1,22 @@
 module Runners
-  module Ruby
+  module Ruby : Processor
     class InstallGemsFailure < UserError
     end
 
-    def install_gems: (untyped default_specs, constraints: untyped constraints, ?optionals: untyped optionals) { () -> untyped } -> untyped
+    def install_gems: [X] (Array[GemInstaller::Spec], constraints: Hash[String, Array[String]], ?optionals: Array[GemInstaller::Spec]) { (Hash[String, String]) -> X } -> X
 
-    def default_specs: (untyped specs, untyped constraints, untyped lockfile) -> untyped
+    def ruby_analyzer_bin: () -> Array[String]
 
-    def optional_specs: (untyped specs, untyped lockfile) -> untyped
+    def installed_gem_versions: (String, *String, ?exception: bool) -> Hash[String, Array[String]]
 
-    def user_specs: (untyped specs, untyped lockfile) -> untyped
+    def default_gem_specs: (?String, *String) -> Array[GemInstaller::Spec]
 
-    def show_runtime_versions: () -> untyped
+    private
 
-    def ruby_analyzer_bin: () -> ::Array["bundle" | "exec" | untyped]
+    def default_specs: (Array[GemInstaller::Spec], Hash[String, Array[String]], LockfileLoader::Lockfile) -> Array[GemInstaller::Spec]
 
-    def analyzer_version: () -> untyped
+    def optional_specs: (Array[GemInstaller::Spec], LockfileLoader::Lockfile) -> Array[GemInstaller::Spec]
 
-    def installed_gem_versions: (untyped gem_name, *untyped gem_names, ?exception: bool exception) -> untyped
-
-    def default_gem_specs: (?untyped gem_name, *untyped gem_names) -> untyped
+    def user_specs: (Array[GemInstaller::Spec] specs, LockfileLoader::Lockfile) -> Array[GemInstaller::Spec]
   end
 end

--- a/sig/runners/swift.rbs
+++ b/sig/runners/swift.rbs
@@ -1,5 +1,4 @@
 module Runners
-  module Swift
-    def show_runtime_versions: () -> untyped
+  module Swift : Processor
   end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to improve the RBS and type-check for the module included by the `Runners::Processor` class (e.g. `Runners::Ruby`).

> Link related issues or pull requests.

A part of #877
