### PR TITLE
Re-enable `Lint/EmptyFile` in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,3 @@ Style/MutableConstant:
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - "test/**/*_test.rb"
-
-# TODO: https://github.com/rubocop-hq/rubocop/issues/8718
-Lint/EmptyFile:
-  Enabled: false


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This issue was resolved:
https://github.com/rubocop-hq/rubocop/issues/8718

> Link related issues or pull requests.

None.

> Check the following.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
