### PR TITLE
Fix RBS for `Runners::Processor::Misspell`

### DIFF
--- a/sig/runners/processor/misspell.rbs
+++ b/sig/runners/processor/misspell.rbs
@@ -1,25 +1,23 @@
 module Runners
   class Processor::Misspell < Processor
-    Schema: untyped
+    class SchemaClass < StrongJSON
+      def runner_config: () -> StrongJSON::Type::Object[untyped]
+      def issue: () -> StrongJSON::Type::Object[untyped]
+    end
+    Schema: SchemaClass
 
-    DEFAULT_TARGET: untyped
+    DEFAULT_TARGET: String
 
-    def extract_version_option: () -> "-v"
+    private
 
-    def setup: () { () -> untyped } -> untyped
+    def cli_args: () -> Array[String]
 
-    def analyze: (untyped _changes) -> untyped
+    def locale: () -> Array[String]
 
-    def run_analyzer: () -> untyped
+    def ignore: () -> Array[String]
 
-    def cli_args: () -> untyped
+    def analysis_targets: () -> Array[String]
 
-    def locale: () -> untyped
-
-    def ignore: () -> untyped
-
-    def analysis_targets: () -> untyped
-
-    def delete_targets: () -> (nil | untyped)
+    def delete_targets: () -> void
   end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to improve the RBS and type-check for the `Runners::Processor::Misspell` class.

> Link related issues or pull requests.

A part of #877

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
