### PR TITLE
Simplify requiring `digest`

### DIFF
--- a/lib/runners.rb
+++ b/lib/runners.rb
@@ -13,7 +13,7 @@ require "tempfile"
 require "set"
 require "forwardable"
 require "rexml/document"
-require "digest/sha2"
+require "digest"
 require 'retryable'
 require "aws-sdk-s3"
 require "bugsnag"


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change simplifies requiring the `digest` module. Only `Digest::SHA1` is used.

```console
$ git grep 'Digest::'
lib/runners/git_blame_info.rb:11:        new(commit: commit, original_line: Integer(original_line), final_line: Integer(final_line), line_hash: Digest::SHA1.hexdigest(content))
lib/runners/issue.rb:23:      @id = missing_id? ? Digest::SHA1.hexdigest(message) : id
lib/runners/processor/pmd_cpd.rb:131:      id = Digest::SHA1.hexdigest("#{path}#{location}") # In case multiple duplicates are found in a file, generate a hash from the file path and the location.
```

See <https://ruby-doc.org/stdlib-2.7.2/libdoc/digest/rdoc/digest/SHA1.html>.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
