### PR TITLE
[ESLint] Add `eslint-config-react-app` as pre-installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.40.1...HEAD)
 
+- **ESLint** Add `eslint-config-react-app` as pre-installed [#1902](https://github.com/sider/runners/pull/1902)
+
 ## 0.40.1
 
 [Full diff](https://github.com/sider/runners/compare/0.40.0...0.40.1)

--- a/images/eslint/package.json
+++ b/images/eslint/package.json
@@ -2,9 +2,11 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "4.11.1",
     "@typescript-eslint/parser": "4.11.1",
+    "babel-eslint": "10.1.0",
     "eslint": "7.15.0",
     "eslint-config-airbnb": "18.2.1",
     "eslint-config-prettier": "7.1.0",
+    "eslint-config-react-app": "6.0.0",
     "eslint-plugin-flowtype": "5.2.0",
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jest": "24.1.3",


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The `eslint-config-react-app` package is popular and used by Create React App.

- https://www.npmjs.com/package/eslint-config-react-app
- https://github.com/facebook/create-react-app/tree/v4.0.1/packages/eslint-config-react-app

NOTE: `babel-eslint` is a peer dependency of `eslint-config-react-app`:

```console
$ npm v eslint-config-react-app peerDependencies | grep babel-eslint
  'babel-eslint': '^10.0.0',
```

> Link related issues or pull requests.

None.

> Check the following.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
