### PR TITLE
Consider line range in `Runners::Changes#include?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.39.1...HEAD)
 
 - **remark-lint** Bump remark-preset-lint-sider from 0.5.0 to 0.6.0 [#1762](https://github.com/sider/runners/pull/1762)
+- Consider line range in `Runners::Changes#include?` [#1781](https://github.com/sider/runners/pull/1781)
 
 ## 0.39.1
 

--- a/lib/runners/location.rb
+++ b/lib/runners/location.rb
@@ -37,5 +37,18 @@ module Runners
     def to_s
       "{ start_line=#{start_line.inspect}, start_column=#{start_column.inspect}, end_line=#{end_line.inspect}, end_column=#{end_column.inspect} }"
     end
+
+    def include_line?(line)
+      s = start_line
+      e = end_line
+      case
+      when s && e
+        s <= line && line <= e
+      when s && !e
+        s == line
+      else
+        false
+      end
+    end
   end
 end

--- a/sig/runners/changes.rbs
+++ b/sig/runners/changes.rbs
@@ -20,6 +20,6 @@ module Runners
 
     def deletable?: (Pathname dir, Pathname file, Array[String] except, Array[String] only) -> bool
 
-    def find_patch_by_file: (String) -> GitDiffParser::Patch?
+    def changed_lines_by_file: (GitDiffParser::Patches, String) -> Array[Integer]
   end
 end

--- a/sig/runners/location.rbs
+++ b/sig/runners/location.rbs
@@ -1,21 +1,17 @@
 module Runners
   class Location
-    attr_reader start_line: untyped
+    attr_reader start_line: Integer?
+    attr_reader start_column: Integer?
+    attr_reader end_line: Integer?
+    attr_reader end_column: Integer?
 
-    attr_reader start_column: untyped
+    def initialize: (start_line: (Numeric | String)?,
+                     ?start_column: (Numeric | String)?,
+                     ?end_line: (Numeric | String)?,
+                     ?end_column: (Numeric | String)?) -> void
 
-    attr_reader end_line: untyped
+    def as_json: () -> Hash[Symbol, Integer?]
 
-    attr_reader end_column: untyped
-
-    def initialize: (start_line: untyped start_line, ?start_column: untyped? start_column, ?end_line: untyped? end_line, ?end_column: untyped? end_column) -> untyped
-
-    def ==: (untyped other) -> untyped
-
-    def hash: () -> untyped
-
-    def as_json: () -> untyped
-
-    def to_s: () -> ::String
+    def include_line?: (Integer) -> bool
   end
 end

--- a/test/changes_test.rb
+++ b/test/changes_test.rb
@@ -139,9 +139,9 @@ index 740c016..cc737a5 100644
 
       changes = Changes.calculate(working_dir: dir)
 
-      assert_includes changes, Issue.new(path: Pathname("group.rb"), location: Location.new(start_line: 1), id: "a", message: "a", links: [])
-      assert_includes changes, Issue.new(path: Pathname("user.rb"), location: nil, id: "a", message: "a", links: [])
-      refute_includes changes, Issue.new(path: Pathname("foo.rb"), location: nil, id: "a", message: "a", links: [])
+      assert_includes changes, Issue.new(path: Pathname("group.rb"), location: Location.new(start_line: 1), id: "a", message: "a")
+      assert_includes changes, Issue.new(path: Pathname("user.rb"), location: nil, id: "a", message: "a")
+      refute_includes changes, Issue.new(path: Pathname("foo.rb"), location: nil, id: "a", message: "a")
     end
   end
 
@@ -162,17 +162,34 @@ index 740c016..cc737a5 100644
 
       changes = Changes.calculate_by_patches(working_dir: dir, patches: patches)
 
