### PR TITLE
Rename `duration_in_sec` to `duration_in_ms` for `finish` trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.40.3...HEAD)
 
+- Rename `duration_in_sec` to `duration_in_ms` for `finish` trace [#1930](https://github.com/sider/runners/pull/1930)
+
 ## 0.40.3
 
 [Full diff](https://github.com/sider/runners/compare/0.40.2...0.40.3)

--- a/lib/runners/schema/trace.rb
+++ b/lib/runners/schema/trace.rb
@@ -15,7 +15,7 @@ module Runners
       let :warning, object(trace: literal(:warning), message: string, file: string?, recorded_at: string)
       let :ci_config, object(trace: literal(:ci_config), content: any, raw_content: string, file: string, recorded_at: string)
       let :error, object(trace: literal(:error), message: string, recorded_at: string, truncated: boolean)
-      let :finish, object(trace: literal(:finish), duration_in_sec: integer, started_at: string, finished_at: string, recorded_at: string)
+      let :finish, object(trace: literal(:finish), duration_in_ms: integer, started_at: string, finished_at: string, recorded_at: string)
       let :anything, enum(command_line, status, stdout, stderr, message, header, warning, ci_config, error, finish)
     end
   end

--- a/lib/runners/trace_writer.rb
+++ b/lib/runners/trace_writer.rb
@@ -8,11 +8,11 @@ module Runners
     end
 
     def command_line(command_line, recorded_at: now)
-      self << { trace: :command_line, command_line: command_line.map { |v| filter.mask(v) }, recorded_at: recorded_at }
+      self << { trace: :command_line, command_line: command_line.map { |v| filter.mask(v) }, recorded_at: time_to_s(recorded_at) }
     end
 
     def status(status, recorded_at: now)
-      self << { trace: :status, status: status.exitstatus, recorded_at: recorded_at }
+      self << { trace: :status, status: status.exitstatus, recorded_at: time_to_s(recorded_at) }
     end
 
     def stdout(string, recorded_at: now, max_length: 4_000)
@@ -22,7 +22,7 @@ module Runners
       return if string.empty?
 
       each_slice(filter.mask(string), size: max_length) do |text, truncated|
-        self << { trace: :stdout, string: text, recorded_at: recorded_at, truncated: truncated }
+        self << { trace: :stdout, string: text, recorded_at: time_to_s(recorded_at), truncated: truncated }
       end
     end
 
@@ -33,7 +33,7 @@ module Runners
       return if string.empty?
 
       each_slice(filter.mask(string), size: max_length) do |text, truncated|
-        self << { trace: :stderr, string: text, recorded_at: recorded_at, truncated: truncated }
+        self << { trace: :stderr, string: text, recorded_at: time_to_s(recorded_at), truncated: truncated }
       end
     end
 
@@ -47,7 +47,7 @@ module Runners
 
       block_given = block_given?
       each_slice(string, size: max_length) do |text, truncated|
-        self << { trace: :message, message: text, recorded_at: recorded_at,
+        self << { trace: :message, message: text, recorded_at: time_to_s(recorded_at),
                   truncated: all_truncated || truncated,
                   duration_in_ms: block_given ? 0 : nil }.compact
       end
@@ -55,43 +55,39 @@ module Runners
       if block_given
         start = now
         yield.tap do
-          duration = now - start
-          duration_in_ms = (duration * 1000).truncate
+          finish = now
+          duration_in_ms = calc_duration_in_ms(start, finish)
           duration_in_ms = 1 if duration_in_ms == 0 # NOTE: Prevent zero (no time)
-          self << { trace: :message, message: "-> #{duration_in_ms / 1000.0}s", recorded_at: recorded_at + duration,
+          self << { trace: :message, message: "-> #{finish - start}s", recorded_at: time_to_s(finish),
                     truncated: false, duration_in_ms: duration_in_ms }
         end
       end
     end
 
     def header(message, recorded_at: now)
-      self << { trace: :header, message: filter.mask(message.strip), recorded_at: recorded_at }
+      self << { trace: :header, message: filter.mask(message.strip), recorded_at: time_to_s(recorded_at) }
     end
 
     def warning(message, file: nil, recorded_at: now)
-      self << { trace: :warning, file: file, message: filter.mask(message.strip), recorded_at: recorded_at }
+      self << { trace: :warning, file: file, message: filter.mask(message.strip), recorded_at: time_to_s(recorded_at) }
     end
 
     def ci_config(content, raw_content:, file:, recorded_at: now)
-      self << { trace: :ci_config, content: content, raw_content: raw_content, file: file, recorded_at: recorded_at }
+      self << { trace: :ci_config, content: content, raw_content: raw_content, file: file, recorded_at: time_to_s(recorded_at) }
     end
 
     def error(message, recorded_at: now, max_length: 4_000)
       each_slice(filter.mask(message.strip), size: max_length) do |text, truncated|
-        self << { trace: :error, message: text, recorded_at: recorded_at, truncated: truncated }
+        self << { trace: :error, message: text, recorded_at: time_to_s(recorded_at), truncated: truncated }
       end
     end
 
     def finish(started_at:, finished_at:, recorded_at: now)
-      duration_in_sec = Integer(finished_at - started_at)
-      started_at = started_at.utc.iso8601(3)
-      finished_at = finished_at.utc.iso8601(3)
-      self << { trace: :finish, duration_in_sec: duration_in_sec, started_at: started_at, finished_at: finished_at, recorded_at: recorded_at }
+      self << { trace: :finish, duration_in_ms: calc_duration_in_ms(started_at, finished_at),
+               started_at: time_to_s(started_at), finished_at: time_to_s(finished_at), recorded_at: time_to_s(recorded_at) }
     end
 
     def <<(object)
-      recorded_at = object[:recorded_at]
-      object = object.merge(recorded_at: recorded_at.utc.iso8601(3)) if recorded_at
       writer << Schema::Trace.anything.coerce(object)
     end
 
@@ -99,6 +95,10 @@ module Runners
 
     def now
       Time.now
+    end
+
+    def time_to_s(time)
+      time.utc.iso8601(3)
     end
 
     def each_slice(string, size:)
@@ -109,6 +109,11 @@ module Runners
         truncated = slice.length == size
         yield slice, truncated
       end
+    end
+
+    def calc_duration_in_ms(start, finish)
+      seconds = finish - start
+      (seconds * 1000).truncate
     end
   end
 end

--- a/sig/runners/trace_writer.rbs
+++ b/sig/runners/trace_writer.rbs
@@ -31,6 +31,10 @@ module Runners
 
     def now: () -> Time
 
+    def time_to_s: (Time) -> String
+
     def each_slice: (String, size: Integer) { (String, bool) -> void } -> void
+
+    def calc_duration_in_ms: (Time, Time) -> Integer
   end
 end

--- a/test/trace_writer_test.rb
+++ b/test/trace_writer_test.rb
@@ -41,13 +41,14 @@ class TraceWriterTest < Minitest::Test
   def test_message_with_block
     return_values = [
       Time.utc(2001, 1, 1, 0, 0, 0),
+      Time.utc(2001, 1, 1, 0, 0, 0),
       Time.utc(2001, 1, 1, 0, 1, 0),
     ]
     writer.stub :now, ->() { return_values.shift } do
-      writer.message("Hello", recorded_at: now) { "noop" }
+      writer.message("Hello") { "noop" }
 
-      assert_equal [{ trace: :message, message: "Hello", recorded_at: "2017-08-01T22:34:51.200Z", truncated: false, duration_in_ms: 0 },
-                    { trace: :message, message: "-> 60.0s", recorded_at: "2017-08-01T22:35:51.200Z", truncated: false, duration_in_ms: 60000 }], writer.writer
+      assert_equal [{ trace: :message, message: "Hello", recorded_at: "2001-01-01T00:00:00.000Z", truncated: false, duration_in_ms: 0 },
+                    { trace: :message, message: "-> 60.0s", recorded_at: "2001-01-01T00:01:00.000Z", truncated: false, duration_in_ms: 60000 }], writer.writer
     end
   end
 
@@ -93,7 +94,7 @@ class TraceWriterTest < Minitest::Test
     started_at = now - 30
     finished_at = now - 1
     writer.finish(started_at: started_at, finished_at: finished_at, recorded_at: now)
-    assert_equal [{ trace: :finish, duration_in_sec: 29, started_at: "2017-08-01T22:34:21.200Z", finished_at: "2017-08-01T22:34:50.200Z", recorded_at: "2017-08-01T22:34:51.200Z" }], writer.writer
+    assert_equal [{ trace: :finish, duration_in_ms: 29000, started_at: "2017-08-01T22:34:21.200Z", finished_at: "2017-08-01T22:34:50.200Z", recorded_at: "2017-08-01T22:34:51.200Z" }], writer.writer
   end
 
   def test_masked_string


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to keep consistency in the trace data schema.

https://github.com/sider/runners/blob/ae3c69b8d627f8f198d96fc602a7b3f1aa52deae/lib/runners/schema/trace.rb#L12

https://github.com/sider/runners/blob/ae3c69b8d627f8f198d96fc602a7b3f1aa52deae/lib/runners/schema/trace.rb#L18

> Link related issues or pull requests.

See also #1914

> Check the following.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
