### PR TITLE
Manage uri via Bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'open3'
 gem 'psych'
 gem 'json'
 gem 'fileutils'
+gem 'uri'
 
 group :development, :test do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
     unicode-display_width (1.7.0)
     unification_assertion (0.0.1)
       minitest (~> 5)
+    uri (0.10.1)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -124,6 +125,7 @@ DEPENDENCIES
   steep (= 0.37.0)
   strong_json
   unification_assertion
+  uri
 
 BUNDLED WITH
    2.2.1


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- https://rubygems.org/gems/uri
- https://github.com/ruby/uri
- https://github.com/ruby/uri/compare/v0.10.0...v0.10.1

The default version in Ruby 2.7.2 is **0.10.0**.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
