### PR TITLE
Stop output `$EXTRA_CERTIFICATE` on debug

### DIFF
--- a/images/docker-entrypoint.sh
+++ b/images/docker-entrypoint.sh
@@ -2,15 +2,15 @@
 
 set -eo pipefail
 
-if [[ "$DEBUG" == "true" ]]; then
-  set -x
-fi
-
 if [[ -n "$EXTRA_CERTIFICATE" ]]; then
   echo "Run update-ca-certificates(8) to add the specified certificate" >&2
   echo "$EXTRA_CERTIFICATE" | base64 --decode > /usr/local/share/ca-certificates/extra-cert.crt
   sudo update-ca-certificates
   unset EXTRA_CERTIFICATE
+fi
+
+if [[ "$DEBUG" == "true" ]]; then
+  set -x
 fi
 
 RUNNERS_TIMEOUT=${RUNNERS_TIMEOUT:-30m}


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

When we run often `bundle exec rake docker:build docker:smoke DEBUG=true` command on development, then output about `$EXTRA_CERTIFICATE` is too much and noisy.

For example:

<img width="1232" alt="image" src="https://user-images.githubusercontent.com/473530/103837576-b976fc80-50ce-11eb-9193-3ba44985c278.png">

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
