### PR TITLE
Manage strscan via Bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'psych'
 gem 'json'
 gem 'fileutils'
 gem 'forwardable'
+gem 'strscan'
 
 group :development, :test do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       rbs (>= 0.20.0)
     strong_json (2.1.2)
+    strscan (3.0.0)
     thor (1.0.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -125,6 +126,7 @@ DEPENDENCIES
   rubocop
   steep (= 0.37.0)
   strong_json
+  strscan
   unification_assertion
 
 BUNDLED WITH


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- https://rubygems.org/gems/strscan
- https://github.com/ruby/strscan
- https://github.com/ruby/strscan/compare/v1.0.3...v3.0.0

The default version in Ruby 2.7.2 is **1.0.3**.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
