### PR TITLE
Stop overriding `Runners::Ruby#default_gem_specs`

### DIFF
--- a/lib/runners/processor/brakeman.rb
+++ b/lib/runners/processor/brakeman.rb
@@ -14,14 +14,13 @@ module Runners
 
     register_config_schema(name: :brakeman, schema: Schema.runner_config)
 
+    GEM_NAME = "brakeman".freeze
     CONSTRAINTS = {
-      "brakeman" => [">= 4.0.0", "< 5.0.0"]
+      GEM_NAME => [">= 4.0.0", "< 5.0.0"]
     }.freeze
 
     def setup
-      install_gems default_gem_specs, constraints: CONSTRAINTS do
-        yield
-      end
+      install_gems(default_gem_specs(GEM_NAME), constraints: CONSTRAINTS) { yield }
     rescue InstallGemsFailure => exn
       trace_writer.error exn.message
       return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)

--- a/lib/runners/processor/goodcheck.rb
+++ b/lib/runners/processor/goodcheck.rb
@@ -21,8 +21,9 @@ module Runners
 
     register_config_schema(name: :goodcheck, schema: Schema.runner_config)
 
+    GEM_NAME = "goodcheck".freeze
     CONSTRAINTS = {
-      "goodcheck" => [">= 1.0.0", "< 3.0"]
+      GEM_NAME => [">= 1.0.0", "< 3.0"]
     }.freeze
 
     DEFAULT_TARGET = ".".freeze
@@ -105,12 +106,10 @@ module Runners
     end
 
     def setup
-      begin
-        install_gems(default_gem_specs, constraints: CONSTRAINTS) { yield }
-      rescue InstallGemsFailure => exn
-        trace_writer.error exn.message
-        return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
-      end
+      install_gems(default_gem_specs(GEM_NAME), constraints: CONSTRAINTS) { yield }
+    rescue InstallGemsFailure => exn
+      trace_writer.error exn.message
+      return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
     end
 
     def analyze(changes)

--- a/lib/runners/processor/querly.rb
+++ b/lib/runners/processor/querly.rb
@@ -24,8 +24,9 @@ module Runners
       GemInstaller::Spec.new(name: "haml", version: []),
     ].freeze
 
+    GEM_NAME = "querly".freeze
     CONSTRAINTS = {
-      "querly" => [">= 0.5.0", "< 2.0.0"]
+      GEM_NAME => [">= 0.5.0", "< 2.0.0"]
     }.freeze
 
     CONFIG_FILE = "querly.yml".freeze
@@ -35,13 +36,11 @@ module Runners
       "version"
     end
 
-    def setup(&block)
-      begin
-        install_gems default_gem_specs, optionals: OPTIONAL_GEMS, constraints: CONSTRAINTS, &block
-      rescue InstallGemsFailure => exn
-        trace_writer.error exn.message
-        return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
-      end
+    def setup
+      install_gems(default_gem_specs(GEM_NAME), optionals: OPTIONAL_GEMS, constraints: CONSTRAINTS) { yield }
+    rescue InstallGemsFailure => exn
+      trace_writer.error exn.message
+      return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
     end
 
     def analyze(changes)

--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -38,17 +38,16 @@ module Runners
       GemInstaller::Spec.new(name: "rake", version: []),
     ].freeze
 
+    GEM_NAME = "rails_best_practices".freeze
     CONSTRAINTS = {
-      "rails_best_practices" => [">= 1.19.1", "< 2.0"]
+      GEM_NAME => [">= 1.19.1", "< 2.0"]
     }.freeze
 
     def setup
       add_warning_if_deprecated_options
 
       prepare_config
-      install_gems default_gem_specs, optionals: OPTIONAL_GEMS, constraints: CONSTRAINTS do
-        yield
-      end
+      install_gems(default_gem_specs(GEM_NAME), optionals: OPTIONAL_GEMS, constraints: CONSTRAINTS) { yield }
     rescue InstallGemsFailure => exn
       trace_writer.error exn.message
       return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)

--- a/lib/runners/processor/reek.rb
+++ b/lib/runners/processor/reek.rb
@@ -13,16 +13,15 @@ module Runners
 
     register_config_schema(name: :reek, schema: Schema.runner_config)
 
+    GEM_NAME = "reek".freeze
     CONSTRAINTS = {
-      "reek" => [">= 4.4.0", "< 7.0.0"]
+      GEM_NAME => [">= 4.4.0", "< 7.0.0"]
     }.freeze
 
     DEFAULT_TARGET = ".".freeze
 
     def setup
