### PR TITLE
Move `{docker,dockerfile}:*` rake tasks to `task/{docker,dockerfile}/`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ ENV["DOCKER_BUILDKIT"] = "1"
 Aufgaben::Release.new(:release) do |t|
   t.files = ["lib/runners/version.rb"]
 end
+task release: [:"dockerfile:verify_devon_rex"]
 
 Aufgaben::Bump::Ruby.new do |t|
   t.files = %w[
@@ -20,136 +21,8 @@ Aufgaben::Bump::Ruby.new do |t|
   ]
 end
 
-ANALYZERS = begin
-  Dir.chdir("images") do
-    Dir.glob("*").select { |f| File.directory? f }.freeze
-  end
-end
-
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/**/*_test.rb'].exclude(%r{^test/smokes})
-end
-
-namespace :dockerfile do
-  def render_erb(file, analyzer: ENV.fetch('ANALYZER'))
-    locals = {
-      analyzer: analyzer,
-      chown: '${RUNNER_USER}:${RUNNER_GROUP}',
-    }
-
-    res = ERB.new(File.read(file), trim_mode: "<>").result_with_hash(locals)
-    "\n#{res.strip}\n" # Ensure to start with one newline and end with one newline
-  end
-
-  desc 'Generate Dockerfile from a template'
-  task :generate do
-    ANALYZERS.each do |analyzer|
-      backup_analyzer = ENV['ANALYZER']
-      ENV['ANALYZER'] = analyzer
-      dir = Pathname('images') / analyzer
-      file = dir / 'Dockerfile.erb'
-      content = <<~EOD
-        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-        # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
-        # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
-        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-        #{render_erb(file, analyzer: analyzer).strip}
-      EOD
-      (dir / 'Dockerfile').write(content)
-    ensure
-      if backup_analyzer
-        ENV['ANALYZER'] = backup_analyzer
-      else
-        ENV.delete 'ANALYZER'
-      end
-    end
-  end
-
-  desc 'Verify Dockerfile is committed'
-  task :verify do
-    sh 'git', 'diff', '--exit-code' do |ok|
-      unless ok
-        abort "\nError: Run `bundle exec rake dockerfile:generate` and include the changes in commit"
-      end
-    end
-  end
-
-  desc 'Verify the devon_rex image tag'
-  task :verify_devon_rex do
-    disallowed_tag = 'master'
-    sh 'git', 'grep', '--quiet', "/devon_rex_.+:#{disallowed_tag}", 'images/' do |found|
-      if found
-        abort "\nError: Disallow to release with the `#{disallowed_tag}` tag of the devon_rex images."
-      end
-    end
-  end
-end
-
-task :release => "dockerfile:verify_devon_rex"
-
-namespace :docker do
-  def image_name(t = tag)
-    "sider/runner_#{analyzer}:#{t}"
-  end
-
-  def build_context
-    Pathname('images') / analyzer
-  end
-
-  def analyzer
-    key = 'ANALYZER'
-    ENV[key].tap do |value|
-      abort <<~MSG if value.nil? || value.empty?
-        Error: `#{key}` environment variable must be required. For example, run as follow:
-
-            $ #{key}=rubocop bundle exec rake docker:build
-      MSG
-    end
-  end
-
-  def tag
-    ENV.fetch('TAG') { 'dev' }
-  end
-
-  def docker_user
-    ENV.fetch('DOCKER_USER')
-  end
-
-  def docker_password
-    ENV.fetch('DOCKER_PASSWORD')
-  end
-
-  desc 'Run docker build'
-  task :build => 'dockerfile:generate' do
-    sh "docker", "build", "--tag", image_name, "--file", "#{build_context}/Dockerfile", "."
-  end
-
-  desc 'Run smoke test on Docker'
-  task :smoke do
-    sh "bin/runners_smoke", image_name, "test/smokes/#{analyzer}/expectations.rb"
-  end
-
-  desc 'Run docker push'
-  task :push do
-    sh "docker", "login", "--username", docker_user, "--password", docker_password
-    begin
-      sh "docker", "push", image_name
-      if ENV["TAG_LATEST"] == "true"
-        image_name_with_new_tag = image_name("latest")
-        sh "docker", "tag", image_name, image_name_with_new_tag
-        sh "docker", "push", image_name_with_new_tag
-      end
-    ensure
-      sh "docker", "logout"
-    end
-  end
-
-  desc 'Run interactive shell in the specified Docker container'
-  task :shell, [:bash_extra_args] do |_task, args|
-    run_args = (args[:bash_extra_args] || "").split(/\s+/)
-    workdir = "/work"
-    sh "docker", "run", "-it", "--rm", "--entrypoint=bash", "--volume=#{Dir.pwd}:#{workdir}", "--workdir=#{workdir}", *run_args, image_name
-  end
 end

