### PR TITLE
Remove deprecated `Runners::Ruby#ruby_analyzer_bin` method

### DIFF
--- a/lib/runners/ruby.rb
+++ b/lib/runners/ruby.rb
@@ -71,11 +71,6 @@ module Runners
       capture3! "bundle", "-v"
     end
 
-    # @deprecated Use {#ruby_analyzer_command} instead.
-    def ruby_analyzer_bin
-      ["bundle", "exec", analyzer_bin]
-    end
-
     def ruby_analyzer_command(*args)
       Command.new("bundle", ["exec", analyzer_bin, *args])
     end

--- a/sig/runners/ruby.rbs
+++ b/sig/runners/ruby.rbs
@@ -7,8 +7,6 @@ module Runners
 
     def install_gems: [X] (Array[GemInstaller::Spec], constraints: constraints, ?optionals: Array[GemInstaller::Spec]) { (Hash[String, String]) -> X } -> X
 
-    def ruby_analyzer_bin: () -> Array[String]
-
     def ruby_analyzer_command: (*String) -> Command
 
     def installed_gem_versions: (Array[String], ?exception: bool) -> Hash[String, Array[String]]


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This method is no longer used.

> Link related issues or pull requests.

None.
