### PR TITLE
Remove needless `__dir__` in Rake tasks

### DIFF
--- a/tasks/bump/analyzers.rake
+++ b/tasks/bump/analyzers.rake
@@ -54,7 +54,8 @@ BumpAnalyzers = Struct.new(
   end
 
   def self.each
-    analyzers = YAML.safe_load(Pathname(__dir__).join("..", "..", "analyzers.yml").read, symbolize_names: true).fetch(:analyzers)
+    filename = "analyzers.yml"
+    analyzers = YAML.safe_load(File.read(filename), filename: filename, symbolize_names: true).fetch(:analyzers)
     analyzers.keep_if { |_, meta| meta[:dependabot] == false && !meta[:deprecated]  }
     analyzers.each do |analyzer, meta|
       yield new(

--- a/tasks/rbs/update_gems.rake
+++ b/tasks/rbs/update_gems.rake
@@ -1,11 +1,7 @@
 namespace :rbs do
   desc "Update `ruby/gem_rbs` Git submodule"
   task :update_gems do
-    root_dir = File.join(__dir__, "..", "..")
-    Dir.chdir(root_dir)
-
-    submodule_dir = File.join(root_dir, "vendor", "rbs", "gem_rbs")
-    Dir.chdir(submodule_dir) do
+    Dir.chdir "vendor/rbs/gem_rbs" do |dir|
       sh "git", "pull", "--rebase", "origin", "main"
     end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

We don't need to use `__dir__` in a Rake task because the current directory is where `Rakefile` is located during the task is running.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
