### PR TITLE
Refactor `Runners::Shell` initialization

### DIFF
--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -43,7 +43,8 @@ module Runners
           end
 
           begin
-            processor = processor_class.new(guid: guid, working_dir: working_dir, config: conf, git_ssh_path: git_ssh_path, trace_writer: trace_writer)
+            processor = processor_class.new(guid: guid, working_dir: working_dir, config: conf,
+                                            shell: build_shell(git_ssh_path), trace_writer: trace_writer)
 
             root_dir_not_found = processor.check_root_dir_exist
             return root_dir_not_found if root_dir_not_found
@@ -140,6 +141,14 @@ module Runners
         dest.parent.rmdir
         trace_writer.message "Restore #{dest} to #{src}"
       end
+    end
+
+    def build_shell(git_ssh_path)
+      env = {
+        "RUBYOPT" => nil,
+        "GIT_SSH_COMMAND" => git_ssh_path&.then { |path| "ssh -F '#{path}'" },
+      }
+      Shell.new(current_dir: working_dir, trace_writer: trace_writer, env_hash: env)
     end
   end
 end

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -5,13 +5,6 @@ module Runners
 
     class CIConfigBroken < UserError; end
 
-    attr_reader :guid, :working_dir, :git_ssh_path, :trace_writer, :warnings, :config, :shell
-
-    def_delegators :@shell,
-      :chdir, :current_dir,
-      :capture3, :capture3!, :capture3_trace, :capture3_with_retry!,
-      :env_hash, :push_env_hash
-
     def self.register_config_schema(name:, schema:)
       Schema::Config.register(name: name, schema: schema)
     end
@@ -25,25 +18,24 @@ module Runners
     register_config_schema(name: :go_vet, schema: RemovedGoToolSchema.config)
     register_config_schema(name: :gometalinter, schema: RemovedGoToolSchema.config)
 
-    def initialize(guid:, working_dir:, config:, git_ssh_path:, trace_writer:)
+    attr_reader :guid, :working_dir, :config, :shell, :trace_writer, :warnings
+
+    def_delegators :@shell,
+      :chdir, :current_dir,
+      :capture3, :capture3!, :capture3_trace, :capture3_with_retry!,
+      :env_hash, :push_env_hash
+
+    def initialize(guid:, working_dir:, config:, shell:, trace_writer:)
       @guid = guid
       @working_dir = working_dir
-      @git_ssh_path = git_ssh_path
+      @config = config
+      @shell = shell
       @trace_writer = trace_writer
       @warnings = []
-      @config = config
 
       if config.path_exist?
         trace_writer.ci_config(config.content, raw_content: config.raw_content!, file: config.path_name)
       end
-
-      hash = {
-        "RUBYOPT" => nil,
-        "GIT_SSH_COMMAND" => git_ssh_path&.then { |path| "ssh -F '#{path}'" },
-      }
-      @shell = Shell.new(current_dir: working_dir,
-                         env_hash: hash,
-                         trace_writer: trace_writer)
     end
 
     def relative_path(original, from: working_dir)

--- a/lib/runners/shell.rb
+++ b/lib/runners/shell.rb
@@ -45,7 +45,7 @@ module Runners
     # signal number for analyse timeout
     SIGUSR2 = Signal.list.fetch('USR2')
 
-    def initialize(current_dir:, trace_writer:, env_hash:)
+    def initialize(current_dir:, trace_writer:, env_hash: {})
       @trace_writer = trace_writer
       @current_dir = current_dir
       @env_hash_stack = [env_hash]

--- a/sig/runners/harness.rbs
+++ b/sig/runners/harness.rbs
@@ -33,5 +33,7 @@ module Runners
     def handle_error: (Exception) -> void
 
     def exclude_special_dirs: [X] () { () -> X } -> X
+
+    def build_shell: (Pathname?) -> Shell
   end
 end

--- a/sig/runners/processor.rbs
+++ b/sig/runners/processor.rbs
@@ -7,14 +7,6 @@ module Runners
     class CIConfigBroken < UserError
     end
 
-    attr_reader guid: String
-    attr_reader working_dir: Pathname
-    attr_reader git_ssh_path: Pathname?
-    attr_reader trace_writer: TraceWriter
-    attr_reader warnings: Array[{ message: String, file: String? }]
-    attr_reader config: Config
-    attr_reader shell: Shell
-
     def self.register_config_schema: (name: Symbol, schema: StrongJSON::_Schema[untyped]) -> void
 
     class RemovedGoToolSchemaClass < StrongJSON
