### PR TITLE
Fix RBS when using Rainbow

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -12,4 +12,5 @@ target :lib do
   library "uri"
   library "strong_json"
   library "retryable"
+  library "rainbow"
 end

--- a/sig/rainbow.rbs
+++ b/sig/rainbow.rbs
@@ -1,12 +1,6 @@
-module Kernel
-  def Rainbow: (String) -> Rainbow
-end
-
-class Rainbow
-  def bright: () -> self
-  def underline: () -> self
-  def green: () -> self
-  def red: () -> self
+# TODO: Remove it when the missing methods will be supported.
+#       See <https://github.com/ruby/gem_rbs/tree/main/gems/rainbow>.
+class Rainbow::Presenter
   def aqua: () -> self
   def darkgray: () -> self
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to use <https://github.com/ruby/gem_rbs/tree/main/gems/rainbow> as possible.
But the polyfill is still needed.

> Link related issues or pull requests.

Related to #877

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
