### PR TITLE
Add `rbs` to Gemfile explicitly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :development, :test do
   gem 'parallel'
   gem 'amazing_print'
   gem 'rainbow'
+  gem 'rbs'
   gem 'steep', '= 0.37.0', require: false # TODO: https://github.com/soutaro/steep/issues/272
   gem 'aufgaben', git: 'https://github.com/ybiquitous/aufgaben.git', tag: '0.5.1', require: false
   gem 'lefthook', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :development, :test do
   gem 'parallel'
   gem 'amazing_print'
   gem 'rainbow'
-  gem 'rbs'
+  gem 'rbs', require: false
   gem 'steep', '= 0.37.0', require: false # TODO: https://github.com/soutaro/steep/issues/272
   gem 'aufgaben', git: 'https://github.com/ybiquitous/aufgaben.git', tag: '0.5.1', require: false
   gem 'lefthook', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ DEPENDENCIES
   parallel
   rainbow
   rake
+  rbs
   retryable
   rexml (>= 3.2, < 4.0)
   rubocop


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

`rbs` is a sub-dependency of `steep` but its explicit declaration is useful to bump only `rbs`.

> Link related issues or pull requests.

Follow up of #877

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
