### PR TITLE
[ESLint] Add `eslint-plugin-cypress` to pre-installed packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.40.5...HEAD)
 
+- **ESLint** Add `eslint-plugin-cypress` to pre-installed packages [#1936](https://github.com/sider/runners/pull/1936)
+
 ## 0.40.5
 
 [Full diff](https://github.com/sider/runners/compare/0.40.4...0.40.5)

--- a/images/eslint/package.json
+++ b/images/eslint/package.json
@@ -8,6 +8,7 @@
     "eslint-config-airbnb": "18.2.1",
     "eslint-config-prettier": "7.1.0",
     "eslint-config-react-app": "6.0.0",
+    "eslint-plugin-cypress": "2.11.2",
     "eslint-plugin-flowtype": "5.2.0",
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jest": "24.1.3",


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

URL: <https://github.com/cypress-io/eslint-plugin-cypress>

`eslint-plugin-cypress` is an official package of Cypress and seems actively maintained.
Also, the peer dependencies have no problems:

```console
$ npm v eslint-plugin-cypress peerDependencies

{ eslint: '>= 3.2.1' }
```

> Link related issues or pull requests.

None.

> Check the following.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
