### PR TITLE
[PMD CPD] Remove needless `CGI.unescape_html`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.39.3...HEAD)
 
 - Remove unused `locale` gem [#1817](https://github.com/sider/runners/pull/1817)
+- **PMD CPD** Remove needless `CGI.unescape_html`[#1821](https://github.com/sider/runners/pull/1821)
 
 ## 0.39.3
 

--- a/lib/runners.rb
+++ b/lib/runners.rb
@@ -22,7 +22,6 @@ require "aws-sdk-s3"
 require "bugsnag"
 require "git_diff_parser"
 require "strscan"
-require "cgi"
 
 require "runners/version"
 require "runners/errors"

--- a/lib/runners/processor/pmd_cpd.rb
+++ b/lib/runners/processor/pmd_cpd.rb
@@ -143,9 +143,6 @@ module Runners
       codefragment = elem_dupli.elements['codefragment']&.cdatas&.first&.value
       codefragment or raise "required codefragment: #{elem_dupli.inspect}"
 
-      # @see https://github.com/pmd/pmd/pull/2633
-      codefragment = CGI.unescape_html(codefragment)
-
       fileobjs = files.map do |f|
         {
           id: f[:id],


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

With the latest version of PMD CPD, the workaround via `CGI.unescape_html` is needless.

> Link related issues or pull requests.

See #1333
See also https://github.com/pmd/pmd/pull/2633 and https://github.com/pmd/pmd/pull/2831

> Check the following.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
