### PR TITLE
Add an option to analyze git metadata directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.39.1...HEAD)
 
 - **remark-lint** Bump remark-preset-lint-sider from 0.5.0 to 0.6.0 [#1762](https://github.com/sider/runners/pull/1762)
+- Add `use_git_metadata_dir?` method for analysis processors. [#1775](https://github.com/sider/runners/pull/1775)
 
 ## 0.39.1
 

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -54,7 +54,11 @@ module Runners
               result = processor.setup do
                 trace_writer.header "Run #{processor.analyzer_name}"
                 @analyzer = processor.analyzer # initialize analyzer
-                exclude_special_dirs { processor.analyze(changes) }
+                if processor.use_git_metadata_dir?
+                  processor.analyze(changes)
+                else
+                  exclude_special_dirs { processor.analyze(changes) }
+                end
               end
 
               case result

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -123,6 +123,11 @@ module Runners
       raise ArgumentError, "Not found version from the command `#{command_line.join(' ')}`"
     end
 
+    # If a processor needs git metadata('.git' dir), override this method as returning true.
+    def use_git_metadata_dir?
+      false
+    end
+
     def config_linter
       config.linter(analyzer_id)
     end

--- a/sig/runners/processor.rbs
+++ b/sig/runners/processor.rbs
@@ -59,6 +59,8 @@ module Runners
 
     def extract_version!: ((String | Array[String]) command, ?(String | Array[String]) version_option, ?pattern: Regexp pattern) -> String
 
+    def use_git_metadata_dir?: () -> bool
+
     def config_linter: () -> Hash[Symbol, untyped]
 
     def check_root_dir_exist: () -> Results::Failure?

--- a/test/harness_test.rb
+++ b/test/harness_test.rb
@@ -182,4 +182,27 @@ class HarnessTest < Minitest::Test
       assert_path_exists harness.working_dir / ".git" / "config"
     end
   end
+
+  def test_not_exclude_special_dirs
+    processor_class = Class.new(TestProcessor) do
+      def use_git_metadata_dir?
+        true
+      end
+
+      def analyze(_)
+        if (working_dir / ".git").exist?
+          super
+        else
+          raise
+        end
+      end
+    end
+
+    with_harness(processor_class: processor_class) do |harness|
+      result = harness.run
+
+      assert_instance_of Results::Success, result
+      assert_path_exists harness.working_dir / ".git" / "config"
+    end
+  end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The current runners exclude git metadata directory (`.git/`) from their analysis targets. This is a barrier to implement a runner to analyze repository information related with git. (e.g. last modified datetime in git commit log)

This PR adds a option for analysis processors to include the metadata in their analysis targets.

> Link related issues or pull requests.

https://github.com/sider/runners/pull/1112#issuecomment-631232932

> Check the following.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
