### PR TITLE
Manage open3 via Bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'aws-sdk-s3'
 gem 'bugsnag'
 gem 'rexml', ">= 3.2", '< 4.0'
 gem 'git_diff_parser'
+gem 'open3'
 
 group :development, :test do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     minitest (5.14.2)
+    open3 (0.1.1)
     parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)
@@ -106,6 +107,7 @@ DEPENDENCIES
   jsonseq
   lefthook
   minitest
+  open3
   parallel
   rainbow
   rake


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

By managing gems via Bundler, we will be able to receive gem updates by Dependabot.

- https://rubygems.org/gems/open3
- https://github.com/ruby/open3
- https://github.com/ruby/open3/compare/v0.1.0...v0.1.1

Ruby 2.7.2 installs `open3` 0.1.0 by default:

```console
$ gem info open3

*** LOCAL GEMS ***

open3 (0.1.1, 0.1.0)
    Author: Yukihiro Matsumoto
    Homepage: https://github.com/ruby/open3
    Licenses: Ruby, BSD-2-Clause
    Installed at (0.1.1): /Users/masafumi.koba/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0
                 (0.1.0, default): /Users/masafumi.koba/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0

    Popen, but with stderr, too
```

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