--- a/tasks/docker/build.rake
+++ b/tasks/docker/build.rake
@@ -1,0 +1,9 @@
+require_relative "common"
+
+namespace :docker do
+  desc 'Run docker build'
+  task :build => 'dockerfile:generate' do
+    include DockerTaskCommon
+    sh "docker", "build", "--tag", image_name, "--file", "#{build_context}/Dockerfile", "."
+  end
+end

--- a/tasks/docker/cli_dummy.rb
+++ b/tasks/docker/cli_dummy.rb
@@ -1,0 +1,19 @@
+require 'minitest/mock'
+
+module Runners
+  class CLI
+    def initialize(**args)
+    end
+
+    def run
+      Open3.capture3('sleep 10')
+    end
+  end
+end
+
+mock = Minitest::Mock.new
+mock.expect(:called, nil)
+Bugsnag.stub :notify, nil do
+  mock.called
+end
+at_exit { mock.verify }

--- a/tasks/docker/common.rb
+++ b/tasks/docker/common.rb
@@ -1,0 +1,32 @@
+module DockerTaskCommon
+  def image_name(t = tag)
+    "sider/runner_#{analyzer}:#{t}"
+  end
+
+  def build_context
+    Pathname('images') / analyzer
+  end
+
+  def analyzer
+    key = 'ANALYZER'
+    ENV[key].tap do |value|
+      abort <<~MSG if value.nil? || value.empty?
+        Error: `#{key}` environment variable must be required. For example, run as follow:
+
+            $ #{key}=rubocop bundle exec rake docker:build
+      MSG
+    end
+  end
+
+  def tag
+    ENV.fetch('TAG') { 'dev' }
+  end
+
+  def docker_user
+    ENV.fetch('DOCKER_USER')
+  end
+
+  def docker_password
+    ENV.fetch('DOCKER_PASSWORD')
+  end
+end

--- a/tasks/docker/push.rake
+++ b/tasks/docker/push.rake
@@ -1,0 +1,19 @@
+require_relative "common"
+
+namespace :docker do
+  desc 'Run docker push'
+  task :push do
+    include DockerTaskCommon
+    sh "docker", "login", "--username", docker_user, "--password", docker_password
+    begin
+      sh "docker", "push", image_name
+      if ENV["TAG_LATEST"] == "true"
+        image_name_with_new_tag = image_name("latest")
+        sh "docker", "tag", image_name, image_name_with_new_tag
+        sh "docker", "push", image_name_with_new_tag
+      end
+    ensure
+      sh "docker", "logout"
+    end
+  end
+end

--- a/tasks/docker/shell.rake
+++ b/tasks/docker/shell.rake
@@ -1,0 +1,11 @@
+require_relative "common"
+
+namespace :docker do
+  desc 'Run interactive shell in the specified Docker container'
+  task :shell, [:bash_extra_args] do |_task, args|
+    include DockerTaskCommon
+    run_args = (args[:bash_extra_args] || "").split(/\s+/)
+    workdir = "/work"
+    sh "docker", "run", "-it", "--rm", "--entrypoint=bash", "--volume=#{Dir.pwd}:#{workdir}", "--workdir=#{workdir}", *run_args, image_name
+  end
+end

