### PR TITLE
Set `error` to Bugsnag severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.39.0...HEAD)
 
+- Set `error` to Bugsnag severity [#1758](https://github.com/sider/runners/pull/1758)
+
 ## 0.39.0
 
 [Full diff](https://github.com/sider/runners/compare/0.38.1...0.39.0)

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -97,7 +97,9 @@ module Runners
       rescue UserError => exn
         Results::Failure.new(guid: guid, message: exn.message, analyzer: @analyzer)
       rescue => exn
-        Bugsnag.notify(exn)
+        Bugsnag.notify(exn) do |report|
+          report.severity = "error"
+        end
         handle_error(exn)
         Results::Error.new(guid: guid, exception: exn, analyzer: @analyzer)
       end

--- a/sig/bugsnag.rbs
+++ b/sig/bugsnag.rbs
@@ -1,0 +1,7 @@
+module Bugsnag
+  def self.notify: (Exception) ?{ (Report) -> void } -> void
+
+  class Report
+    attr_accessor severity: "error" | "warning" | "info"
+  end
+end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

When using `Bugsnag.notify`, the severity will be `warning` by default.
But `warning` is not suitable and `error` should be suitable in `Runners::Harness`.

See also:
- https://docs.bugsnag.com/platforms/ruby/other/reporting-handled-errors/#severity
- https://github.com/bugsnag/bugsnag-ruby/blob/v6.18.0/lib/bugsnag/report.rb#L125

> Link related issues or pull requests.

None.
