### PR TITLE
Refactor `Runners::Config` class

### DIFF
--- a/sig/runners/config.rbs
+++ b/sig/runners/config.rbs
@@ -12,18 +12,19 @@ module Runners
     class InvalidConfiguration < Error
     end
 
-    CONFIG_FILE_NAME: String
-    OLD_CONFIG_FILE_NAME: String
+    FILE_NAME: String
+    FILE_NAME_OLD: String
 
     def self.load_from_dir: (Pathname) -> instance
 
     attr_reader path: Pathname?
     attr_reader raw_content: String?
-    attr_reader content: Hash[Symbol, untyped]
 
-    def initialize: (Pathname?) -> void
+    def initialize: (path: Pathname?, raw_content: String?) -> void
 
     def raw_content!: () -> String
+
+    def content: () -> Hash[Symbol, untyped]
 
     def path_name: () -> String
 
@@ -37,7 +38,7 @@ module Runners
 
     private
 
-    def parse_yaml: () -> untyped
+    def parse_yaml: (String) -> untyped
 
     def check_schema: (untyped) -> Hash[Symbol, untyped]
   end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -3,275 +3,234 @@ require "test_helper"
 class ConfigTest < Minitest::Test
   include TestHelper
 
-  CONFIG_FILE_NAME = Runners::Config::CONFIG_FILE_NAME
-  OLD_CONFIG_FILE_NAME = Runners::Config::OLD_CONFIG_FILE_NAME
+  FILE_NAME = Runners::Config::FILE_NAME
+  FILE_NAME_OLD = Runners::Config::FILE_NAME_OLD
 
   def test_file_priority
     mktmpdir do |dir|
-      (dir / CONFIG_FILE_NAME).write("")
-      (dir / OLD_CONFIG_FILE_NAME).write("")
-      assert_equal CONFIG_FILE_NAME, Runners::Config.load_from_dir(dir).path_name
+      (dir / FILE_NAME).write("")
+      (dir / FILE_NAME_OLD).write("")
+      assert_equal FILE_NAME, Runners::Config.load_from_dir(dir).path_name
     end
   end
 
   def test_content_without_sider_yml
-    assert_equal({}, Runners::Config.new(nil).content)
+    assert_equal({}, Runners::Config.new(path: nil, raw_content: nil).content)
   end
 
   def test_content_with_empty_sider_yml
-    mktmpdir do |dir|
-      file = dir / CONFIG_FILE_NAME
-
-      file.write("---")
-      assert_equal({}, Runners::Config.new(file).content)
-
-      file.write("")
-      assert_equal({}, Runners::Config.new(file).content)
-    end
+    file = Pathname(FILE_NAME)
+    assert_equal({}, Runners::Config.new(path: file, raw_content: "---").content)
+    assert_equal({}, Runners::Config.new(path: file, raw_content: "---").content)
   end
 
   def test_content_with_linter_section
