### PR TITLE
Manage forwardable via Bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'open3'
 gem 'psych'
 gem 'json'
 gem 'fileutils'
+gem 'forwardable'
 
 group :development, :test do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
     concurrent-ruby (1.1.7)
     ffi (1.13.1)
     fileutils (1.5.0)
+    forwardable (1.3.2)
     git_diff_parser (3.2.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -107,6 +108,7 @@ DEPENDENCIES
   bugsnag
   bundler (>= 1.12, < 3.0)
   fileutils
+  forwardable
   git_diff_parser
   json
   jsonseq


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- https://rubygems.org/gems/forwardable
- https://github.com/ruby/forwardable
- https://github.com/ruby/forwardable/compare/v1.3.1...v1.3.2

The default version in Ruby 2.7.2 is **1.3.1**.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
