### PR TITLE
Fix RBS for `Runners::Processor::ClangTidy`

### DIFF
--- a/lib/runners/processor/clang_tidy.rb
+++ b/lib/runners/processor/clang_tidy.rb
@@ -2,7 +2,9 @@ module Runners
   class Processor::ClangTidy < Processor
     include CPlusPlus
 
-    Schema = StrongJSON.new do
+    Schema = _ = StrongJSON.new do
+      # @type self: SchemaClass
+
       let :runner_config, Schema::BaseConfig.cplusplus
 
       let :issue, object(
@@ -49,6 +51,8 @@ module Runners
       # <path>:<line>:<column>: <severity>: <message> [<id>]
       pattern = /^(.+):(\d+):(\d+): ([^:]+): (.+) \[([^\[]+)\]$/
       stdout.scan(pattern) do |path, line, column, severity, message, id|
+        raise "Unexpected match data: #{path.inspect}" unless path.is_a? String
+
         yield Issue.new(
           path: relative_path(path),
           location: Location.new(start_line: line, start_column: column),

--- a/sig/runners/processor/clang_tidy.rbs
+++ b/sig/runners/processor/clang_tidy.rbs
@@ -2,14 +2,14 @@ module Runners
   class Processor::ClangTidy < Processor
     include CPlusPlus
 
-    Schema: untyped
+    class SchemaClass < StrongJSON
+      def runner_config: () -> StrongJSON::Type::Object[untyped]
+      def issue: () -> StrongJSON::Type::Object[untyped]
+    end
+    Schema: SchemaClass
 
-    def setup: () { () -> untyped } -> untyped
+    private
 
-    def analyzer_bin: () -> "clang-tidy"
-
-    def analyze: (untyped changes) -> untyped
-
-    def construct_result: (untyped stdout) { (untyped) -> untyped } -> untyped
+    def construct_result: (String) { (Issue) -> void } -> void
   end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to improve the RBS and type-check for the `Runners::Processor::ClangTidy` class.

> Link related issues or pull requests.

A part of #877

