### PR TITLE
[Flake 8] add more debug code

### DIFF
--- a/lib/runners/processor/flake8.rb
+++ b/lib/runners/processor/flake8.rb
@@ -35,17 +35,17 @@ module Runners
     end
 
     def analyze(changes)
-      capture3!(
+      # modify output for debugging. Revert before release.
+      stdout, _ = capture3!(
         analyzer_bin,
         "-vv", # This is a debug code. Remove before release.
         "--exit-zero",
-        "--output-file", report_file,
         "--format", OUTPUT_FORMAT,
         "--append-config", IGNORED_CONFIG_PATH,
         *(config_linter[:config]&.then { |c| ["--config", c] }),
         *Array(config_linter[:target] || DEFAULT_TARGET),
       )
-      output = read_report_file
+      output = stdout
 
       Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
         next if output.empty?


### PR DESCRIPTION
add several debug code for an investigation for an issue.

We've already added debug code in #1899. But it is useless in a time-out situation because the runner don't output `result_file` in the situation. This commit force to output debug log to `stderr` trace.

