### PR TITLE
Manage json via Bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'rexml', ">= 3.2", '< 4.0'
 gem 'git_diff_parser'
 gem 'open3'
 gem 'psych'
+gem 'json'
 
 group :development, :test do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
+    json (2.5.1)
     jsonseq (0.2.0)
     language_server-protocol (3.15.0.1)
     lefthook (0.7.2)
@@ -105,6 +106,7 @@ DEPENDENCIES
   bugsnag
   bundler (>= 1.12, < 3.0)
   git_diff_parser
+  json
   jsonseq
   lefthook
   minitest

--- a/test/harness_test.rb
+++ b/test/harness_test.rb
@@ -145,7 +145,7 @@ class HarnessTest < Minitest::Test
       assert_instance_of Results::Error, result
       assert_instance_of JSON::ParserError, result.exception
       assert_equal(
-        [{ trace: :error, message: "783: unexpected token at 'something wrong' (JSON::ParserError)" }],
+        [{ trace: :error, message: "809: unexpected token at 'something wrong' (JSON::ParserError)" }],
         trace_writer.writer.map { |entry| entry.slice(:trace, :message) },
       )
     end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- https://rubygems.org/gems/json
- https://github.com/flori/json
- https://github.com/flori/json/compare/v2.3.0...v2.5.1

The `json` default version in Ruby 2.7.2 is **2.3.0**.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
