### PR TITLE
Add `fraction_digits` to `Time#iso8601`

### DIFF
--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -65,5 +65,23 @@ rules:
     justification:
       - When the same version has been used already.
 
+  - id: sider.runners.time_iso8601
+    pattern: iso8601
+    glob: lib/**/*.rb
+    message: |
+      Consider adding `fraction_digits` to when using `Time#iso8601`.
+
+      In most cases, milliseconds are necessary. For example:
+
+      ```ruby
+      Time.now.iso8601    #=> "2021-01-08T11:35:05+09:00"
+      Time.now.iso8601(3) #=> "2021-01-08T11:35:05.371+09:00"
+      ```
+
+      See also <https://ruby-doc.org/stdlib-2.7.2/libdoc/time/rdoc/Time.html#iso8601-method>.
+    justification:
+      - When `fraction_digits` is given already.
+      - When milliseconds are never necessary.
+
 import:
   - https://raw.githubusercontent.com/sider/goodcheck-rules/master/rules/typo.yml

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -78,7 +78,7 @@ rules:
       Time.now.iso8601(3) #=> "2021-01-08T11:35:05.371+09:00"
       ```
 
-      See also <https://ruby-doc.org/stdlib-2.7.2/libdoc/time/rdoc/Time.html#iso8601-method>.
+      See also <https://ruby-doc.org/stdlib-2.7.2/libdoc/time/rdoc/Time.html#method-i-iso8601>.
     justification:
       - When `fraction_digits` is given already.
       - When milliseconds are never necessary.

--- a/lib/runners/results.rb
+++ b/lib/runners/results.rb
@@ -12,7 +12,7 @@ module Runners
       def as_json
         {
           guid: guid,
-          timestamp: timestamp.utc.iso8601
+          timestamp: timestamp.utc.iso8601(3)
         }
       end
 

--- a/sig/time.rbs
+++ b/sig/time.rbs
@@ -1,3 +1,3 @@
 class Time
-  def iso8601: () -> String
+  def iso8601: (?Integer) -> String
 end

--- a/test/results_test.rb
+++ b/test/results_test.rb
@@ -35,7 +35,7 @@ class ResultsTest < Minitest::Test
     assert_unifiable(result.as_json,
                      {
                        guid: result.guid,
-                       timestamp: result.timestamp.utc.iso8601,
+                       timestamp: result.timestamp.utc.iso8601(3),
                        type: 'success',
                        issue_count: 2,
                        issues: [
@@ -94,7 +94,7 @@ class ResultsTest < Minitest::Test
     assert_unifiable(result.as_json,
                      {
                        guid: result.guid,
-                       timestamp: result.timestamp.utc.iso8601,
+                       timestamp: result.timestamp.utc.iso8601(3),
                        type: 'success',
                        issue_count: 1,
                        issues: [
@@ -166,7 +166,7 @@ class ResultsTest < Minitest::Test
     assert_unifiable(result.as_json,
                      {
                        guid: result.guid,
-                       timestamp: result.timestamp.utc.iso8601,
+                       timestamp: result.timestamp.utc.iso8601(3),
                        type: 'success',
                        issue_count: 2,
                        issues: [
@@ -237,7 +237,7 @@ class ResultsTest < Minitest::Test
     assert_unifiable(result.as_json,
                      {
                        guid: result.guid,
-                       timestamp: result.timestamp.utc.iso8601,
+                       timestamp: result.timestamp.utc.iso8601(3),
                        type: 'success',
                        issue_count: 1,
                        issues: [
@@ -276,7 +276,7 @@ class ResultsTest < Minitest::Test
     assert_unifiable(result.as_json,
                      {
                        guid: result.guid,
-                       timestamp: result.timestamp.utc.iso8601,
+                       timestamp: result.timestamp.utc.iso8601(3),
                        type: 'success',
                        issue_count: 1,
                        issues: [
@@ -302,7 +302,7 @@ class ResultsTest < Minitest::Test
     assert_unifiable(result.as_json,
                      {
                        guid: result.guid,
-                       timestamp: result.timestamp.utc.iso8601,
+                       timestamp: result.timestamp.utc.iso8601(3),
                        type: "failure",
                        message: "Something wrong...",
                        analyzer: nil
@@ -317,7 +317,7 @@ class ResultsTest < Minitest::Test
     assert_unifiable(result.as_json,
                      {
                        guid: result.guid,
-                       timestamp: result.timestamp.utc.iso8601,
+                       timestamp: result.timestamp.utc.iso8601(3),
                        type: "failure",
                        message: "Something wrong...",
                        analyzer: { name: "Foo", version: "bar" }
@@ -333,7 +333,7 @@ class ResultsTest < Minitest::Test
     assert_unifiable(result.as_json,
                      {
                        guid: result.guid,
-                       timestamp: result.timestamp.utc.iso8601,
+                       timestamp: result.timestamp.utc.iso8601(3),
                        type: "error",
                        class: "RuntimeError",
                        backtrace: nil,


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

In most cases, I think a timestamp representation needs milliseconds.
This change also adds a Goodcheck rule about the use of `Time#iso8601`.

See also <https://ruby-doc.org/stdlib-2.7.2/libdoc/time/rdoc/Time.html#method-i-iso8601>.

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