-      refute_includes changes, Issue.new(path: Pathname("group.rb"), location: Location.new(start_line: 1), id: "a", message: "a", links: [])
-      assert_includes changes, Issue.new(path: Pathname("group.rb"), location: Location.new(start_line: 2), id: "a", message: "a", links: [])
-      assert_includes changes, Issue.new(path: Pathname("group.rb"), location: Location.new(start_line: 3), id: "a", message: "a", links: [])
-      refute_includes changes, Issue.new(path: Pathname("group.rb"), location: Location.new(start_line: 4), id: "a", message: "a", links: [])
-      assert_includes changes, Issue.new(path: Pathname("user.rb"), location: nil, id: "a", message: "a", links: [])
-      refute_includes changes, Issue.new(path: Pathname("user.rb"), location: Location.new(start_line: 1), id: "a", message: "a", links: [])
-      assert_includes changes, Issue.new(path: Pathname("user.rb"), location: Location.new(start_line: 2), id: "a", message: "a", links: [])
-      refute_includes changes, Issue.new(path: Pathname("user.rb"), location: Location.new(start_line: 3), id: "a", message: "a", links: [])
-      refute_includes changes, Issue.new(path: Pathname("user.rb"), location: Location.new(start_line: 4), id: "a", message: "a", links: [])
-      refute_includes changes, Issue.new(path: Pathname("foo.rb"), location: nil, id: "a", message: "a", links: [])
-      refute_includes changes, Issue.new(path: Pathname("foo.rb"), location: Location.new(start_line: 2), id: "a", message: "a", links: [])
+      issue = ->(path:, start_line: nil, end_line: nil, no_location: false) {
+        Issue.new(path: Pathname(path), location: no_location ? nil : Location.new(start_line: start_line, end_line: end_line), id: "a", message: "a")
+      }
+
+      refute_includes changes, issue.(path: "group.rb", start_line: 1)
+      assert_includes changes, issue.(path: "group.rb", start_line: 2)
+      assert_includes changes, issue.(path: "group.rb", start_line: 3)
+      refute_includes changes, issue.(path: "group.rb", start_line: 4)
+      refute_includes changes, issue.(path: "group.rb", start_line: 1, end_line: 1)
+      assert_includes changes, issue.(path: "group.rb", start_line: 1, end_line: 2)
+      assert_includes changes, issue.(path: "group.rb", start_line: 2, end_line: 3)
+      assert_includes changes, issue.(path: "group.rb", start_line: 3, end_line: 4)
+      refute_includes changes, issue.(path: "group.rb", start_line: 4, end_line: 4)
+
+      assert_includes changes, issue.(path: "user.rb", no_location: true)
+      refute_includes changes, issue.(path: "user.rb", start_line: 1)
+      assert_includes changes, issue.(path: "user.rb", start_line: 2)
+      refute_includes changes, issue.(path: "user.rb", start_line: 3)
+      refute_includes changes, issue.(path: "user.rb", start_line: 4)
+      refute_includes changes, issue.(path: "user.rb", start_line: 1, end_line: 1)
+      assert_includes changes, issue.(path: "user.rb", start_line: 1, end_line: 2)
+      assert_includes changes, issue.(path: "user.rb", start_line: 1, end_line: 3)
+      assert_includes changes, issue.(path: "user.rb", start_line: 2, end_line: 3)
+      refute_includes changes, issue.(path: "user.rb", start_line: 3, end_line: 5)
+
+      refute_includes changes, issue.(path: "foo.rb", no_location: true)
+      refute_includes changes, issue.(path: "foo.rb", start_line: 2)
+      refute_includes changes, issue.(path: "foo.rb", start_line: 2, end_line: 3)
     end
   end
 end

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -28,4 +28,16 @@ class LocationTest < Minitest::Test
       Location.new(start_line: 1).to_s,
     )
   end
+
+  def test_include_line
+    assert Location.new(start_line: 1).include_line?(1)
+    refute Location.new(start_line: 1).include_line?(2)
+    refute Location.new(start_line: nil).include_line?(1)
+
+    assert Location.new(start_line: 1, end_line: 1).include_line?(1)
+    assert Location.new(start_line: 1, end_line: 2).include_line?(1)
+    assert Location.new(start_line: 1, end_line: 2).include_line?(2)
+    refute Location.new(start_line: 1, end_line: 2).include_line?(0)
+    refute Location.new(start_line: 1, end_line: 2).include_line?(3)
+  end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Some tools have a line range (start and end) for an issue.
But the current implementation of `Runners::Changes#include?` checks only a start line.
In the following case, an issue is never reported.

Code:

```ruby
def foo     # L1
  p "Hi"    # L2 <--- changed line, but never reported!
end         # L3
```

Issue: "Too long method with L1-3"

This change aims to fix the bug by checking a line range of an issue.

> Link related issues or pull requests.

None.

> Check the following.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
