### PR TITLE
Move `base64` to `runners/testing/smoke`

### DIFF
--- a/lib/runners.rb
+++ b/lib/runners.rb
@@ -1,5 +1,4 @@
 require "bundler"
-require "base64"
 require "pathname"
 require "open3"
 require "json"

--- a/lib/runners/testing/smoke.rb
+++ b/lib/runners/testing/smoke.rb
@@ -4,6 +4,7 @@ require 'parallel'
 require "amazing_print"
 require "rainbow"
 require "openssl"
+require "base64"
 
 module Runners
   module Testing


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

`base64` is used only in `runners/testing/smoke.rb`.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
