### PR TITLE
[PMD Java] NoMethodError: undefined method `gsub' for 2:Integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.39.2...HEAD)
 
-- [PMD Java] NoMethodError: undefined method `gsub' for 2:Integer [#1818](https://github.com/sider/runners/pull/1818)
+- **PMD Java** NoMethodError: undefined method `gsub' for 2:Integer [#1818](https://github.com/sider/runners/pull/1818)
 
 ## 0.39.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.39.2...HEAD)
 
+- [PMD Java] NoMethodError: undefined method `gsub' for 2:Integer [#1818](https://github.com/sider/runners/pull/1818)
+
 ## 0.39.2
 
 [Full diff](https://github.com/sider/runners/compare/0.39.1...0.39.2)

--- a/lib/runners/processor/pmd_java.rb
+++ b/lib/runners/processor/pmd_java.rb
@@ -70,16 +70,16 @@ module Runners
     private
 
     def cli_args
-      [].tap do |args|
-        args << "-language" << "java"
-        args << "-threads" << "2"
-        args << "-format" << "xml"
-        args << "-reportfile" << report_file
-        args << "-dir" << dir
-        args << "-rulesets" << rulesets.join(",")
-        min_priority&.tap { |num| args << "-minimumpriority" << num }
-        encoding&.tap { |enc| args << "-encoding" << enc }
-      end
+      [
+        "-language", "java",
+        "-threads", "2",
+        "-format", "xml",
+        "-reportfile", report_file,
+        "-dir", dir,
+        "-rulesets", rulesets.join(","),
+        *min_priority,
+        *encoding,
+      ]
     end
 
     def construct_result(xml)
@@ -133,11 +133,13 @@ module Runners
     end
 
     def encoding
-      config_linter[:encoding]
+      enc = config_linter[:encoding]
+      enc ? ["-encoding", enc] : []
     end
 
     def min_priority
-      config_linter[:min_priority]
+      num = config_linter[:min_priority]
+      num ? ["-minimumpriority", num.to_s] : []
     end
   end
 end

--- a/sig/runners/processor/pmd_java.rbs
+++ b/sig/runners/processor/pmd_java.rbs
@@ -21,8 +21,8 @@ module Runners
 
     def dir: () -> String
 
-    def encoding: () -> String?
+    def encoding: () -> Array[String]
 
-    def min_priority: () -> Numeric?
+    def min_priority: () -> Array[String]
   end
 end

--- a/test/smokes/pmd_java/config/sideci.yml
+++ b/test/smokes/pmd_java/config/sideci.yml
@@ -2,3 +2,4 @@ linter:
   pmd_java:
     rulesets: category/java/codestyle.xml
     dir: src
+    min_priority: 5


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to fix the bug that `Runners::Processor::PmdJava#cli_args` returns an array including a `Numeric` element when `linter.pmd_java.min_priority` has a numeric value like this:

```yaml
# sider.yml
linter:
  pmd_java:
    min_priority: 5
```

> Link related issues or pull requests.

None.

> Check the following.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
