### PR TITLE
Refactor `Runners::Config` class

### DIFF
--- a/lib/runners/config.rb
+++ b/lib/runners/config.rb
@@ -15,10 +15,19 @@ module Runners
     CONFIG_FILE_NAME = "sider.yml".freeze
     OLD_CONFIG_FILE_NAME = "sideci.yml".freeze
 
-    attr_reader :working_dir, :raw_content, :content
+    def self.load_from_dir(dir)
+      file = [
+        dir / CONFIG_FILE_NAME,
+        dir / OLD_CONFIG_FILE_NAME,
+      ].find(&:file?)
 
-    def initialize(working_dir)
-      @working_dir = working_dir
+      new(file)
+    end
+
+    attr_reader :path, :raw_content, :content
+
+    def initialize(path)
+      @path = path
       @raw_content = path&.read
       @content = check_schema(parse_yaml).freeze
     end
@@ -28,7 +37,7 @@ module Runners
     end
 
     def path_name
-      path&.basename&.to_s || CONFIG_FILE_NAME
+      path&.basename&.to_path || CONFIG_FILE_NAME
     end
 
     def path_exist?
@@ -48,14 +57,6 @@ module Runners
     end
 
     private
-
-    def path
-      return @path if defined?(@path)
-
-      @path ||= [working_dir / CONFIG_FILE_NAME, working_dir / OLD_CONFIG_FILE_NAME].find do |pathname|
-        pathname.file?
-      end
-    end
 
     def parse_yaml
       raw_content&.yield_self { |s| YAML.safe_load(s, symbolize_names: true) }

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -33,7 +33,7 @@ module Runners
       ensure_result do
         workspace = Workspace.prepare(options: options, working_dir: working_dir, trace_writer: trace_writer)
         workspace.open do |git_ssh_path, changes|
-          @config = conf = Config.new(workspace.working_dir)
+          @config = conf = Config.load_from_dir(workspace.working_dir)
 
           unless conf.ignore_patterns.empty?
             trace_writer.message "Deleting ignored files..." do

--- a/sig/runners/config.rbs
+++ b/sig/runners/config.rbs
@@ -15,11 +15,13 @@ module Runners
     CONFIG_FILE_NAME: String
     OLD_CONFIG_FILE_NAME: String
 
-    attr_reader working_dir: Pathname
+    def self.load_from_dir: (Pathname) -> instance
+
+    attr_reader path: Pathname?
     attr_reader raw_content: String?
     attr_reader content: Hash[Symbol, untyped]
 
-    def initialize: (Pathname) -> void
+    def initialize: (Pathname?) -> void
 
     def raw_content!: () -> String
 
@@ -34,8 +36,6 @@ module Runners
     def linter?: (Symbol | String) -> bool
 
     private
-
-    def path: () -> Pathname?
 
     def parse_yaml: () -> untyped
 

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -3,27 +3,37 @@ require "test_helper"
 class ConfigTest < Minitest::Test
   include TestHelper
 
-  def test_content_without_sider_yml
-    mktmpdir do |path|
-      assert_equal({}, Runners::Config.new(path).content)
+  CONFIG_FILE_NAME = Runners::Config::CONFIG_FILE_NAME
+  OLD_CONFIG_FILE_NAME = Runners::Config::OLD_CONFIG_FILE_NAME
+
+  def test_file_priority
+    mktmpdir do |dir|
+      (dir / CONFIG_FILE_NAME).write("")
+      (dir / OLD_CONFIG_FILE_NAME).write("")
+      assert_equal CONFIG_FILE_NAME, Runners::Config.load_from_dir(dir).path_name
     end
   end
 
-  def test_content_with_empty_sider_yml
-    mktmpdir do |path|
-      (path / "sider.yml").write("---")
-      assert_equal({}, Runners::Config.new(path).content)
-    end
+  def test_content_without_sider_yml
+    assert_equal({}, Runners::Config.new(nil).content)
+  end
 
-    mktmpdir do |path|
-      (path / "sider.yml").write("")
-      assert_equal({}, Runners::Config.new(path).content)
+  def test_content_with_empty_sider_yml
+    mktmpdir do |dir|
+      file = dir / CONFIG_FILE_NAME
+
+      file.write("---")
+      assert_equal({}, Runners::Config.new(file).content)
+
+      file.write("")
+      assert_equal({}, Runners::Config.new(file).content)
     end
   end
 
   def test_content_with_linter_section