-    mktmpdir do |dir|
-      file = dir / CONFIG_FILE_NAME
-      file.write <<~YAML
-        ---
-        linter:
-          eslint:
-            config: abc
-            options:
-              npm_install: true
-      YAML
-      assert_equal(
-        { linter: {
-          golint: nil, go_vet: nil, gometalinter: nil,
-          brakeman: nil,
-          checkstyle: nil,
-          clang_tidy: nil,
-          code_sniffer: nil,
-          coffeelint: nil,
-          cppcheck: nil,
-          cpplint: nil,
-          detekt: nil,
-          eslint: {
-            root_dir: nil,
-            npm_install: nil,
-            target: nil,
-            dir: nil,
-            ext: nil,
-            config: "abc",
-            "ignore-path": nil,
-            "ignore-pattern": nil,
-            "no-ignore": nil,
-            global: nil,
-            quiet: nil,
-            options: { npm_install: true,
-                       dir: nil,
-                       ext: nil,
-                       config: nil,
-                       "ignore-path": nil,
-                       "no-ignore": nil,
-                       "ignore-pattern": nil,
-                       global: nil,
-                       quiet: nil,
-            },
+    yaml = <<~YAML
+      ---
+      linter:
+        eslint:
+          config: abc
+          options:
+            npm_install: true
+    YAML
+    assert_equal(
+      { linter: {
+        golint: nil, go_vet: nil, gometalinter: nil,
+        brakeman: nil,
+        checkstyle: nil,
+        clang_tidy: nil,
+        code_sniffer: nil,
+        coffeelint: nil,
+        cppcheck: nil,
+        cpplint: nil,
+        detekt: nil,
+        eslint: {
+          root_dir: nil,
+          npm_install: nil,
+          target: nil,
+          dir: nil,
+          ext: nil,
+          config: "abc",
+          "ignore-path": nil,
+          "ignore-pattern": nil,
+          "no-ignore": nil,
+          global: nil,
+          quiet: nil,
+          options: { npm_install: true,
+                     dir: nil,
+                     ext: nil,
+                     config: nil,
+                     "ignore-path": nil,
+                     "no-ignore": nil,
+                     "ignore-pattern": nil,
+                     global: nil,
+                     quiet: nil,
           },
-          flake8: nil,
-          fxcop: nil,
-          golangci_lint: nil,
-          goodcheck: nil,
-          hadolint: nil,
-          rubocop: nil,
-          haml_lint: nil,
-          javasee: nil,
-          jshint: nil,
-          ktlint: nil,
-          languagetool: nil,
-          misspell: nil,
-          phinder: nil,
-          phpmd: nil,
-          pmd_cpd: nil,
-          pmd_java: nil,
-          pylint: nil,
-          querly: nil,
-          rails_best_practices: nil,
-          reek: nil,
-          remark_lint: nil,
-          scss_lint: nil,
-          shellcheck: nil,
-          stylelint: nil,
-          swiftlint: nil,
-          tslint: nil,
-          tyscan: nil },
-          ignore: nil,
-          branches: nil,
         },
-        Runners::Config.new(file).content,
-      )
-    end
+        flake8: nil,
+        fxcop: nil,
+        golangci_lint: nil,
+        goodcheck: nil,
+        hadolint: nil,
+        rubocop: nil,
+        haml_lint: nil,
+        javasee: nil,
+        jshint: nil,
+        ktlint: nil,
+        languagetool: nil,
+        misspell: nil,
+        phinder: nil,
+        phpmd: nil,
+        pmd_cpd: nil,
+        pmd_java: nil,
+        pylint: nil,
+        querly: nil,
+        rails_best_practices: nil,
+        reek: nil,
+        remark_lint: nil,
+        scss_lint: nil,
+        shellcheck: nil,
+        stylelint: nil,
+        swiftlint: nil,
+        tslint: nil,
+        tyscan: nil },
+        ignore: nil,
+        branches: nil,
+      },
+      Runners::Config.new(path: Pathname(FILE_NAME), raw_content: yaml).content,
+    )
   end
 
   def test_content_with_unknown_linter
-    mktmpdir do |dir|
-      yaml = <<~YAML
-        ---
-        linter:
-          unknown_linter:
-            config: abc
-      YAML
-      file = (dir / CONFIG_FILE_NAME).tap { _1.write(yaml) }
-      exn = assert_raises Runners::Config::InvalidConfiguration do
-        Runners::Config.new(file)
-      end
-      assert_equal "The attribute `linter.unknown_linter` in your `sider.yml` is unsupported. Please fix and retry.", exn.message
-      assert_equal yaml, exn.raw_content
+    yaml = <<~YAML
+      ---
+      linter:
+        unknown_linter:
+          config: abc
+    YAML
+    exn = assert_raises Runners::Config::InvalidConfiguration do
+      Runners::Config.new(path: Pathname(FILE_NAME), raw_content: yaml).content
     end
+    assert_equal "The attribute `linter.unknown_linter` in your `sider.yml` is unsupported. Please fix and retry.", exn.message
+    assert_equal yaml, exn.raw_content
   end
 
   def test_content_with_invalid_type_of_linter
-    mktmpdir do |dir|
-      yaml = <<~YAML
-        ---
-        linter: []
-      YAML
-      file = (dir / CONFIG_FILE_NAME).tap { _1.write(yaml) }
-      exn = assert_raises Runners::Config::InvalidConfiguration do
-        Runners::Config.new(file)
-      end
-      assert_equal "The value of the attribute `linter` in your `sider.yml` is invalid. Please fix and retry.", exn.message
-      assert_equal yaml, exn.raw_content
+    yaml = <<~YAML
+      ---
+      linter: []
+    YAML
+    exn = assert_raises Runners::Config::InvalidConfiguration do
+      Runners::Config.new(path: Pathname(FILE_NAME), raw_content: yaml).content
     end
+    assert_equal "The value of the attribute `linter` in your `sider.yml` is invalid. Please fix and retry.", exn.message
+    assert_equal yaml, exn.raw_content
   end
 
   def test_content_with_ignore_section
-    mktmpdir do |dir|
-      file = (dir / CONFIG_FILE_NAME).tap { _1.write <<~YAML }
-        ---
-        ignore:
-          - ".pdf"
-          - ".mp4"
-          - "images/**"
-      YAML
-      assert_equal({ linter: nil, ignore: %w[.pdf .mp4 images/**], branches: nil },
-                   Runners::Config.new(file).content)
-    end
+    yaml = <<~YAML
+      ---
+      ignore:
+        - ".pdf"
+        - ".mp4"
+        - "images/**"
+    YAML
+    assert_equal({ linter: nil, ignore: %w[.pdf .mp4 images/**], branches: nil },
+                 Runners::Config.new(path: Pathname(FILE_NAME), raw_content: yaml).content)
   end
 
   def test_content_with_branches_section
-    mktmpdir do |dir|
-      file = (dir / CONFIG_FILE_NAME).tap { _1.write <<~YAML }
-        ---
-        branches:
-          exclude:
-            - master
-            - /^release-.*$/
-      YAML
-      assert_equal({ linter: nil, ignore: nil, branches: { exclude: %w[master /^release-.*$/] } },
-                   Runners::Config.new(file).content)
-    end
+    yaml = <<~YAML
+      ---
+      branches:
+        exclude:
+          - master
+          - /^release-.*$/
+    YAML
+    assert_equal({ linter: nil, ignore: nil, branches: { exclude: %w[master /^release-.*$/] } },
+                 Runners::Config.new(path: Pathname(FILE_NAME), raw_content: yaml).content)
   end
 
   def test_content_with_broken_yaml
-    mktmpdir do |dir|
-      file = (dir / CONFIG_FILE_NAME).tap { _1.write "@" }
-      exn = assert_raises Runners::Config::BrokenYAML do
-        Runners::Config.new(file)
-      end
-      assert_equal "Your `sider.yml` is broken at line 1 and column 1. Please fix and retry.", exn.message
+    exn = assert_raises Runners::Config::BrokenYAML do
+      Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "@").content
     end
+    assert_equal "Your `sider.yml` is broken at line 1 and column 1. Please fix and retry.", exn.message
   end
 
   def test_path_name
-    mktmpdir do |dir|
-      assert_equal CONFIG_FILE_NAME, Runners::Config.new(nil).path_name
-
-      file_1 = (dir / CONFIG_FILE_NAME).tap { _1.write "" }
-      assert_equal CONFIG_FILE_NAME, Runners::Config.new(file_1).path_name
-
-      file_1.delete
-
-      file_2 = (dir / OLD_CONFIG_FILE_NAME).tap { _1.write "" }
-      assert_equal OLD_CONFIG_FILE_NAME, Runners::Config.new(file_2).path_name
-    end
+    assert_equal FILE_NAME, Runners::Config.new(path: nil, raw_content: nil).path_name
+    assert_equal FILE_NAME, Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "").path_name
+    assert_equal FILE_NAME_OLD, Runners::Config.new(path: Pathname(FILE_NAME_OLD), raw_content: "").path_name
   end
 
   def test_ignore_patterns
-    mktmpdir do |dir|
-      assert_equal [], Runners::Config.new(nil).ignore_patterns
+    assert_equal [], Runners::Config.new(path: nil, raw_content: nil).ignore_patterns
 
-      file = (dir / CONFIG_FILE_NAME).tap { _1.write "ignore: abc" }
-      assert_equal %w[abc], Runners::Config.new(file).ignore_patterns
+    file = Pathname(FILE_NAME)
+    assert_equal %w[abc], Runners::Config.new(path: file, raw_content: "ignore: abc").ignore_patterns
 
-      file.write <<~YAML
-        ignore:
-          - "*.mp4"
-          - docs/**/*.pdf
-      YAML
-      assert_equal %w[*.mp4 docs/**/*.pdf], Runners::Config.new(file).ignore_patterns
-    end
+    yaml = <<~YAML
+      ignore:
+        - "*.mp4"
+        - docs/**/*.pdf
+    YAML
+    assert_equal %w[*.mp4 docs/**/*.pdf], Runners::Config.new(path: file, raw_content: yaml).ignore_patterns
   end
 
   def test_linter
-    mktmpdir do |dir|
-      file = (dir / CONFIG_FILE_NAME).tap { _1.write <<~YAML }
-        linter:
-          eslint:
-            ext: .js
-      YAML
-      assert_equal({
-        ext: ".js",
-        root_dir: nil,
-        npm_install: nil,
-        target: nil,
-        dir: nil,
-        config: nil,
-        "ignore-path": nil,
-        "ignore-pattern": nil,
-        "no-ignore": nil,
-        global: nil,
-        quiet: nil,
-        options: nil,
-      }, Runners::Config.new(file).linter("eslint"))
-    end
+    yaml = <<~YAML
+      linter:
+        eslint:
+          ext: .js
+    YAML
+    assert_equal({
+      ext: ".js",
+      root_dir: nil,
+      npm_install: nil,
+      target: nil,
+      dir: nil,
+      config: nil,
+      "ignore-path": nil,
+      "ignore-pattern": nil,
+      "no-ignore": nil,
+      global: nil,
+      quiet: nil,
+      options: nil,
+    }, Runners::Config.new(path: Pathname(FILE_NAME), raw_content: yaml).linter("eslint"))
   end
 
   def test_linter_default
-    mktmpdir do |dir|
-      file  = (dir / CONFIG_FILE_NAME).tap { _1.write "" }
-      assert_equal({}, Runners::Config.new(file).linter("eslint"))
-    end
+    assert_equal({}, Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "").linter("eslint"))
   end
 
   def test_linter?
-    mktmpdir do |dir|
-      file = (dir / CONFIG_FILE_NAME).tap { _1.write <<~YAML }
-        linter:
-          eslint: { root_dir: "src" }
-      YAML
-      config = Runners::Config.new(file)
-      assert config.linter?("eslint")
-      refute config.linter?("foo")
+    file = Pathname(FILE_NAME)
+    yaml = <<~YAML
+      linter:
+        eslint: { root_dir: "src" }
+    YAML
+    config = Runners::Config.new(path: file, raw_content: yaml)
+    assert config.linter?("eslint")
+    refute config.linter?("foo")
 
-      file.write ""
-      refute Runners::Config.new(file).linter?("foo")
-    end
+    refute Runners::Config.new(path: file, raw_content: "").linter?("foo")
   end
 
   def test_removed_go_tools_do_not_break
-    mktmpdir do |dir|
-      file = (dir / CONFIG_FILE_NAME).tap { _1.write <<~YAML }
-        linter:
-          golint:
-            root_dir: src/
-          go_vet:
-            root_dir: lib/
-          gometalinter:
-            root_dir: module/
-            import_path: foo
-      YAML
-      config = Runners::Config.new(file)
-      assert_equal({ root_dir: "src/" }, config.linter("golint"))
-      assert_equal({ root_dir: "lib/" }, config.linter("go_vet"))
-      assert_equal({ root_dir: "module/", import_path: "foo" }, config.linter("gometalinter"))
-    end
+    yaml = <<~YAML
+      linter:
+        golint:
+          root_dir: src/
+        go_vet:
+          root_dir: lib/
+        gometalinter:
+          root_dir: module/
+          import_path: foo
+    YAML
+    config = Runners::Config.new(path: Pathname(FILE_NAME), raw_content: yaml)
+    assert_equal({ root_dir: "src/" }, config.linter("golint"))
+    assert_equal({ root_dir: "lib/" }, config.linter("go_vet"))
+    assert_equal({ root_dir: "module/", import_path: "foo" }, config.linter("gometalinter"))
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,10 +54,11 @@ module TestHelper
   end
 
   def config(yaml = "")
+    yaml ||= ""
     mktmpdir do |dir|
-      file = dir / Runners::Config::CONFIG_FILE_NAME
+      file = dir / Runners::Config::FILE_NAME
       file.write(yaml)
-      Runners::Config.new(file)
+      Runners::Config.new(path: file, raw_content: yaml)
     end
   end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- Rename the constants.
- Lazy initialization of the `#content` method.
- Not depend on the file system.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
