### PR TITLE
Refactor Bugsnag configuration on CLI

### DIFF
--- a/bin/runners
+++ b/bin/runners
@@ -7,19 +7,6 @@ require "runners/cli"
 
 EXIT_STATUS_FOR_SIGTERM = 126
 
-# @see https://docs.bugsnag.com/platforms/ruby/configuration-options
-Bugsnag.configure do |config|
-  config.api_key = ENV.delete("BUGSNAG_API_KEY")
-  config.app_version = ENV.delete("RUNNERS_VERSION")
-  config.release_stage = ENV.delete("BUGSNAG_RELEASE_STAGE")
-
-  # @see https://docs.bugsnag.com/platforms/ruby/customizing-error-reports/#adding-callbacks
-  config.add_on_error(proc do |report|
-    report.add_tab(:task_guid, ENV.delete("TASK_GUID")) if ENV["TASK_GUID"]
-    report.add_tab(:arguments, ARGV)
-  end)
-end
-
 trap('SIGTERM') do
   Bugsnag.notify(Runners::TimeoutError.new)
   exit(EXIT_STATUS_FOR_SIGTERM)

--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -92,7 +92,8 @@ module Runners
 
         # @see https://docs.bugsnag.com/platforms/ruby/customizing-error-reports/#adding-callbacks
         config.add_on_error(proc do |report|
-          # @type var report: Bugsnag:Report
+          # TODO: Ignored Steep error
+          # @type var report: untyped
           report.add_tab :task_guid, guid
           report.add_tab :arguments, argv
         end)

--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -14,6 +14,8 @@ module Runners
       @stdout = stdout
       @stderr = stderr
 
+      setup_bugsnag!(argv.dup)
+
       OptionParser.new do |opts|
         opts.banner = "Usage: runners [options] <GUID>"
 
@@ -75,6 +77,27 @@ module Runners
     end
 
     private
+
+    def setup_bugsnag!(argv)
+      # NOTE: Prevent information from being stolen from environment variables.
+      api_key = ENV.delete("BUGSNAG_API_KEY")
+      app_version = ENV.delete("RUNNERS_VERSION")
+      release_stage = ENV.delete("BUGSNAG_RELEASE_STAGE")
+
+      # @see https://docs.bugsnag.com/platforms/ruby/configuration-options
+      Bugsnag.configure do |config|
+        config.api_key = api_key if api_key
+        config.app_version = app_version if app_version
+        config.release_stage = release_stage if release_stage
+
+        # @see https://docs.bugsnag.com/platforms/ruby/customizing-error-reports/#adding-callbacks
+        config.add_on_error(proc do |report|
+          # @type var report: Bugsnag:Report
+          report.add_tab :task_guid, guid
+          report.add_tab :arguments, argv
+        end)
+      end
+    end
 
     def with_working_dir(&block)
       mktmpdir(&block)

--- a/sig/bugsnag.rbs
+++ b/sig/bugsnag.rbs
@@ -1,7 +1,19 @@
 module Bugsnag
   def self.notify: (Exception) ?{ (Report) -> void } -> void
 
+  def self.configure: () { (Configuration) -> void } -> void
+
+  class Configuration
+    attr_accessor api_key: String
+    attr_accessor app_version: String
+    attr_accessor release_stage: String
+
+    def add_on_error: (^(Report) -> void) -> void
+  end
+
   class Report
     attr_accessor severity: "error" | "warning" | "info"
+
+    def add_tab: (Symbol, untyped) -> void
   end
 end

--- a/sig/bugsnag.rbs
+++ b/sig/bugsnag.rbs
@@ -8,7 +8,7 @@ module Bugsnag
     attr_accessor app_version: String
     attr_accessor release_stage: String
 
-    def add_on_error: (^(Report) -> void) -> void
+    def add_on_error: (untyped) -> void
   end
 
   class Report

--- a/sig/runners/cli.rbs
+++ b/sig/runners/cli.rbs
@@ -14,6 +14,8 @@ module Runners
 
     private
 
+    def setup_bugsnag!: (Array[String]) -> void
+
     def with_working_dir: [X] () { (Pathname) -> X } -> X
 
     def all_processor_classes: () -> Hash[String, Class]

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -36,7 +36,6 @@ class CLITest < Minitest::Test
     assert_raises OptionParser::InvalidArgument do
       CLI.new(argv: ["--analyzer=FOO", "test-guid"], stdout: stdout, stderr: stderr, options_json: options_json)
     end.tap do |error|
-      pp error
       assert_equal "invalid argument: --analyzer=FOO", error.message
     end
 
@@ -118,5 +117,21 @@ class CLITest < Minitest::Test
     assert_equal "2h 46m 40s", target.(10000.1234567)
     assert_equal "27h 46m 40s", target.(100000.1234567)
     assert_equal "27h 46m 40s", target.(100000)
+  end
+
+  def test_setup_bugsnag
+    ENV["BUGSNAG_API_KEY"] = "key"
+    ENV["RUNNERS_VERSION"] = "version"
+    ENV["BUGSNAG_RELEASE_STAGE"] = nil
+
+    CLI.new(argv: ["--analyzer=rubocop", "test-guid"], stdout: stdout, stderr: stderr, options_json: options_json)
+
+    assert_equal "key", Bugsnag.configuration.api_key
+    assert_equal "version", Bugsnag.configuration.app_version
+    assert_nil Bugsnag.configuration.release_stage
+
+    refute_includes ENV, "BUGSNAG_API_KEY"
+    refute_includes ENV, "RUNNERS_VERSION"
+    refute_includes ENV, "BUGSNAG_RELEASE_STAGE"
   end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change moves the Bugsnag configuration code from `bin/runners` to `lib/runners/cli.rb` for testability and type-checking.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
