### PR TITLE
Refactor AWS SDK setup

### DIFF
--- a/bin/runners
+++ b/bin/runners
@@ -17,14 +17,6 @@ trap('SIGUSR2') do
 end
 
 begin
-  # @see https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html
-  if ENV["AWS_ACCESS_KEY_ID"]
-    Aws.config[:credentials] = Aws::Credentials.new(ENV.delete("AWS_ACCESS_KEY_ID"), ENV.delete("AWS_SECRET_ACCESS_KEY"))
-  end
-  if ENV["AWS_REGION"]
-    Aws.config[:region] = ENV.delete("AWS_REGION")
-  end
-
   Runners::CLI.new(
     argv: ARGV.dup,
     stdout: STDOUT,

--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -15,6 +15,7 @@ module Runners
       @stderr = stderr
 
       setup_bugsnag!(argv.dup)
+      setup_aws!
 
       OptionParser.new do |opts|
         opts.banner = "Usage: runners [options] <GUID>"
@@ -98,6 +99,17 @@ module Runners
           report.add_tab :arguments, argv
         end)
       end
+    end
+
+    def setup_aws!
+      # NOTE: Prevent information from being stolen from environment variables.
+      id = ENV.delete("AWS_ACCESS_KEY_ID")
+      secret = ENV.delete("AWS_SECRET_ACCESS_KEY")
+      region = ENV.delete("AWS_REGION")
+
+      # @see https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html
+      Aws.config[:credentials] = Aws::Credentials.new(id, secret) if id && secret
+      Aws.config[:region] = region if region
     end
 
     def with_working_dir(&block)

--- a/sig/aws-sdk-s3.rbs
+++ b/sig/aws-sdk-s3.rbs
@@ -1,4 +1,12 @@
 module Aws
+  def self.config: () -> Hash[Symbol, Credentials | String]
+
+  class Credentials
+    private
+
+    def initialize: (String, String) -> void
+  end
+
   module S3
     # @see https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html
     class Client

--- a/sig/runners/cli.rbs
+++ b/sig/runners/cli.rbs
@@ -16,6 +16,8 @@ module Runners
 
     def setup_bugsnag!: (Array[String]) -> void
 
+    def setup_aws!: () -> void
+
     def with_working_dir: [X] () { (Pathname) -> X } -> X
 
     def all_processor_classes: () -> Hash[String, Class]

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -134,4 +134,20 @@ class CLITest < Minitest::Test
     refute_includes ENV, "RUNNERS_VERSION"
     refute_includes ENV, "BUGSNAG_RELEASE_STAGE"
   end
+
+  def test_setup_aws
+    ENV["AWS_ACCESS_KEY_ID"] = "id"
+    ENV["AWS_SECRET_ACCESS_KEY"] = "secret"
+    ENV["AWS_REGION"] = nil
+
+    CLI.new(argv: ["--analyzer=rubocop", "test-guid"], stdout: stdout, stderr: stderr, options_json: options_json)
+
+    assert_equal "id", Aws.config[:credentials].access_key_id
+    assert_equal "secret", Aws.config[:credentials].secret_access_key
+    assert_nil Aws.config[:region]
+
+    refute_includes ENV, "AWS_ACCESS_KEY_ID"
+    refute_includes ENV, "AWS_SECRET_ACCESS_KEY"
+    refute_includes ENV, "AWS_REGION"
+  end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change moves the AWS SKD setup code from `bin/runners` to `lib/runners/cli.rb` for testability and type-checking.

> Link related issues or pull requests.

This refactoring is similar to #1830.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
