### PR TITLE
Add a new smoke test type for git metadata analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.40.5...HEAD)
 
 - **ESLint** Add `eslint-plugin-cypress` to pre-installed packages [#1936](https://github.com/sider/runners/pull/1936)
-- Add a new smoke test type using git metadata [#1931](https://github.com/sider/runners/pull/1931)
+
 ## 0.40.5
 
 [Full diff](https://github.com/sider/runners/compare/0.40.4...0.40.5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.40.5...HEAD)
 
 - **ESLint** Add `eslint-plugin-cypress` to pre-installed packages [#1936](https://github.com/sider/runners/pull/1936)
-
+- Add a new smoke test type using git metadata [#1931](https://github.com/sider/runners/pull/1931)
 ## 0.40.5
 
 [Full diff](https://github.com/sider/runners/compare/0.40.4...0.40.5)

--- a/test/smokes/smoke.rb
+++ b/test/smokes/smoke.rb
@@ -111,13 +111,13 @@ module Runners
       def run_test(params, out)
         command_output, _ = Dir.mktmpdir do |dir|
           if params.use_git_metadata
-            repo_dir, base, head = setup_existing_git_repository(
+            repo_dir, base, head = prepare_existing_git_repository(
                 workdir: Pathname(dir).realpath,
                 smoke_target: expectations.parent.join(params.name).realpath,
                 out: out,
                 )
           else
-            repo_dir, base, head = prepare_git_repository(
+            repo_dir, base, head = prepare_new_git_repository(
                 workdir: Pathname(dir).realpath,
                 smoke_target: expectations.parent.join(params.name).realpath,
                 out: out,
@@ -187,7 +187,7 @@ module Runners
         commands
       end
 
-      def prepare_git_repository(workdir:, smoke_target:, out:)
+      def prepare_new_git_repository(workdir:, smoke_target:, out:)
         # Create a bare repository
         bare_dir = workdir.join("bare").to_path
         sh! "git", "init", "--bare", bare_dir, out: out
@@ -213,7 +213,7 @@ module Runners
         end
       end
 
-      def setup_existing_git_repository(workdir:, smoke_target:, out:)
+      def prepare_existing_git_repository(workdir:, smoke_target:, out:)
         smoke_dir = workdir.join("smoke").to_path
         FileUtils.copy_entry smoke_target, smoke_dir
 

--- a/test/smokes/smoke.rb
+++ b/test/smokes/smoke.rb
@@ -215,7 +215,7 @@ module Runners
 
       def setup_existing_git_repository(workdir:, smoke_target:, out:)
         smoke_dir = workdir.join("smoke").to_path
-        FileUtils.copy_entry "#{smoke_target}", smoke_dir
+        FileUtils.copy_entry smoke_target, smoke_dir
 
         Dir.chdir(smoke_dir) do
           head_commit, _ = sh! "git", "rev-parse", "HEAD", out: out

--- a/test/smokes/smoke.rb
+++ b/test/smokes/smoke.rb
@@ -219,8 +219,7 @@ module Runners
 
         Dir.chdir(smoke_dir) do
           head_commit, _ = sh! "git", "rev-parse", "HEAD", out: out
-          # TODO: Ignored Steep error
-          _ = [smoke_dir, nil, head_commit.chomp]
+          [smoke_dir, nil, head_commit.chomp]
         end
       end
 

--- a/test/smokes/smoke.rb
+++ b/test/smokes/smoke.rb
@@ -215,6 +215,7 @@ module Runners
         FileUtils.copy_entry smoke_target, smoke_dir
 
         Dir.chdir(smoke_dir) do
+          FileUtils.move "gitmetadata", ".git"
           head_commit, _ = sh! "git", "rev-parse", "HEAD", out: out
           [smoke_dir, nil, head_commit.chomp]
         end
@@ -293,6 +294,8 @@ module Runners
         add_test_helper TestParams.new(name: name, pattern: build_pattern(**pattern), offline: true, use_git_metadata: false)
       end
 
+      # for runners using git metadata for their analysis.
+      # You have to place git metadata directory (.git/) as "gitmetadata" in the test case directory.
       def self.add_test_with_git_metadata(name, **pattern)
         add_test_helper TestParams.new(name: name, pattern: build_pattern(**pattern), offline: false, use_git_metadata: true)
       end

--- a/test/smokes/smoke.rb
+++ b/test/smokes/smoke.rb
@@ -110,18 +110,15 @@ module Runners
 
       def run_test(params, out)
         command_output, _ = Dir.mktmpdir do |dir|
+          repo_args = {
+              workdir: Pathname(dir).realpath,
+              smoke_target: expectations.parent.join(params.name).realpath,
+              out: out,
+          }
           if params.use_git_metadata
-            repo_dir, base, head = prepare_existing_git_repository(
-                workdir: Pathname(dir).realpath,
-                smoke_target: expectations.parent.join(params.name).realpath,
-                out: out,
-                )
+            repo_dir, base, head = prepare_existing_git_repository(**repo_args)
           else
-            repo_dir, base, head = prepare_new_git_repository(
-                workdir: Pathname(dir).realpath,
-                smoke_target: expectations.parent.join(params.name).realpath,
-                out: out,
-                )
+            repo_dir, base, head = prepare_new_git_repository(**repo_args)
           end
           cmd = command_line(params: params, repo_dir: repo_dir, base: base, head: head)
           sh!(*cmd, out: out, exception: false)

--- a/test/smokes/smoke.rb
+++ b/test/smokes/smoke.rb
@@ -111,9 +111,9 @@ module Runners
       def run_test(params, out)
         command_output, _ = Dir.mktmpdir do |dir|
           repo_args = {
-              workdir: Pathname(dir).realpath,
-              smoke_target: expectations.parent.join(params.name).realpath,
-              out: out,
+            workdir: Pathname(dir).realpath,
+            smoke_target: expectations.parent.join(params.name).realpath,
+            out: out,
           }
           if params.use_git_metadata
             repo_dir, base, head = prepare_existing_git_repository(**repo_args)


### PR DESCRIPTION
We're implementing a runner to analyze git metadata (.git/ directory). #1825 
This PR modifies smoke test module to preserve git metadata directory in smoke test cases.

In a preparation phase, the smoke test module creates a new git repo, copies target files and makes a commit for them. It fails the process if the test case directory contains `.git/` directory.

I added `setup_existing_git_repository` method to prevent the problem. This is called instead of `prepare_git_repository` method when the runner analyse git metadata. Git metadata analysis is a special test case for the runners. Thus, I added a new test types and adding test case methods: `add_test_with_git_metadata` and `add_offline_test_with_git_metadata`.


checklist before merging
- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
