### PR TITLE
Bump devon_rex images from master to 2.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - **PMD CPD** Remove needless `CGI.unescape_html`[#1821](https://github.com/sider/runners/pull/1821)
 - Move `bin/runners` to `exe/runners` [#1833](https://github.com/sider/runners/pull/1833)
 - **RuboCop** Add supported gems [#1834](https://github.com/sider/runners/pull/1834)
-- Bump devon_rex images from 2.28.0 to master [#1859](https://github.com/sider/runners/pull/1859)
+- Bump devon_rex images from 2.28.0 to 2.29.0 [#1859](https://github.com/sider/runners/pull/1859) [#1864](https://github.com/sider/runners/pull/1864)
 - Gemification [#1858](https://github.com/sider/runners/pull/1858)
 
 ## 0.39.3

--- a/images/Dockerfile.java.erb
+++ b/images/Dockerfile.java.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_java:master
+FROM sider/devon_rex_java:2.29.0
 
 # Install dependencies via Gradle
 ARG DEPS_DIR=${RUNNER_USER_HOME}/dependencies

--- a/images/brakeman/Dockerfile
+++ b/images/brakeman/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/brakeman/Dockerfile.erb
+++ b/images/brakeman/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>

--- a/images/checkstyle/Dockerfile
+++ b/images/checkstyle/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:master
+FROM sider/devon_rex_java:2.29.0
 
 # Install dependencies via Gradle
 ARG DEPS_DIR=${RUNNER_USER_HOME}/dependencies

--- a/images/clang_tidy/Dockerfile
+++ b/images/clang_tidy/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_base:master
+FROM sider/devon_rex_base:2.29.0
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/clang_tidy/packages.list ${RUNNER_USER_HOME}/
 

--- a/images/clang_tidy/Dockerfile.erb
+++ b/images/clang_tidy/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_base:master
+FROM sider/devon_rex_base:2.29.0
 
 COPY --chown=<%= chown %> images/clang_tidy/packages.list ${RUNNER_USER_HOME}/
 

--- a/images/code_sniffer/Dockerfile
+++ b/images/code_sniffer/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_php:master
+FROM sider/devon_rex_php:2.29.0
 
 
 # Install PHP packages via Composer

--- a/images/code_sniffer/Dockerfile.erb
+++ b/images/code_sniffer/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_php:master
+FROM sider/devon_rex_php:2.29.0
 
 <%= render_erb 'images/Dockerfile.php.erb' %>
 

--- a/images/coffeelint/Dockerfile
+++ b/images/coffeelint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:master
+FROM sider/devon_rex_npm:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/coffeelint/Dockerfile.erb
+++ b/images/coffeelint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:master
+FROM sider/devon_rex_npm:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.npm.erb' %>

--- a/images/cppcheck/Dockerfile
+++ b/images/cppcheck/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_python:master
+FROM sider/devon_rex_python:2.29.0
 
 # NOTE: The reason using Python image: when setting `MATCHCOMPILER=yes`, Python is used to optimise cppcheck.
 #

--- a/images/cppcheck/Dockerfile.erb
+++ b/images/cppcheck/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_python:master
+FROM sider/devon_rex_python:2.29.0
 
 # NOTE: The reason using Python image: when setting `MATCHCOMPILER=yes`, Python is used to optimise cppcheck.
 #

--- a/images/cpplint/Dockerfile
+++ b/images/cpplint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_python:master
+FROM sider/devon_rex_python:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/cpplint/Dockerfile.erb
+++ b/images/cpplint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_python:master
+FROM sider/devon_rex_python:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.python.erb' %>

--- a/images/detekt/Dockerfile
+++ b/images/detekt/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:master
+FROM sider/devon_rex_java:2.29.0
 
 # Install dependencies via Gradle
 ARG DEPS_DIR=${RUNNER_USER_HOME}/dependencies

--- a/images/eslint/Dockerfile
+++ b/images/eslint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:master
+FROM sider/devon_rex_npm:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/eslint/Dockerfile.erb
+++ b/images/eslint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:master
+FROM sider/devon_rex_npm:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.npm.erb' %>

--- a/images/flake8/Dockerfile
+++ b/images/flake8/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_python:master
+FROM sider/devon_rex_python:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/flake8/Dockerfile.erb
+++ b/images/flake8/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_python:master
+FROM sider/devon_rex_python:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.python.erb' %>

--- a/images/fxcop/Dockerfile
+++ b/images/fxcop/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_dotnet:master
+FROM sider/devon_rex_dotnet:2.29.0
 
 ENV FXCOP_VERSION=3.3.1
 

--- a/images/fxcop/Dockerfile.erb
+++ b/images/fxcop/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_dotnet:master
+FROM sider/devon_rex_dotnet:2.29.0
 
 ENV FXCOP_VERSION=3.3.1
 

--- a/images/golangci_lint/Dockerfile
+++ b/images/golangci_lint/Dockerfile
@@ -4,7 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM golangci/golangci-lint:v1.33.0 as golangci-lint
 
-FROM sider/devon_rex_go:master
+FROM sider/devon_rex_go:2.29.0
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} --from=golangci-lint /usr/bin/golangci-lint ${RUNNER_USER_HOME}/bin/
 

--- a/images/golangci_lint/Dockerfile.erb
+++ b/images/golangci_lint/Dockerfile.erb
@@ -1,6 +1,6 @@
 FROM golangci/golangci-lint:v1.33.0 as golangci-lint
 
-FROM sider/devon_rex_go:master
+FROM sider/devon_rex_go:2.29.0
 
 COPY --chown=<%= chown %> --from=golangci-lint /usr/bin/golangci-lint ${RUNNER_USER_HOME}/bin/
 

--- a/images/goodcheck/Dockerfile
+++ b/images/goodcheck/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/goodcheck/Dockerfile.erb
+++ b/images/goodcheck/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>

--- a/images/hadolint/Dockerfile
+++ b/images/hadolint/Dockerfile
@@ -4,7 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM hadolint/hadolint:v1.19.0-debian as hadolint
 
-FROM sider/devon_rex_base:master
+FROM sider/devon_rex_base:2.29.0
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} --from=hadolint /bin/hadolint ${RUNNER_USER_HOME}/bin/
 

--- a/images/hadolint/Dockerfile.erb
+++ b/images/hadolint/Dockerfile.erb
@@ -1,6 +1,6 @@
 FROM hadolint/hadolint:v1.19.0-debian as hadolint
 
-FROM sider/devon_rex_base:master
+FROM sider/devon_rex_base:2.29.0
 
 COPY --chown=<%= chown %> --from=hadolint /bin/hadolint ${RUNNER_USER_HOME}/bin/
 

--- a/images/haml_lint/Dockerfile
+++ b/images/haml_lint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/haml_lint/Dockerfile.erb
+++ b/images/haml_lint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>

--- a/images/javasee/Dockerfile
+++ b/images/javasee/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:master
+FROM sider/devon_rex_java:2.29.0
 
 ARG JAVASEE_VERSION=0.2.0
 

--- a/images/javasee/Dockerfile.erb
+++ b/images/javasee/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_java:master
+FROM sider/devon_rex_java:2.29.0
 
 ARG JAVASEE_VERSION=0.2.0
 

--- a/images/jshint/Dockerfile
+++ b/images/jshint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:master
+FROM sider/devon_rex_npm:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/jshint/Dockerfile.erb
+++ b/images/jshint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:master
+FROM sider/devon_rex_npm:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.npm.erb' %>

--- a/images/ktlint/Dockerfile
+++ b/images/ktlint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:master
+FROM sider/devon_rex_java:2.29.0
 
 # Install dependencies via Gradle
 ARG DEPS_DIR=${RUNNER_USER_HOME}/dependencies

--- a/images/languagetool/Dockerfile
+++ b/images/languagetool/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:master
+FROM sider/devon_rex_java:2.29.0
 
 ARG LANGUAGETOOL_VERSION=5.1
 

--- a/images/languagetool/Dockerfile.erb
+++ b/images/languagetool/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_java:master
+FROM sider/devon_rex_java:2.29.0
 
 ARG LANGUAGETOOL_VERSION=5.1
 

--- a/images/misspell/Dockerfile
+++ b/images/misspell/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_base:master
+FROM sider/devon_rex_base:2.29.0
 
 ARG MISSPELL_VERSION=0.3.4
 

--- a/images/misspell/Dockerfile.erb
+++ b/images/misspell/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_base:master
+FROM sider/devon_rex_base:2.29.0
 
 ARG MISSPELL_VERSION=0.3.4
 

--- a/images/phinder/Dockerfile
+++ b/images/phinder/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_php:master
+FROM sider/devon_rex_php:2.29.0
 
 
 # Install PHP packages via Composer

--- a/images/phinder/Dockerfile.erb
+++ b/images/phinder/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_php:master
+FROM sider/devon_rex_php:2.29.0
 
 <%= render_erb 'images/Dockerfile.php.erb' %>
 <%= render_erb 'images/Dockerfile.base.erb' %>

--- a/images/phpmd/Dockerfile
+++ b/images/phpmd/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_php:master
+FROM sider/devon_rex_php:2.29.0
 
 
 # Install PHP packages via Composer

--- a/images/phpmd/Dockerfile.erb
+++ b/images/phpmd/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_php:master
+FROM sider/devon_rex_php:2.29.0
 
 <%= render_erb 'images/Dockerfile.php.erb' %>
 <%= render_erb 'images/Dockerfile.base.erb' %>

--- a/images/pmd_cpd/Dockerfile
+++ b/images/pmd_cpd/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:master
+FROM sider/devon_rex_java:2.29.0
 
 # Install dependencies via Gradle
 ARG DEPS_DIR=${RUNNER_USER_HOME}/dependencies

--- a/images/pmd_java/Dockerfile
+++ b/images/pmd_java/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:master
+FROM sider/devon_rex_java:2.29.0
 
 # Install dependencies via Gradle
 ARG DEPS_DIR=${RUNNER_USER_HOME}/dependencies

--- a/images/pylint/Dockerfile
+++ b/images/pylint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_python:master
+FROM sider/devon_rex_python:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/pylint/Dockerfile.erb
+++ b/images/pylint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_python:master
+FROM sider/devon_rex_python:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.python.erb' %>

--- a/images/querly/Dockerfile
+++ b/images/querly/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/querly/Dockerfile.erb
+++ b/images/querly/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>

--- a/images/rails_best_practices/Dockerfile
+++ b/images/rails_best_practices/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/rails_best_practices/Dockerfile.erb
+++ b/images/rails_best_practices/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>

--- a/images/reek/Dockerfile
+++ b/images/reek/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/reek/Dockerfile.erb
+++ b/images/reek/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>

--- a/images/remark_lint/Dockerfile
+++ b/images/remark_lint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:master
+FROM sider/devon_rex_npm:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/remark_lint/Dockerfile.erb
+++ b/images/remark_lint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:master
+FROM sider/devon_rex_npm:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.npm.erb' %>

--- a/images/rubocop/Dockerfile
+++ b/images/rubocop/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/rubocop/Dockerfile.erb
+++ b/images/rubocop/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>

--- a/images/scss_lint/Dockerfile
+++ b/images/scss_lint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/scss_lint/Dockerfile.erb
+++ b/images/scss_lint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:master
+FROM sider/devon_rex_ruby:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>

--- a/images/shellcheck/Dockerfile
+++ b/images/shellcheck/Dockerfile
@@ -4,7 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM koalaman/shellcheck:v0.7.1 as shellcheck
 
-FROM sider/devon_rex_base:master
+FROM sider/devon_rex_base:2.29.0
 
 USER root
 RUN apt-get update && \

--- a/images/shellcheck/Dockerfile.erb
+++ b/images/shellcheck/Dockerfile.erb
@@ -1,6 +1,6 @@
 FROM koalaman/shellcheck:v0.7.1 as shellcheck
 
-FROM sider/devon_rex_base:master
+FROM sider/devon_rex_base:2.29.0
 
 USER root
 RUN apt-get update && \

--- a/images/stylelint/Dockerfile
+++ b/images/stylelint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:master
+FROM sider/devon_rex_npm:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/stylelint/Dockerfile.erb
+++ b/images/stylelint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:master
+FROM sider/devon_rex_npm:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.npm.erb' %>

--- a/images/swiftlint/Dockerfile
+++ b/images/swiftlint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_swift:master
+FROM sider/devon_rex_swift:2.29.0
 
 ARG SWIFTLINT_VERSION=0.41.0
 

--- a/images/swiftlint/Dockerfile.erb
+++ b/images/swiftlint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_swift:master
+FROM sider/devon_rex_swift:2.29.0
 
 ARG SWIFTLINT_VERSION=0.41.0
 

--- a/images/tslint/Dockerfile
+++ b/images/tslint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:master
+FROM sider/devon_rex_npm:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/tslint/Dockerfile.erb
+++ b/images/tslint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:master
+FROM sider/devon_rex_npm:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.npm.erb' %>

--- a/images/tyscan/Dockerfile
+++ b/images/tyscan/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:master
+FROM sider/devon_rex_npm:2.29.0
 
 
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners

--- a/images/tyscan/Dockerfile.erb
+++ b/images/tyscan/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:master
+FROM sider/devon_rex_npm:2.29.0
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.npm.erb' %>


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Via:
```
$ bundle exec rake dockerfile:bump_devon_rex'[2.29.0]'
```

See also:
- https://github.com/sider/devon_rex/releases/tag/2.29.0
- https://github.com/sider/devon_rex/blob/2.29.0/CHANGELOG.md

> Link related issues or pull requests.

None.

> Check the following.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
