### PR TITLE
Improve `rake steep:stats`

### DIFF
--- a/lib/tasks/steep/stats.rb
+++ b/lib/tasks/steep/stats.rb
@@ -1,6 +1,6 @@
 namespace :steep do
   desc "Show the Steep coverage report"
   task :stats do
-    sh "bundle exec steep stats --log-level=fatal | column -s, -t"
+    sh "bundle exec steep stats --log-level=fatal | column -s, -t | sort --key=7 --sort=numeric"
   end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to make it easy to find needed RBS.
Using the [`sort`](https://www.man7.org/linux/man-pages/man1/sort.1.html) command.

> Link related issues or pull requests.

Related to #877
