### PR TITLE
Downgrade Steep to 0.37.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :development, :test do
   gem 'parallel'
   gem 'amazing_print'
   gem 'rainbow'
-  gem 'steep', require: false
+  gem 'steep', '= 0.37.0', require: false # TODO: https://github.com/soutaro/steep/issues/272
   gem 'aufgaben', git: 'https://github.com/ybiquitous/aufgaben.git', tag: '0.5.1', require: false
   gem 'lefthook', require: false
   gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     rubocop-ast (1.3.0)
       parser (>= 2.7.1.5)
     ruby-progressbar (1.10.1)
-    steep (0.38.0)
+    steep (0.37.0)
       activesupport (>= 5.1)
       ast_utils (~> 0.3.0)
       language_server-protocol (~> 3.15.0.1)
@@ -85,7 +85,7 @@ GEM
       rbs (>= 0.20.0)
     strong_json (2.1.2)
     thor (1.0.1)
-    tzinfo (2.0.3)
+    tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.7.0)
     unification_assertion (0.0.1)
@@ -112,7 +112,7 @@ DEPENDENCIES
   retryable
   rexml (>= 3.2, < 4.0)
   rubocop
-  steep
+  steep (= 0.37.0)
   strong_json
   unification_assertion
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The version 0.38.0 has a bug: https://github.com/soutaro/steep/issues/272

```
lib/runners/nodejs.rb:229:10: BreakTypeMismatch: expected=::Hash[::String, ::Runners::Nodejs::Constraint], actual=nil (break)
  nil <: ::Hash[::String, ::Runners::Nodejs::Constraint]
==> nil <: ::Hash[::String, ::Runners::Nodejs::Constraint] does not hold
```

> Link related issues or pull requests.

A part of #877

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
