### PR TITLE
[ESLint] Add `@vue/eslint-config-typescript` to pre-installed packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.40.4...HEAD)
 
+- **ESLint** Add `@vue/eslint-config-typescript` to pre-installed packages [#1934](https://github.com/sider/runners/pull/1934)
+
 ## 0.40.4
 
 [Full diff](https://github.com/sider/runners/compare/0.40.3...0.40.4)

--- a/images/eslint/package.json
+++ b/images/eslint/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "4.13.0",
     "@typescript-eslint/parser": "4.13.0",
+    "@vue/eslint-config-typescript": "7.0.0",
     "babel-eslint": "10.1.0",
     "eslint": "7.15.0",
     "eslint-config-airbnb": "18.2.1",


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

URL: <https://github.com/vuejs/eslint-config-typescript>

`@vue/eslint-config-typescript` is an official package of Vue.js and seems actively maintained.

Also, we have installed the peer dependencies of the package already:

```console
$ npm v @vue/eslint-config-typescript peerDependencies

{
  '@typescript-eslint/eslint-plugin': '^4.4.0',
  '@typescript-eslint/parser': '^4.4.0',
  eslint: '^5.0.0 || ^6.0.0 || ^7.0.0',
  'eslint-plugin-vue': '^5.2.3 || ^6.0.0 || ^7.0.0'
}
```

> Link related issues or pull requests.

None.

> Check the following.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
