### PR TITLE
Fix RBS for `Runners::GitBlameInfo`

### DIFF
--- a/sig/runners/git_blame_info.rbs
+++ b/sig/runners/git_blame_info.rbs
@@ -1,23 +1,14 @@
 module Runners
   class GitBlameInfo
-    # @param porcelain_output [String] The output of git-blame(1) with -p option
-    # @see https://www.git-scm.com/docs/git-blame#_the_porcelain_format
-    def self.parse: (untyped porcelain_output) -> untyped
+    def self.parse: (String) -> Array[instance]
 
-    attr_reader commit: untyped
+    attr_reader commit: String
+    attr_reader original_line: Integer
+    attr_reader final_line: Integer
+    attr_reader line_hash: Integer
 
-    attr_reader original_line: untyped
+    def initialize: (commit: String, original_line: Integer, final_line: Integer, line_hash: Integer) -> void
 
-    attr_reader final_line: untyped
-
-    attr_reader line_hash: untyped
-
-    def initialize: (commit: untyped commit, original_line: untyped original_line, final_line: untyped final_line, line_hash: untyped line_hash) -> untyped
-
-    def ==: (untyped other) -> untyped
-
-    def hash: () -> untyped
-
-    def as_json: () -> { commit: untyped, original_line: untyped, final_line: untyped, line_hash: untyped }
+    def as_json: () -> Hash[Symbol, String | Integer]
   end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to improve the RBS and type-check for the `Runners::GitBlameInfo` class.

> Link related issues or pull requests.

A part of #877

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
