### PR TITLE
[Flake8] Add smoke test case for VCS URL

### DIFF
--- a/test/smokes/flake8/expectations.rb
+++ b/test/smokes/flake8/expectations.rb
@@ -149,6 +149,17 @@ s.add_test(
       git_blame_info: {
         commit: :_, line_hash: "7685a618e081e273bac47658d6b0e4dbf76597a6", original_line: 2, final_line: 2
       }
+    },
+    {
+      path: "foo2.py",
+      location: { start_line: 3, start_column: 6 },
+      id: "TAE002",
+      message: "too complex annotation (4 > 3)",
+      links: [],
+      object: nil,
+      git_blame_info: {
+        commit: :_, line_hash: "de436b94e2ba3f59e974ac43c742803eede574cf", original_line: 3, final_line: 3
+      }
     }
   ],
   analyzer: { name: "Flake8", version: default_version }

--- a/test/smokes/flake8/with_plugins/foo2.py
+++ b/test/smokes/flake8/with_plugins/foo2.py
@@ -1,0 +1,3 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+foo: Tuple[str, str, str, int, List, Any, List[int], Optional[Dict[str, int]]] = tuple()

--- a/test/smokes/flake8/with_plugins/sideci.yml
+++ b/test/smokes/flake8/with_plugins/sideci.yml
@@ -2,3 +2,4 @@ linter:
   flake8:
     plugins:
       - flake8-builtins==1.4.1
+      - git+https://github.com/best-doctor/flake8-annotations-complexity.git@b678cafb3ac7471163fad5b11eb1bdc4880c5c74


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Users can specify any VCS URL to `linter.flake8.plugins`.
See the `pip` document: <https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support>

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