-      install_gems default_gem_specs, constraints: CONSTRAINTS do
-        yield
-      end
+      install_gems(default_gem_specs(GEM_NAME), constraints: CONSTRAINTS) { yield }
     rescue InstallGemsFailure => exn
       trace_writer.error exn.message
       return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)

--- a/lib/runners/ruby.rb
+++ b/lib/runners/ruby.rb
@@ -84,9 +84,7 @@ module Runners
       @analyzer_version ||= extract_version! ruby_analyzer_command.to_a
     end
 
-    def installed_gem_versions(gem_name, *gem_names, exception: true)
-      gem_names = [gem_name] + gem_names
-
+    def installed_gem_versions(gem_names, exception: true)
       # @see https://guides.rubygems.org/command-reference/#gem-list
       stdout, = capture3! "gem", "list", "--quiet", "--exact", *gem_names
       gem_names.each_with_object({}) do |name, hash|
@@ -100,8 +98,8 @@ module Runners
       end
     end
 
-    def default_gem_specs(gem_name = analyzer_bin, *gem_names)
-      installed_gem_versions(gem_name, *gem_names).map do |name, versions|
+    def default_gem_specs(gem_name, *gem_names)
+      installed_gem_versions([gem_name, *gem_names]).map do |name, versions|
         GemInstaller::Spec.new(name: name, version: versions)
       end
     end

--- a/sig/runners/processor/brakeman.rbs
+++ b/sig/runners/processor/brakeman.rbs
@@ -8,6 +8,7 @@ module Runners
     end
     Schema: SchemaClass
 
+    GEM_NAME: String
     CONSTRAINTS: Ruby::constraints
   end
 end

--- a/sig/runners/processor/goodcheck.rbs
+++ b/sig/runners/processor/goodcheck.rbs
@@ -8,6 +8,7 @@ module Runners
     end
     Schema: SchemaClass
 
+    GEM_NAME: String
     CONSTRAINTS: Ruby::constraints
     DEFAULT_TARGET: String
     DEFAULT_CONFIG_FILE: String

--- a/sig/runners/ruby.rbs
+++ b/sig/runners/ruby.rbs
@@ -11,9 +11,9 @@ module Runners
 
     def ruby_analyzer_command: (*String) -> Command
 
-    def installed_gem_versions: (String, *String, ?exception: bool) -> Hash[String, Array[String]]
+    def installed_gem_versions: (Array[String], ?exception: bool) -> Hash[String, Array[String]]
 
-    def default_gem_specs: (?String, *String) -> Array[GemInstaller::Spec]
+    def default_gem_specs: (String, *String) -> Array[GemInstaller::Spec]
 
     private
 

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -826,17 +826,17 @@ EOF
 
       processor.stub :capture3!, "rubocop (0.75.1, 0.75.0)\nmeowcop (2.4.0)\n" do
         assert_equal({ "rubocop" => ["0.75.1", "0.75.0"], "meowcop" => ["2.4.0"] },
-                     processor.installed_gem_versions("rubocop", "meowcop"))
+                     processor.installed_gem_versions(["rubocop", "meowcop"]))
       end
 
       processor.stub :capture3!, "" do
-        error = assert_raises(RuntimeError) { processor.installed_gem_versions("foo") }
+        error = assert_raises(RuntimeError) { processor.installed_gem_versions(["foo"]) }
         assert_equal 'Not found installed gem "foo"', error.message
       end
 
       processor.stub :capture3!, "meowcop (2.4.0)\n" do
         assert_equal({ "meowcop" => ["2.4.0"] },
-                     processor.installed_gem_versions("foo", "meowcop", exception: false))
+                     processor.installed_gem_versions(["foo", "meowcop"], exception: false))
       end
     end
   end
@@ -845,12 +845,7 @@ EOF
     with_workspace do |workspace|
       processor = new_processor(workspace: workspace)
 
-      def processor.analyzer_bin
-        "rubocop"
-      end
-
       processor.stub :capture3!, "rubocop (0.75.1, 0.75.0)\n" do
-        assert_equal [Spec.new(name: "rubocop", version: ["0.75.1", "0.75.0"])], processor.default_gem_specs
         assert_equal [Spec.new(name: "rubocop", version: ["0.75.1", "0.75.0"])], processor.default_gem_specs("rubocop")
       end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change refactoring aims to make type-checking easier.
Thus, this improvement for type-checking leads to a better API and simpler code.
Overriding methods tend to be hard.

> Link related issues or pull requests.

See also #877
