### PR TITLE
Commit `Gemfile.lock` on `rake release`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.40.0...HEAD)
 
+- Commit `Gemfile.lock` on `rake release` [#1898](https://github.com/sider/runners/pull/1898)
+
 ## 0.40.0
 
 [Full diff](https://github.com/sider/runners/compare/0.39.3...0.40.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    runners (0.39.3)
+    runners (0.40.0)
       aws-sdk-s3 (>= 1.87)
       bugsnag (>= 6.18)
       bundler (= 2.2.3)

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ task default: ["steep:check", :test]
 ENV["DOCKER_BUILDKIT"] = "1"
 
 Aufgaben::Release.new(:release, depends: ["dockerfile:verify_devon_rex"]) do |t|
-  t.files = ["lib/runners/version.rb"]
+  t.files = ["lib/runners/version.rb", "Gemfile.lock"]
 end
 
 Aufgaben::Bump::Ruby.new do |t|


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

By the effect of *gemification*, `Gemfile.lock` is updated on `rake release`.
This change aims to support the file.

> Link related issues or pull requests.

None.

> Check the following.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