--- a/tasks/docker/smoke.rake
+++ b/tasks/docker/smoke.rake
@@ -1,0 +1,9 @@
+require_relative "common"
+
+namespace :docker do
+  desc 'Run smoke test on Docker'
+  task :smoke do
+    include DockerTaskCommon
+    sh "bin/runners_smoke", image_name, "test/smokes/#{analyzer}/expectations.rb"
+  end
+end

--- a/tasks/docker/timeout_test.rake
+++ b/tasks/docker/timeout_test.rake
@@ -11,7 +11,7 @@ namespace :docker do
     Dir.mktmpdir do |dir|
       FileUtils.cp_r('.', dir)
       Dir.chdir(dir) do
-        File.write('lib/runners/cli.rb', runners_cli_code)
+        File.write('lib/runners/cli.rb', Pathname(__dir__).join('cli_dummy.rb').read)
         Rake::Task['docker:build'].invoke
       end
     end
@@ -22,29 +22,5 @@ namespace :docker do
     sh "pgrep", "sleep" do |ok|
       abort "sleep(1) still remains! It's unexpected." if ok
     end
-  end
-
-  def runners_cli_code
-    <<~EOF
-      require 'minitest/mock'
-
-      module Runners
-        class CLI
-          def initialize(**args)
-          end
-
-          def run
-            Open3.capture3('sleep 10')
-          end
-        end
-      end
-
-      mock = Minitest::Mock.new
-      mock.expect(:called, nil)
-      Bugsnag.stub :notify, nil do
-        mock.called
-      end
-      at_exit { mock.verify }
-    EOF
   end
 end

--- a/tasks/dockerfile/generate.rake
+++ b/tasks/dockerfile/generate.rake
@@ -1,0 +1,35 @@
+def render_erb(file, analyzer: ENV.fetch('ANALYZER'))
+  locals = {
+    analyzer: analyzer,
+    chown: '${RUNNER_USER}:${RUNNER_GROUP}',
+  }
+
+  res = ERB.new(File.read(file), trim_mode: "<>").result_with_hash(locals)
+  "\n#{res.strip}\n" # Ensure to start with one newline and end with one newline
+end
+
+namespace :dockerfile do
+  desc 'Generate Dockerfile from a template'
+  task :generate do
+    Pathname.glob("images/*").filter(&:directory?).sort.each do |analyzer_dir|
+      analyzer = analyzer_dir.basename.to_path
+      backup_analyzer = ENV['ANALYZER']
+      ENV['ANALYZER'] = analyzer
+
+      content = <<~EOD
+        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
+        # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
+        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        #{render_erb(analyzer_dir / 'Dockerfile.erb', analyzer: analyzer).strip}
+      EOD
+      (analyzer_dir / 'Dockerfile').write(content)
+    ensure
+      if backup_analyzer
+        ENV['ANALYZER'] = backup_analyzer
+      else
+        ENV.delete 'ANALYZER'
+      end
+    end
+  end
+end

--- a/tasks/dockerfile/verify.rake
+++ b/tasks/dockerfile/verify.rake
@@ -1,0 +1,10 @@
+namespace :dockerfile do
+  desc 'Verify Dockerfile is committed'
+  task :verify do
+    sh 'git', 'diff', '--exit-code', 'images' do |ok|
+      unless ok
+        abort "\nError: Run `bundle exec rake dockerfile:generate` and include the changes in commit"
+      end
+    end
+  end
+end

--- a/tasks/dockerfile/verify_devon_rex.rake
+++ b/tasks/dockerfile/verify_devon_rex.rake
@@ -1,0 +1,11 @@
+namespace :dockerfile do
+  desc 'Verify the devon_rex image tag'
+  task :verify_devon_rex do
+    disallowed_tag = 'master'
+    sh 'git', 'grep', '--quiet', "/devon_rex_.+:#{disallowed_tag}", 'images/' do |found|
+      if found
+        abort "\nError: Disallow to release with the `#{disallowed_tag}` tag of the devon_rex images."
+      end
+    end
+  end
+end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring aims to simplify `Rakefile` by splitting the tasks into each `.rake` file.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
