### PR TITLE
Add `Runners::Config#exclude_branch?` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - **ESLint** Add `eslint-config-react-app` as pre-installed [#1902](https://github.com/sider/runners/pull/1902)
 - Fix checking unsupported tools [#1911](https://github.com/sider/runners/pull/1911)
+- Add `Runners::Config#exclude_branch?` method [#1913](https://github.com/sider/runners/pull/1913)
 
 ## 0.40.1
 

--- a/lib/runners/config.rb
+++ b/lib/runners/config.rb
@@ -29,7 +29,7 @@ module Runners
     attr_reader :path, :raw_content
 
     def initialize(path:, raw_content:)
-      @path = path
+      @path = path ? Pathname(path) : path
       @raw_content = raw_content
     end
 

--- a/lib/runners/config.rb
+++ b/lib/runners/config.rb
@@ -75,6 +75,23 @@ module Runners
       end
     end
 
+    def exclude_branch?(branch)
+      Array(content.dig(:branches, :exclude)).any? do |pattern|
+        # @type var pattern: String
+        match = pattern.match(%r{\A/(.+)/(i)?\z})
+        if match
+          pat, ignorecase = match.captures
+          if pat
+            Regexp.compile(pat, !!ignorecase).match?(branch)
+          else
+            raise "Unexpected regexp: #{match.inspect}"
+          end
+        else
+          pattern == branch
+        end
+      end
+    end
+
     private
 
     def parse_yaml(text)

--- a/sig/runners/config.rbs
+++ b/sig/runners/config.rbs
@@ -20,7 +20,7 @@ module Runners
     attr_reader path: Pathname?
     attr_reader raw_content: String?
 
-    def initialize: (path: Pathname?, raw_content: String?) -> void
+    def initialize: (path: (Pathname | String)?, raw_content: String?) -> void
 
     def raw_content!: () -> String
 

--- a/sig/runners/config.rbs
+++ b/sig/runners/config.rbs
@@ -38,6 +38,8 @@ module Runners
 
     def check_unsupported_linters: (Array[String]) -> String
 
+    def exclude_branch?: (String) -> bool
+
     private
 
     def parse_yaml: (String) -> untyped

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -252,4 +252,29 @@ class ConfigTest < Minitest::Test
     config = Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "")
     assert_equal "", config.check_unsupported_linters(%w[foo bar])
   end
+
+  def test_exclude_branch?
+    yaml = <<~YAML
+      branches:
+        exclude:
+          - foo
+          - /^bar/
+          - /baz/i
+          - /abc
+          - /^features\/.+/
+    YAML
+    config = Runners::Config.new(path: Pathname(FILE_NAME), raw_content: yaml)
+
+    assert config.exclude_branch?("foo")
+    refute config.exclude_branch?("foooo")
+    assert config.exclude_branch?("bar")
+    assert config.exclude_branch?("bar--")
+    refute config.exclude_branch?("--bar--")
+    assert config.exclude_branch?("baz")
+    assert config.exclude_branch?("BAZ")
+    assert config.exclude_branch?("/abc")
+    refute config.exclude_branch?("abc")
+    assert config.exclude_branch?("features/123")
+    refute config.exclude_branch?("features/")
+  end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to provide the check by the `branches.exclude` option in `sider.yml`.
See also <https://help.sider.review/getting-started/custom-configuration#branchesexclude>

> Link related issues or pull requests.

A part of #1303

> Check the following.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
