### PR TITLE
Manage fileutils via Bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'git_diff_parser'
 gem 'open3'
 gem 'psych'
 gem 'json'
+gem 'fileutils'
 
 group :development, :test do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
       concurrent-ruby (~> 1.0)
     concurrent-ruby (1.1.7)
     ffi (1.13.1)
+    fileutils (1.5.0)
     git_diff_parser (3.2.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -105,6 +106,7 @@ DEPENDENCIES
   aws-sdk-s3
   bugsnag
   bundler (>= 1.12, < 3.0)
+  fileutils
   git_diff_parser
   json
   jsonseq


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- https://rubygems.org/gems/fileutils
- https://github.com/ruby/fileutils
- https://github.com/ruby/fileutils/compare/v1.4.1...v1.5.0

The `fileutils` default version in Ruby 2.7.2 is **1.4.1**.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
