### PR TITLE
Fix Ruby warning on javasee.rb

### DIFF
--- a/lib/runners/processor/javasee.rb
+++ b/lib/runners/processor/javasee.rb
@@ -38,7 +38,7 @@ module Runners
     def analyze(changes)
       delete_unchanged_files changes, only: ["*.java"]
 
-      stdout, stderr, status = shell.capture3(
+      stdout, _stderr, status = shell.capture3(
         analyzer_bin,
         "check",
         "-format", "json",


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to fix the following warning:

```
lib/runners/processor/javasee.rb:41: warning: assigned but unused variable - stderr
```

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
