### PR TITLE
Bump bugsnag from 6.18.0 to 6.19.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    bugsnag (6.18.0)
+    bugsnag (6.19.0)
       concurrent-ruby (~> 1.0)
     concurrent-ruby (1.1.7)
     ffi (1.14.2)


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- https://github.com/bugsnag/bugsnag-ruby/compare/v6.18.0...v6.19.0
- https://github.com/bugsnag/bugsnag-ruby/releases/tag/v6.19.0
- https://github.com/bugsnag/bugsnag-ruby/blob/v6.19.0/CHANGELOG.md

Note that Dependabot does not work now due to #1917.

> Link related issues or pull requests.

To fix the error on #1917.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
