### PR TITLE
Bump steep from 0.37.0 to a227bcc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 group :development do
   gem 'rbs', require: false
-  gem 'steep', '= 0.37.0', require: false # TODO: https://github.com/soutaro/steep/issues/272
+  gem 'steep', require: false
   gem 'aufgaben', git: 'https://github.com/ybiquitous/aufgaben.git', tag: '0.6.0', require: false
   gem 'lefthook', require: false
   gem 'rubocop', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 group :development do
   gem 'rbs', require: false
-  gem 'steep', require: false
+  gem 'steep', require: false, git: 'https://github.com/soutaro/steep.git'
   gem 'aufgaben', git: 'https://github.com/ybiquitous/aufgaben.git', tag: '0.6.0', require: false
   gem 'lefthook', require: false
   gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,17 @@
 GIT
+  remote: https://github.com/soutaro/steep.git
+  revision: a227bcc62ad378fe88d2dfed8c600861988ba376
+  specs:
+    steep (0.39.0)
+      activesupport (>= 5.1)
+      ast_utils (>= 0.4.0)
+      language_server-protocol (~> 3.15.0.1)
+      listen (~> 3.0)
+      parser (>= 2.7)
+      rainbow (>= 2.2.2, < 4.0)
+      rbs (~> 1.0.0)
+
+GIT
   remote: https://github.com/ybiquitous/aufgaben.git
   revision: 3a17f6a7a722e37f60a393246edc44ef78373588
   tag: 0.6.0
@@ -35,9 +48,8 @@ GEM
       zeitwerk (~> 2.3)
     amazing_print (1.2.2)
     ast (2.4.1)
-    ast_utils (0.3.0)
-      parser (~> 2.4)
-      thor (>= 0.19)
+    ast_utils (0.4.0)
+      parser (>= 2.7.0)
     aws-eventstream (1.1.0)
     aws-partitions (1.413.0)
     aws-sdk-core (3.110.0)
@@ -98,17 +110,8 @@ GEM
     rubocop-ast (1.3.0)
       parser (>= 2.7.1.5)
     ruby-progressbar (1.10.1)
-    steep (0.39.0)
-      activesupport (>= 5.1)
-      ast_utils (~> 0.3.0)
-      language_server-protocol (~> 3.15.0.1)
-      listen (~> 3.0)
-      parser (~> 2.7.0)
-      rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 1.0.0)
     strong_json (2.1.2)
     strscan (3.0.0)
-    thor (1.0.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.7.0)
@@ -132,7 +135,7 @@ DEPENDENCIES
   rbs
   rubocop
   runners!
-  steep
+  steep!
   unification_assertion
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,17 +61,17 @@ GEM
     fileutils (1.5.0)
     forwardable (1.3.2)
     git_diff_parser (3.2.0)
-    i18n (1.8.5)
+    i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     json (2.5.1)
     jsonseq (0.2.0)
     language_server-protocol (3.15.0.1)
     lefthook (0.7.2)
-    listen (3.3.3)
+    listen (3.4.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    minitest (5.14.2)
+    minitest (5.14.3)
     open3 (0.1.1)
     parallel (1.20.1)
     parser (2.7.2.0)
@@ -82,7 +82,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbs (0.20.1)
+    rbs (1.0.0)
     regexp_parser (2.0.1)
     retryable (3.0.5)
     rexml (3.2.4)
@@ -98,14 +98,14 @@ GEM
     rubocop-ast (1.3.0)
       parser (>= 2.7.1.5)
     ruby-progressbar (1.10.1)
-    steep (0.37.0)
+    steep (0.39.0)
       activesupport (>= 5.1)
       ast_utils (~> 0.3.0)
       language_server-protocol (~> 3.15.0.1)
       listen (~> 3.0)
       parser (~> 2.7.0)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (>= 0.20.0)
+      rbs (~> 1.0.0)
     strong_json (2.1.2)
     strscan (3.0.0)
     thor (1.0.1)
@@ -132,7 +132,7 @@ DEPENDENCIES
   rbs
   rubocop
   runners!
-  steep (= 0.37.0)
+  steep
   unification_assertion
 
 BUNDLED WITH

--- a/Steepfile
+++ b/Steepfile
@@ -9,6 +9,7 @@ target :lib do
   library "tmpdir"
   library "forwardable"
   library "uri"
+  library "time"
   library "strong_json"
   library "retryable"
 end

--- a/sig/module.rbs
+++ b/sig/module.rbs
@@ -1,3 +1,0 @@
-class Module
-  def const_source_location: (String | Symbol, ?boolish) -> [String, Integer]
-end

--- a/sig/time.rbs
+++ b/sig/time.rbs
@@ -1,3 +1,0 @@
-class Time
-  def iso8601: () -> String
-end

--- a/sig/uri.rbs
+++ b/sig/uri.rbs
@@ -1,5 +1,0 @@
-module URI
-  def self.parse: (String) -> URI::Generic
-  def self.join: (*String) -> URI::Generic
-  def self.extract: (String, ?Array[String]) -> Array[String]
-end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- ~~https://github.com/soutaro/steep/blob/v0.39.0/CHANGELOG.md~~
- ~~https://github.com/soutaro/steep/compare/v0.37.0...v0.39.0~~
- https://github.com/soutaro/steep/blob/a227bcc62ad378fe88d2dfed8c600861988ba376/CHANGELOG.md
- https://github.com/soutaro/steep/compare/v0.37.0...a227bcc62ad378fe88d2dfed8c600861988ba376

*Note that the latest version [0.39.0](https://github.com/soutaro/steep/releases/tag/v0.39.0) causes many errors, so this bumps to the `master` version.*

This change also bumps `rbs` from 0.20.1 to 1.0.0:

- https://github.com/ruby/rbs/blob/v1.0.0/CHANGELOG.md
- https://github.com/ruby/rbs/compare/v0.20.1...v1.0.0

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
