### PR TITLE
Unify `#mktmpdir` and `#mktmpdir_as_pathname` in `Tmpdir` module

### DIFF
--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -122,7 +122,7 @@ module Runners
       saved = [".git"].filter_map do |dir|
         src = working_dir / dir
         if src.directory?
-          dest = mktmpdir_as_pathname / dir
+          dest = mktmpdir / dir
           src.rename(dest)
           trace_writer.message "Move #{src} to #{dest}"
           [src, dest]

--- a/lib/runners/tmpdir.rb
+++ b/lib/runners/tmpdir.rb
@@ -1,14 +1,13 @@
 module Runners
   module Tmpdir
     def mktmpdir
-      Dir.mktmpdir do |dir|
-        yield Pathname(dir)
+      if block_given?
+        Dir.mktmpdir do |dir|
+          yield Pathname(dir)
+        end
+      else
+        Pathname(Dir.mktmpdir)
       end
-    end
-
-    # TODO: We should unify `#mktmpdir` and `mktmpdir_as_pathname` but Steep checking fails...
-    def mktmpdir_as_pathname
-      Pathname(Dir.mktmpdir)
     end
   end
 end

--- a/sig/runners/tmpdir.rbs
+++ b/sig/runners/tmpdir.rbs
@@ -1,6 +1,6 @@
 module Runners
   module Tmpdir
     def mktmpdir: [X] () { (Pathname) -> X } -> X
-    def mktmpdir_as_pathname: () -> Pathname
+                | () -> Pathname
   end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Steep now checks the `Tmpdir` module, so this change refactors the module for simplicity.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