-    mktmpdir do |path|
-      (path / "sider.yml").write(<<~YAML)
+    mktmpdir do |dir|
+      file = dir / CONFIG_FILE_NAME
+      file.write <<~YAML
         ---
         linter:
           eslint:
@@ -95,35 +105,37 @@ class ConfigTest < Minitest::Test
           ignore: nil,
           branches: nil,
         },
-        Runners::Config.new(path).content,
+        Runners::Config.new(file).content,
       )
     end
   end
 
   def test_content_with_unknown_linter
-    mktmpdir do |path|
+    mktmpdir do |dir|
       yaml = <<~YAML
         ---
         linter:
           unknown_linter:
             config: abc
       YAML
-      (path / "sider.yml").write(yaml)
+      file = (dir / CONFIG_FILE_NAME).tap { _1.write(yaml) }
       exn = assert_raises Runners::Config::InvalidConfiguration do
-        Runners::Config.new(path)
+        Runners::Config.new(file)
       end
       assert_equal "The attribute `linter.unknown_linter` in your `sider.yml` is unsupported. Please fix and retry.", exn.message
       assert_equal yaml, exn.raw_content
     end
+  end
 
-    mktmpdir do |path|
+  def test_content_with_invalid_type_of_linter
+    mktmpdir do |dir|
       yaml = <<~YAML
         ---
         linter: []
       YAML
-      (path / "sider.yml").write(yaml)
+      file = (dir / CONFIG_FILE_NAME).tap { _1.write(yaml) }
       exn = assert_raises Runners::Config::InvalidConfiguration do
-        Runners::Config.new(path)
+        Runners::Config.new(file)
       end
       assert_equal "The value of the attribute `linter` in your `sider.yml` is invalid. Please fix and retry.", exn.message
       assert_equal yaml, exn.raw_content
@@ -131,88 +143,76 @@ class ConfigTest < Minitest::Test
   end
 
   def test_content_with_ignore_section
-    mktmpdir do |path|
-      (path / "sider.yml").write(<<~YAML)
+    mktmpdir do |dir|
+      file = (dir / CONFIG_FILE_NAME).tap { _1.write <<~YAML }
         ---
         ignore:
           - ".pdf"
           - ".mp4"
           - "images/**"
       YAML
-      assert_equal({ linter: nil, ignore: %w[.pdf .mp4 images/**], branches: nil }, Runners::Config.new(path).content)
+      assert_equal({ linter: nil, ignore: %w[.pdf .mp4 images/**], branches: nil },
+                   Runners::Config.new(file).content)
     end
   end
 
   def test_content_with_branches_section
-    mktmpdir do |path|
-      (path / "sider.yml").write(<<~YAML)
+    mktmpdir do |dir|
+      file = (dir / CONFIG_FILE_NAME).tap { _1.write <<~YAML }
         ---
         branches:
           exclude:
             - master
             - /^release-.*$/
       YAML
-      assert_equal({ linter: nil, ignore: nil, branches: { exclude: %w[master /^release-.*$/] } }, Runners::Config.new(path).content)
+      assert_equal({ linter: nil, ignore: nil, branches: { exclude: %w[master /^release-.*$/] } },
+                   Runners::Config.new(file).content)
     end
   end
 
   def test_content_with_broken_yaml
-    mktmpdir do |path|
-      (path / "sider.yml").write(<<~YAML)
-        @
-      YAML
+    mktmpdir do |dir|
+      file = (dir / CONFIG_FILE_NAME).tap { _1.write "@" }
       exn = assert_raises Runners::Config::BrokenYAML do
-        Runners::Config.new(path)
+        Runners::Config.new(file)
       end
       assert_equal "Your `sider.yml` is broken at line 1 and column 1. Please fix and retry.", exn.message
     end
   end
 
   def test_path_name
-    mktmpdir do |path|
-      assert_equal "sider.yml", Runners::Config.new(path).path_name
-    end
+    mktmpdir do |dir|
+      assert_equal CONFIG_FILE_NAME, Runners::Config.new(nil).path_name
 
-    mktmpdir do |path|
-      (path / "sider.yml").write("")
-      assert_equal "sider.yml", Runners::Config.new(path).path_name
-    end
+      file_1 = (dir / CONFIG_FILE_NAME).tap { _1.write "" }
+      assert_equal CONFIG_FILE_NAME, Runners::Config.new(file_1).path_name
 
-    mktmpdir do |path|
-      (path / "sideci.yml").write("")
-      assert_equal "sideci.yml", Runners::Config.new(path).path_name
-    end
+      file_1.delete
 
-    mktmpdir do |path|
-      (path / "sider.yml").write("")
-      (path / "sideci.yml").write("")
-      assert_equal "sider.yml", Runners::Config.new(path).path_name
+      file_2 = (dir / OLD_CONFIG_FILE_NAME).tap { _1.write "" }
+      assert_equal OLD_CONFIG_FILE_NAME, Runners::Config.new(file_2).path_name
     end
   end
 
   def test_ignore_patterns
-    mktmpdir do |path|
-      assert_equal [], Runners::Config.new(path).ignore_patterns
-    end
+    mktmpdir do |dir|
+      assert_equal [], Runners::Config.new(nil).ignore_patterns
 
-    mktmpdir do |path|
-      (path / "sider.yml").write("ignore: abc")
-      assert_equal %w[abc], Runners::Config.new(path).ignore_patterns
-    end
+      file = (dir / CONFIG_FILE_NAME).tap { _1.write "ignore: abc" }
+      assert_equal %w[abc], Runners::Config.new(file).ignore_patterns
 
-    mktmpdir do |path|
-      (path / "sider.yml").write(<<~YAML)
+      file.write <<~YAML
         ignore:
           - "*.mp4"
           - docs/**/*.pdf
       YAML
-      assert_equal %w[*.mp4 docs/**/*.pdf], Runners::Config.new(path).ignore_patterns
+      assert_equal %w[*.mp4 docs/**/*.pdf], Runners::Config.new(file).ignore_patterns
     end
   end
 
   def test_linter
-    mktmpdir do |path|
-      (path / "sider.yml").write(<<~YAML)
+    mktmpdir do |dir|
+      file = (dir / CONFIG_FILE_NAME).tap { _1.write <<~YAML }
         linter:
           eslint:
             ext: .js
@@ -230,35 +230,35 @@ class ConfigTest < Minitest::Test
         global: nil,
         quiet: nil,
         options: nil,
-      }, Runners::Config.new(path).linter("eslint"))
+      }, Runners::Config.new(file).linter("eslint"))
     end
   end
 
   def test_linter_default
