### PR TITLE
Downgrade `spec.required_ruby_version` for Dependabot

### DIFF
--- a/runners.gemspec
+++ b/runners.gemspec
@@ -10,7 +10,11 @@ Gem::Specification.new do |spec|
   spec.description   = "Sider Runners is a framework for analysis tools that run on Sider."
   spec.homepage      = "https://github.com/sider/runners"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new("2.7.2") # NOTE: It must be same as devon_rex and .ruby-version
+
+  # TODO: Dependabot does not support Ruby 2.7 yet.
+  #       See <https://github.com/dependabot/dependabot-core/issues/2910>.
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0", "<= 2.7.2")
+  # spec.required_ruby_version = Gem::Requirement.new("2.7.2") # NOTE: It must be same as devon_rex and .ruby-version
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

We cannot receive updates from Dependabot, so this change downgrades `spec.required_ruby_version` temporarily.
When Dependabot will support Ruby 2.7+, we should revert this change.

> Link related issues or pull requests.

See also <https://github.com/dependabot/dependabot-core/issues/2910>

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
