### PR TITLE
Refactor `Runners::Processor::RailsBestPractices#prepare_config` method a bit

### DIFF
--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -104,7 +104,7 @@ module Runners
     def prepare_config
       # NOTE: We expect sider_rails_best_practices.yml to be located in $HOME.
       default_config = Pathname(Dir.home) / 'sider_rails_best_practices.yml'
-      path = Pathname("#{current_dir.to_s}/config/rails_best_practices.yml")
+      path = current_dir / 'config' / 'rails_best_practices.yml'
       return if path.exist?
       path.parent.mkpath
       FileUtils.copy_file(default_config, path)


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring simplifies the `Runners::Processor::RailsBestPractices#prepare_config` method about the use of `Pathname`.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