@@ -22,7 +14,14 @@ module Runners
     end
     RemovedGoToolSchema: RemovedGoToolSchemaClass
 
-    def initialize: (guid: String, working_dir: Pathname, config: Config, git_ssh_path: Pathname?, trace_writer: TraceWriter) -> void
+    attr_reader guid: String
+    attr_reader working_dir: Pathname
+    attr_reader config: Config
+    attr_reader shell: Shell
+    attr_reader trace_writer: TraceWriter
+    attr_reader warnings: Array[{ message: String, file: String? }]
+
+    def initialize: (guid: String, working_dir: Pathname, config: Config, shell: Shell, trace_writer: TraceWriter) -> void
 
     def current_dir: () -> Pathname
     def chdir: [X] (Pathname) { (Pathname) -> X } -> X

--- a/sig/runners/shell.rbs
+++ b/sig/runners/shell.rbs
@@ -26,7 +26,7 @@ module Runners
 
     def initialize: (current_dir: Pathname,
                      trace_writer: TraceWriter,
-                     env_hash: Hash[String, String?]) -> void
+                     ?env_hash: Hash[String, String?]) -> void
 
     def chdir: [X] (Pathname) { (Pathname) -> X } -> X
     def push_env_hash: [X] (Hash[String, String?]) { () -> X } -> X

--- a/test/java_test.rb
+++ b/test/java_test.rb
@@ -117,7 +117,7 @@ class JavaTest < Minitest::Test
       guid: "test-guid",
       working_dir: workspace.working_dir,
       config: config(config_yaml),
-      git_ssh_path: nil,
+      shell: Runners::Shell.new(current_dir: workspace.working_dir, trace_writer: trace_writer),
       trace_writer: trace_writer,
     )
   end

--- a/test/nodejs_test.rb
+++ b/test/nodejs_test.rb
@@ -14,6 +14,8 @@ class NodejsTest < Minitest::Test
   INSTALL_OPTION_PRODUCTION = Runners::Nodejs::INSTALL_OPTION_PRODUCTION
   INSTALL_OPTION_DEVELOPMENT = Runners::Nodejs::INSTALL_OPTION_DEVELOPMENT
 
+  private
+
   def processor_class
     @processor_class ||= Class.new(Runners::Processor) do
       include Runners::Nodejs
@@ -57,7 +59,7 @@ class NodejsTest < Minitest::Test
       guid: SecureRandom.uuid,
       working_dir: workspace.working_dir,
       config: config,
-      git_ssh_path: nil,
+      shell: Runners::Shell.new(current_dir: workspace.working_dir, trace_writer: trace_writer),
       trace_writer: trace_writer,
     )
   end
@@ -71,6 +73,8 @@ class NodejsTest < Minitest::Test
       silence_warnings { Runners::Nodejs.const_set(name, saved_value) }
     end
   end
+
+  public
 
   def test_nodejs_analyzer_local_command
     with_workspace do |workspace|

--- a/test/processor/phpmd_test.rb
+++ b/test/processor/phpmd_test.rb
@@ -5,17 +5,27 @@ class Runners::Processor::PhpmdTest < Minitest::Test
 
   Phpmd = Runners::Processor::Phpmd
 
+  private
+
   def trace_writer
     @trace_writer ||= new_trace_writer
   end
 
-  def subject(workspace, yaml: nil)
-    Phpmd.new(guid: SecureRandom.uuid, working_dir: workspace.working_dir, config: config(yaml), git_ssh_path: nil, trace_writer: trace_writer).tap do |s|
+  def subject(workspace, yaml: "")
+    Phpmd.new(
+      guid: SecureRandom.uuid,
+      working_dir: workspace.working_dir,
+      config: config(yaml),
+      shell: Runners::Shell.new(current_dir: workspace.working_dir, trace_writer: trace_writer),
+      trace_writer: trace_writer,
+    ).tap do |s|
       def s.analyzer_id
         "phpmd"
       end
     end
   end
+
+  public
 
   def test_target_files
     with_workspace do |workspace|

--- a/test/processor/remark_lint_test.rb
+++ b/test/processor/remark_lint_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 class Runners::Processor::RemarkLintTest < Minitest::Test
   include TestHelper
 
+  private
+
   def trace_writer
     @trace_writer ||= new_trace_writer
   end