-    mktmpdir do |path|
-      (path / "sider.yml").write("")
-      assert_equal({}, Runners::Config.new(path).linter("eslint"))
+    mktmpdir do |dir|
+      file  = (dir / CONFIG_FILE_NAME).tap { _1.write "" }
+      assert_equal({}, Runners::Config.new(file).linter("eslint"))
     end
   end
 
   def test_linter?
-    mktmpdir do |path|
-      (path / "sider.yml").write(<<~YAML)
+    mktmpdir do |dir|
+      file = (dir / CONFIG_FILE_NAME).tap { _1.write <<~YAML }
         linter:
           eslint: { root_dir: "src" }
       YAML
-      config = Runners::Config.new(path)
+      config = Runners::Config.new(file)
       assert config.linter?("eslint")
       refute config.linter?("foo")
 
-      (path / "sider.yml").write("")
-      refute Runners::Config.new(path).linter?("foo")
+      file.write ""
+      refute Runners::Config.new(file).linter?("foo")
     end
   end
 
   def test_removed_go_tools_do_not_break
-    mktmpdir do |path|
-      (path / "sider.yml").write(<<~YAML)
+    mktmpdir do |dir|
+      file = (dir / CONFIG_FILE_NAME).tap { _1.write <<~YAML }
         linter:
           golint:
             root_dir: src/
@@ -268,7 +268,7 @@ class ConfigTest < Minitest::Test
             root_dir: module/
             import_path: foo
       YAML
-      config = Runners::Config.new(path)
+      config = Runners::Config.new(file)
       assert_equal({ root_dir: "src/" }, config.linter("golint"))
       assert_equal({ root_dir: "lib/" }, config.linter("go_vet"))
       assert_equal({ root_dir: "module/", import_path: "foo" }, config.linter("gometalinter"))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,10 +53,11 @@ module TestHelper
     end
   end
 
-  def config(yaml = nil)
-    mktmpdir do |path|
-      (path / 'sider.yml').write(yaml) if yaml
-      Runners::Config.new(path)
+  def config(yaml = "")
+    mktmpdir do |dir|
+      file = dir / Runners::Config::CONFIG_FILE_NAME
+      file.write(yaml)
+      Runners::Config.new(file)
     end
   end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring does the following:

- remove the `#working_dir` attribute
- simplify the `#path` method

This allows us to test the class easily.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
