### PR TITLE
Prevent Git hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Bump devon_rex images from 2.28.0 to 2.30.0 [#1859](https://github.com/sider/runners/pull/1859) [#1864](https://github.com/sider/runners/pull/1864) [#1875](https://github.com/sider/runners/pull/1875)
 - Gemification [#1858](https://github.com/sider/runners/pull/1858)
 - Use always Yarn v1 even if `.yarnrc` exists [#1876](https://github.com/sider/runners/pull/1876)
+- Prevent Git hooks [#1879](https://github.com/sider/runners/pull/1879)
 
 ## 0.39.3
 

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -25,6 +25,7 @@ module Runners
       shell.capture3!("git", "config", "gc.auto", "0")
       shell.capture3!("git", "config", "advice.detachedHead", "false")
       shell.capture3!("git", "config", "core.quotePath", "false")
+      shell.capture3!("git", "config", "core.hooksPath", mktmpdir.to_path) # NOTE: Prevent evil hooks from being executed.
       shell.capture3!("git", "remote", "add", "origin", remote_url)
 
       begin

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -23,12 +23,23 @@ class WorkspaceGitTest < Minitest::Test
 
   def test_prepare_head_source
     with_workspace do |workspace|
+      dest = workspace.working_dir
+
+      (dest / ".git" / "hooks").mkpath
+      (dest / ".git" / "hooks" / "post-checkout").tap do |hook|
+        hook.write <<~EOF
+          #!/usr/bin/env ruby
+          raise "Error!"
+        EOF
+        hook.chmod 0777
+      end
+
       workspace.prepare_head_source
 
-      dest = workspace.working_dir
       refute_empty dest.children
       assert_path_exists dest / "README.md"
       assert_path_exists dest / ".git"
+      assert_path_exists dest / ".git" / "hooks" / "post-checkout"
     end
   end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Users may be able to execute any scripts via GitHooks. This change aims to prevent it.

Git 2.29 has added `core.hooksPath`:

- https://git-scm.com/docs/git-config#Documentation/git-config.txt-corehooksPath
- https://github.com/sider/devon_rex/blob/2.30.0/CHANGELOG.md#2300

> Link related issues or pull requests.

None.

> Check the following.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
