### PR TITLE
Add rake task for `steep stats`

### DIFF
--- a/.github/workflows/steep.yml
+++ b/.github/workflows/steep.yml
@@ -20,3 +20,12 @@ jobs:
       - run: |
           (bundle exec steep check | ruby -pe 'sub(/^(.+):(\d+):(\d+): (.+)$/, %q{::error file=\1,line=\2,col=\3::\4})') || echo 'not failed'
         shell: bash
+
+  stats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec rake steep:stats

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ require_relative "lib/tasks/bump/devon_rex"
 require_relative "lib/tasks/docker/timeout_test"
 require_relative "lib/tasks/rbs/update_gems"
 require_relative "lib/tasks/readme/generate"
+require_relative "lib/tasks/steep/stats"
 
 ENV["DOCKER_BUILDKIT"] = "1"
 

--- a/lib/tasks/steep/stats.rb
+++ b/lib/tasks/steep/stats.rb
@@ -1,0 +1,6 @@
+namespace :steep do
+  desc "Show the Steep coverage report"
+  task :stats do
+    sh "bundle exec steep stats --log-level=fatal | column -s, -t"
+  end
+end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The new task aims to show the progress of #877. Usage of `rake steep:stats`:

```console
$ bundle exec rake steep:stats
Target  File                                           Status   Typed calls  Untyped calls  All calls  Typed %
lib     lib/runners/analyzer.rb                        success  13           2              15         86.67
lib     lib/runners/analyzers.rb                       success  8            13             21         38.10
lib     lib/runners/changes.rb                         success  55           6              61         90.16
lib     lib/runners/cli.rb                             success  90           11             101        89.11
lib     lib/runners/command.rb                         success  4            0              4          100.00
lib     lib/runners/config.rb                          success  41           20             61         67.21
lib     lib/runners/cplusplus.rb                       success  32           0              32         100.00
lib     lib/runners/errors.rb                          success  0            0              0          0
lib     lib/runners/git_blame_info.rb                  success  17           25             42         40.48
lib     lib/runners/go.rb                              success  1            0              1          100.00
lib     lib/runners/harness.rb                         success  82           28             110        74.55
lib     lib/runners/ignoring.rb                        success  11           6              17         64.71
lib     lib/runners/io/aws_s3.rb                       success  41           0              41         100.00
lib     lib/runners/io.rb                              success  11           0              11         100.00
lib     lib/runners/issue.rb                           success  35           45             80         43.75
lib     lib/runners/java.rb                            success  47           0              47         100.00
lib     lib/runners/kotlin.rb                          success  0            0              0          0
lib     lib/runners/location.rb                        success  25           21             46         54.35
lib     lib/runners/nodejs/constraint.rb               success  7            6              13         53.85
lib     lib/runners/nodejs/dependency.rb               success  4            0              4          100.00
lib     lib/runners/nodejs.rb                          success  113          4              118        95.76
lib     lib/runners/options.rb                         success  25           5              30         83.33
lib     lib/runners/php.rb                             success  3            0              3          100.00
lib     lib/runners/processor/brakeman.rb              success  46           15             61         75.41
lib     lib/runners/processor/checkstyle.rb            success  63           27             93         67.74
lib     lib/runners/processor/clang_tidy.rb            success  27           17             46         58.70
lib     lib/runners/processor/code_sniffer.rb          success  56           26             84         66.67
lib     lib/runners/processor/coffeelint.rb            success  36           15             52         69.23
lib     lib/runners/processor/cppcheck.rb              success  89           34             125        71.20
lib     lib/runners/processor/cpplint.rb               success  67           25             94         71.28
lib     lib/runners/processor/detekt.rb                success  94           4              100        94.00
lib     lib/runners/processor/eslint.rb                success  107          23             133        80.45
lib     lib/runners/processor/flake8.rb                success  55           6              62         88.71
lib     lib/runners/processor/fxcop.rb                 success  17           32             51         33.33
lib     lib/runners/processor/golangci_lint.rb         success  117          27             146        80.14
lib     lib/runners/processor/goodcheck.rb             success  81           23             104        77.88
lib     lib/runners/processor/hadolint.rb              success  64           15             81         79.01
lib     lib/runners/processor/haml_lint.rb             success  77           21             102        75.49
lib     lib/runners/processor/javasee.rb               success  31           28             61         50.82
lib     lib/runners/processor/jshint.rb                success  59           7              70         84.29
lib     lib/runners/processor/ktlint.rb                success  34           12             48         70.83
lib     lib/runners/processor/languagetool.rb          success  89           39             131        67.94
lib     lib/runners/processor/misspell.rb              success  54           3              68         79.41
lib     lib/runners/processor/phinder.rb               success  62           38             102        60.78
lib     lib/runners/processor/phpmd.rb                 success  81           8              92         88.04
lib     lib/runners/processor/pmd_cpd.rb               success  74           58             136        54.41
lib     lib/runners/processor/pmd_java.rb              success  55           22             81         67.90
lib     lib/runners/processor/pylint.rb                success  47           20             71         66.20
lib     lib/runners/processor/querly.rb                success  43           10             63         68.25
lib     lib/runners/processor/rails_best_practices.rb  success  85           13             101        84.16
lib     lib/runners/processor/reek.rb                  success  43           18             66         65.15
lib     lib/runners/processor/remark_lint.rb           success  76           27             107        71.03
lib     lib/runners/processor/rubocop.rb               success  160          33             198        80.81
lib     lib/runners/processor/scss_lint.rb             success  36           13             50         72.00
lib     lib/runners/processor/shellcheck.rb            success  73           33             111        65.77
lib     lib/runners/processor/stylelint.rb             success  129          30             165        78.18
lib     lib/runners/processor/swiftlint.rb             success  57           7              68         83.82
lib     lib/runners/processor/tslint.rb                success  70           13             84         83.33
lib     lib/runners/processor/tyscan.rb                success  67           28             97         69.07
lib     lib/runners/processor.rb                       success  179          4              183        97.81
lib     lib/runners/python.rb                          success  3            0              3          100.00
lib     lib/runners/recommended_config.rb              success  21           0              21         100.00
lib     lib/runners/results.rb                         success  79           11             90         87.78
lib     lib/runners/ruby/gem_installer/source.rb       success  60           7              67         89.55
lib     lib/runners/ruby/gem_installer/spec.rb         success  45           11             56         80.36
lib     lib/runners/ruby/gem_installer.rb              success  84           0              84         100.00
lib     lib/runners/ruby/lockfile_loader/lockfile.rb   success  37           0              37         100.00
lib     lib/runners/ruby/lockfile_loader.rb            success  44           0              44         100.00
lib     lib/runners/ruby/lockfile_parser.rb            success  2            5              7          28.57
lib     lib/runners/ruby.rb                            success  73           1              74         98.65
lib     lib/runners/schema/config.rb                   success  80           3              83         96.39
lib     lib/runners/schema/options.rb                  success  19           0              19         100.00
lib     lib/runners/schema/result.rb                   success  79           0              79         100.00
lib     lib/runners/schema/trace.rb                    success  72           0              72         100.00
lib     lib/runners/sensitive_filter.rb                success  9            0              9          100.00
lib     lib/runners/shell.rb                           success  70           21             91         76.92
lib     lib/runners/swift.rb                           success  1            0              1          100.00
lib     lib/runners/testing/smoke.rb                   success  172          108            280        61.43
lib     lib/runners/tmpdir.rb                          success  4            0              4          100.00
lib     lib/runners/trace_writer.rb                    success  80           4              84         95.24
lib     lib/runners/version.rb                         success  1            0              1          100.00
lib     lib/runners/workspace/git.rb                   success  36           23             59         61.02
lib     lib/runners/workspace.rb                       success  31           10             41         75.61
lib     lib/runners.rb                                 success  109          0              109        100.00
```

> Link related issues or pull requests.

Related to #877
