### PR TITLE
Add TraceWriter.finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.40.1...HEAD)
 
 - **ESLint** Add `eslint-config-react-app` as pre-installed [#1902](https://github.com/sider/runners/pull/1902)
+- Add a new trace schema `finish` [#1914](https://github.com/sider/runners/pull/1914)
 
 ## 0.40.1
 

--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -63,14 +63,14 @@ module Runners
 
         result.tap do
           finished_at = Time.now
-          trace_writer.header "Analysis finished", recorded_at: finished_at
+          trace_writer.header "Analysis finished"
 
           if result.is_a? Results::Success
             trace_writer.message "#{result.issues.size} issue(s) found."
           end
 
           trace_writer.message "Finished at #{finished_at.utc}"
-          trace_writer.message "Elapsed time: #{format_duration(finished_at - started_at)}"
+          trace_writer.finish "Elapsed time: #{format_duration(finished_at - started_at)}", duration_in_sec: Integer(finished_at - started_at)
         end
       end
     ensure

--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -70,7 +70,8 @@ module Runners
           end
 
           trace_writer.message "Finished at #{finished_at.utc}"
-          trace_writer.finish "Elapsed time: #{format_duration(finished_at - started_at)}", duration_in_sec: Integer(finished_at - started_at)
+          trace_writer.message "Elapsed time: #{format_duration(finished_at - started_at)}"
+          trace_writer.finish duration_in_sec: Integer(finished_at - started_at)
         end
       end
     ensure

--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -71,7 +71,7 @@ module Runners
 
           trace_writer.message "Finished at #{finished_at.utc}"
           trace_writer.message "Elapsed time: #{format_duration(finished_at - started_at)}"
-          trace_writer.finish duration_in_sec: Integer(finished_at - started_at), started_at: started_at, finished_at: finished_at
+          trace_writer.finish started_at: started_at, finished_at: finished_at
         end
       end
     ensure

--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -71,7 +71,7 @@ module Runners
 
           trace_writer.message "Finished at #{finished_at.utc}"
           trace_writer.message "Elapsed time: #{format_duration(finished_at - started_at)}"
-          trace_writer.finish duration_in_sec: Integer(finished_at - started_at)
+          trace_writer.finish duration_in_sec: Integer(finished_at - started_at), started_at: started_at, finished_at: finished_at
         end
       end
     ensure

--- a/lib/runners/schema/trace.rb
+++ b/lib/runners/schema/trace.rb
@@ -15,7 +15,7 @@ module Runners
       let :warning, object(trace: literal(:warning), message: string, file: string?, recorded_at: string)
       let :ci_config, object(trace: literal(:ci_config), content: any, raw_content: string, file: string, recorded_at: string)
       let :error, object(trace: literal(:error), message: string, recorded_at: string, truncated: boolean)
-      let :finish, object(trace: literal(:finish), duration_in_sec: integer, recorded_at: string)
+      let :finish, object(trace: literal(:finish), duration_in_sec: integer, started_at: string, finished_at: string, recorded_at: string)
       let :anything, enum(command_line, status, stdout, stderr, message, header, warning, ci_config, error, finish)
     end
   end

--- a/lib/runners/schema/trace.rb
+++ b/lib/runners/schema/trace.rb
@@ -15,7 +15,7 @@ module Runners
       let :warning, object(trace: literal(:warning), message: string, file: string?, recorded_at: string)
       let :ci_config, object(trace: literal(:ci_config), content: any, raw_content: string, file: string, recorded_at: string)
       let :error, object(trace: literal(:error), message: string, recorded_at: string, truncated: boolean)
-      let :finish, object(trace: literal(:finish), message: string, duration_in_sec: integer, recorded_at: string)
+      let :finish, object(trace: literal(:finish), duration_in_sec: integer, recorded_at: string)
       let :anything, enum(command_line, status, stdout, stderr, message, header, warning, ci_config, error, finish)
     end
   end

--- a/lib/runners/schema/trace.rb
+++ b/lib/runners/schema/trace.rb
@@ -15,7 +15,8 @@ module Runners
       let :warning, object(trace: literal(:warning), message: string, file: string?, recorded_at: string)
       let :ci_config, object(trace: literal(:ci_config), content: any, raw_content: string, file: string, recorded_at: string)
       let :error, object(trace: literal(:error), message: string, recorded_at: string, truncated: boolean)
-      let :anything, enum(command_line, status, stdout, stderr, message, header, warning, ci_config, error)
+      let :finish, object(trace: literal(:finish), message: string, duration_in_sec: integer, recorded_at: string)
+      let :anything, enum(command_line, status, stdout, stderr, message, header, warning, ci_config, error, finish)
     end
   end
 end

--- a/lib/runners/trace_writer.rb
+++ b/lib/runners/trace_writer.rb
@@ -82,8 +82,8 @@ module Runners
       end
     end
 
-    def finish(message, duration_in_sec:, recorded_at: now)
-      self << { trace: :finish, message: filter.mask(message.strip), duration_in_sec: duration_in_sec, recorded_at: recorded_at }
+    def finish(duration_in_sec:, recorded_at: now)
+      self << { trace: :finish, duration_in_sec: duration_in_sec, recorded_at: recorded_at }
     end
 
     def <<(object)

--- a/lib/runners/trace_writer.rb
+++ b/lib/runners/trace_writer.rb
@@ -82,8 +82,10 @@ module Runners
       end
     end
 
-    def finish(duration_in_sec:, recorded_at: now)
-      self << { trace: :finish, duration_in_sec: duration_in_sec, recorded_at: recorded_at }
+    def finish(duration_in_sec:, started_at:, finished_at:, recorded_at: now)
+      started_at = started_at.utc.iso8601(3)
+      finished_at = finished_at.utc.iso8601(3)
+      self << { trace: :finish, duration_in_sec: duration_in_sec, started_at: started_at, finished_at: finished_at, recorded_at: recorded_at }
     end
 
     def <<(object)

--- a/lib/runners/trace_writer.rb
+++ b/lib/runners/trace_writer.rb
@@ -82,7 +82,8 @@ module Runners
       end
     end
 
-    def finish(duration_in_sec:, started_at:, finished_at:, recorded_at: now)
+    def finish(started_at:, finished_at:, recorded_at: now)
+      duration_in_sec = Integer(finished_at - started_at)
       started_at = started_at.utc.iso8601(3)
       finished_at = finished_at.utc.iso8601(3)
       self << { trace: :finish, duration_in_sec: duration_in_sec, started_at: started_at, finished_at: finished_at, recorded_at: recorded_at }

--- a/lib/runners/trace_writer.rb
+++ b/lib/runners/trace_writer.rb
@@ -82,6 +82,10 @@ module Runners
       end
     end
 
+    def finish(message, duration_in_sec:, recorded_at: now)
+      self << { trace: :finish, message: filter.mask(message.strip), duration_in_sec: duration_in_sec, recorded_at: recorded_at }
+    end
+
     def <<(object)
       recorded_at = object[:recorded_at]
       object = object.merge(recorded_at: recorded_at.utc.iso8601(3)) if recorded_at

--- a/sig/runners/schema/trace.rbs
+++ b/sig/runners/schema/trace.rbs
@@ -10,6 +10,7 @@ module Runners
       def warning: () -> StrongJSON::Type::Object[untyped]
       def ci_config: () -> StrongJSON::Type::Object[untyped]
       def error: () -> StrongJSON::Type::Object[untyped]
+      def finish: () -> StrongJSON::Type::Object[untyped]
       def anything: () -> StrongJSON::Type::Enum[untyped]
     end
     Trace: TraceClass

--- a/sig/runners/trace_writer.rbs
+++ b/sig/runners/trace_writer.rbs
@@ -23,7 +23,7 @@ module Runners
 
     def error: (String, ?recorded_at: Time, ?max_length: Integer) -> void
 
-    def finish: (duration_in_sec: Integer, ?recorded_at: Time) -> void
+    def finish: (duration_in_sec: Integer, started_at: Time, finished_at: Time, ?recorded_at: Time) -> void
 
     def <<: (Hash[Symbol, untyped]) -> void
 

--- a/sig/runners/trace_writer.rbs
+++ b/sig/runners/trace_writer.rbs
@@ -23,7 +23,7 @@ module Runners
 
     def error: (String, ?recorded_at: Time, ?max_length: Integer) -> void
 
-    def finish: (String, duration_in_sec: Integer, ?recorded_at: Time) -> void
+    def finish: (duration_in_sec: Integer, ?recorded_at: Time) -> void
 
     def <<: (Hash[Symbol, untyped]) -> void
 

--- a/sig/runners/trace_writer.rbs
+++ b/sig/runners/trace_writer.rbs
@@ -23,7 +23,7 @@ module Runners
 
     def error: (String, ?recorded_at: Time, ?max_length: Integer) -> void
 
-    def finish: (duration_in_sec: Integer, started_at: Time, finished_at: Time, ?recorded_at: Time) -> void
+    def finish: (started_at: Time, finished_at: Time, ?recorded_at: Time) -> void
 
     def <<: (Hash[Symbol, untyped]) -> void
 

--- a/sig/runners/trace_writer.rbs
+++ b/sig/runners/trace_writer.rbs
@@ -23,6 +23,8 @@ module Runners
 
     def error: (String, ?recorded_at: Time, ?max_length: Integer) -> void
 
+    def finish: (String, duration_in_sec: Integer, ?recorded_at: Time) -> void
+
     def <<: (Hash[Symbol, untyped]) -> void
 
     private

--- a/sig/time.rbs
+++ b/sig/time.rbs
@@ -1,3 +1,3 @@
 class Time
-  def iso8601: () -> String
+  def iso8601: (?Integer) -> String
 end

--- a/test/trace_writer_test.rb
+++ b/test/trace_writer_test.rb
@@ -89,6 +89,11 @@ class TraceWriterTest < Minitest::Test
     assert_equal [{ trace: :error, message: 'hoge error', recorded_at: "2017-08-01T22:34:51.200Z", truncated: false }], writer.writer
   end
 
+  def test_finish
+    writer.finish('Finish!', duration_in_sec: 30, recorded_at: now)
+    assert_equal [{ trace: :finish, message: 'Finish!', duration_in_sec: 30, recorded_at: "2017-08-01T22:34:51.200Z" }], writer.writer
+  end
+
   def test_masked_string
     writer.command_line(%w[cat https://user:secret@github.com], recorded_at: now)
     writer.stdout("user:secret in stdout", recorded_at: now)

--- a/test/trace_writer_test.rb
+++ b/test/trace_writer_test.rb
@@ -90,8 +90,10 @@ class TraceWriterTest < Minitest::Test
   end
 
   def test_finish
-    writer.finish(duration_in_sec: 30, recorded_at: now)
-    assert_equal [{ trace: :finish, duration_in_sec: 30, recorded_at: "2017-08-01T22:34:51.200Z" }], writer.writer
+    started_at = now - 30
+    finished_at = now - 1
+    writer.finish(duration_in_sec: 30, started_at: started_at, finished_at: finished_at, recorded_at: now)
+    assert_equal [{ trace: :finish, duration_in_sec: 30, started_at: "2017-08-01T22:34:21.200Z", finished_at: "2017-08-01T22:34:50.200Z", recorded_at: "2017-08-01T22:34:51.200Z" }], writer.writer
   end
 
   def test_masked_string

--- a/test/trace_writer_test.rb
+++ b/test/trace_writer_test.rb
@@ -90,8 +90,8 @@ class TraceWriterTest < Minitest::Test
   end
 
   def test_finish
-    writer.finish('Finish!', duration_in_sec: 30, recorded_at: now)
-    assert_equal [{ trace: :finish, message: 'Finish!', duration_in_sec: 30, recorded_at: "2017-08-01T22:34:51.200Z" }], writer.writer
+    writer.finish(duration_in_sec: 30, recorded_at: now)
+    assert_equal [{ trace: :finish, duration_in_sec: 30, recorded_at: "2017-08-01T22:34:51.200Z" }], writer.writer
   end
 
   def test_masked_string

--- a/test/trace_writer_test.rb
+++ b/test/trace_writer_test.rb
@@ -92,8 +92,8 @@ class TraceWriterTest < Minitest::Test
   def test_finish
     started_at = now - 30
     finished_at = now - 1
-    writer.finish(duration_in_sec: 30, started_at: started_at, finished_at: finished_at, recorded_at: now)
-    assert_equal [{ trace: :finish, duration_in_sec: 30, started_at: "2017-08-01T22:34:21.200Z", finished_at: "2017-08-01T22:34:50.200Z", recorded_at: "2017-08-01T22:34:51.200Z" }], writer.writer
+    writer.finish(started_at: started_at, finished_at: finished_at, recorded_at: now)
+    assert_equal [{ trace: :finish, duration_in_sec: 29, started_at: "2017-08-01T22:34:21.200Z", finished_at: "2017-08-01T22:34:50.200Z", recorded_at: "2017-08-01T22:34:51.200Z" }], writer.writer
   end
 
   def test_masked_string


### PR DESCRIPTION
This new method is responsible for indicating the finish of an analysis.
It's basically assumed to be called from `CLI`.

Fix #1912 
