### PR TITLE
Manage psych via Bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'bugsnag'
 gem 'rexml', ">= 3.2", '< 4.0'
 gem 'git_diff_parser'
 gem 'open3'
+gem 'psych'
 
 group :development, :test do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,7 @@ GEM
     parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)
+    psych (3.2.1)
     rainbow (3.0.0)
     rake (13.0.3)
     rb-fsevent (0.10.4)
@@ -109,6 +110,7 @@ DEPENDENCIES
   minitest
   open3
   parallel
+  psych
   rainbow
   rake
   rbs


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- https://rubygems.org/gems/psych
- https://github.com/ruby/psych
- https://github.com/ruby/psych/compare/v3.1.0...v3.2.0

The psych default version in Ruby 2.7.2 is **3.1.0**.

Note that `Psych` is an alias for `YAML`.

> Link related issues or pull requests.

Similar to #1849

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