@@ -16,14 +18,16 @@ class Runners::Processor::RemarkLintTest < Minitest::Test
       guid: SecureRandom.uuid,
       working_dir: workspace.working_dir,
       config: config,
+      shell: Runners::Shell.new(current_dir: workspace.working_dir, trace_writer: trace_writer),
       trace_writer: trace_writer,
-      git_ssh_path: nil
     ).tap do |s|
       def s.analyzer_id
         "remark_lint"
       end
     end
   end
+
+  public
 
   def test_no_rc_files?
     with_workspace do |workspace|

--- a/test/processor/rubocop_test.rb
+++ b/test/processor/rubocop_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 class Runners::Processor::RuboCopTest < Minitest::Test
   include TestHelper
 
+  private
+
   def trace_writer
     @trace_writer ||= new_trace_writer
   end
@@ -16,14 +18,16 @@ class Runners::Processor::RuboCopTest < Minitest::Test
       guid: SecureRandom.uuid,
       working_dir: workspace.working_dir,
       config: config,
+      shell: Runners::Shell.new(current_dir: workspace.working_dir, trace_writer: trace_writer),
       trace_writer: trace_writer,
-      git_ssh_path: nil
     ).tap do |s|
       def s.analyzer_id
         "rubocop"
       end
     end
   end
+
+  public
 
   def test_build_cop_links
     with_workspace do |workspace|

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -8,16 +8,12 @@ class RubyTest < Minitest::Test
   Source = GemInstaller::Source
   LockfileLoader = Runners::Ruby::LockfileLoader
 
-  def trace_writer
+  private def trace_writer
     @trace_writer ||= new_trace_writer
   end
 
-  def shell
-    @shell ||= Runners::Shell.new(
-      current_dir: __dir__,
-      env_hash: {},
-      trace_writer: trace_writer
-    )
+  private def shell
+    @shell ||= Runners::Shell.new(current_dir: __dir__, trace_writer: trace_writer)
   end
 
   def processor_class
@@ -30,12 +26,14 @@ class RubyTest < Minitest::Test
     end
   end
 
-  def new_processor(workspace:, git_ssh_path: nil, config_yaml: nil)
+  private def new_processor(workspace:, git_ssh_path: nil, config_yaml: "")
     processor_class.new(
       guid: SecureRandom.uuid,
       working_dir: workspace.working_dir,
       config: config(config_yaml),
-      git_ssh_path: git_ssh_path,
+      shell: Runners::Shell.new(current_dir: workspace.working_dir, trace_writer: trace_writer, env_hash: {
+        "GIT_SSH_COMMAND" => git_ssh_path&.then { |path| "ssh -F '#{path}'" },
+      }),
       trace_writer: trace_writer,
     )
   end

--- a/test/shell_test.rb
+++ b/test/shell_test.rb
@@ -5,6 +5,8 @@ class ShellTest < Minitest::Test
 
   Shell = Runners::Shell
 
+  private
+
   def trace_writer
     @trace_writer ||= new_trace_writer
   end
@@ -15,6 +17,8 @@ class ShellTest < Minitest::Test
     end
     assert_equal expected, actual
   end
+
+  public
 
   def test_chdir
     mktmpdir do |path|
@@ -39,6 +43,20 @@ class ShellTest < Minitest::Test
       assert_equal "Hi.", ret
 
       assert_equal path, shell.current_dir
+    end
+  end
+
+  def test_push_env_hash
+    mktmpdir do |dir|
+      shell = Shell.new(current_dir: dir, trace_writer: trace_writer, env_hash: { "RUBYOPT" => nil, "GIT_SSH_COMMAND" => "foo" })
+
+      assert_equal({ "RUBYOPT" => nil, "GIT_SSH_COMMAND" => "foo" }, shell.env_hash)
+
+      shell.push_env_hash({ "RBENV_VERSION" => "2.5.0" }) do
+        assert_equal({ "RUBYOPT" => nil, "GIT_SSH_COMMAND" => "foo", "RBENV_VERSION" => "2.5.0" }, shell.env_hash)
+      end
+
+      assert_equal({ "RUBYOPT" => nil, "GIT_SSH_COMMAND" => "foo" }, shell.env_hash)
     end
   end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring aims to make it easier to share a `Runners::Shell` instance between `Processor` classes.
This change mainly moves the initialization of `Runners::Shell` out of `Processor#initialize`.

> Link related issues or pull requests.

See <https://github.com/sider/runners/pull/1878#issuecomment-755824363>

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
