### PR TITLE
Remove TODO comment from smoke.rb

### DIFF
--- a/test/smokes/smoke.rb
+++ b/test/smokes/smoke.rb
@@ -200,8 +200,7 @@ module Runners
           sh! "git", "push", out: out
           head_commit, _ = sh! "git", "rev-parse", "HEAD", out: out
 
-          # TODO: Ignored Steep error
-          _ = [bare_dir, base_commit.chomp, head_commit.chomp]
+          [bare_dir, base_commit.chomp, head_commit.chomp]
         end
       end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

`test/smokes/smoke.rb` has not been checked via Steep. See:

https://github.com/sider/runners/blob/7799dcbc49ef48416ae549eef49cf016f376b8be/Steepfile#L5

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
