### PR TITLE
Move `RunnersTimeoutError` to `Runners::TimeoutError`

### DIFF
--- a/bin/runners
+++ b/bin/runners
@@ -5,8 +5,6 @@ $LOAD_PATH.prepend File.join(__dir__, "..", "lib")
 require "runners"
 require "runners/cli"
 
-class RunnersTimeoutError < StandardError; end
-
 EXIT_STATUS_FOR_SIGTERM = 126
 
 # @see https://docs.bugsnag.com/platforms/ruby/configuration-options
@@ -23,12 +21,12 @@ Bugsnag.configure do |config|
 end
 
 trap('SIGTERM') do
-  Bugsnag.notify(RunnersTimeoutError.new)
+  Bugsnag.notify(Runners::TimeoutError.new)
   exit(EXIT_STATUS_FOR_SIGTERM)
 end
 
 trap('SIGUSR2') do
-  Bugsnag.notify(RunnersTimeoutError.new)
+  Bugsnag.notify(Runners::TimeoutError.new)
 end
 
 begin

--- a/lib/runners/errors.rb
+++ b/lib/runners/errors.rb
@@ -2,4 +2,5 @@ module Runners
   class Error < StandardError; end
   class UserError < Error; end
   class SystemError < Error; end
+  class TimeoutError < SystemError; end
 end

--- a/sig/runners/errors.rbs
+++ b/sig/runners/errors.rbs
@@ -7,4 +7,7 @@ module Runners
 
   class SystemError < Error
   end
+
+  class TimeoutError < SystemError
+  end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to unify handling errors raised in Runners.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
