### PR TITLE
Add `#valid?` and `#invalid?` to `Runners::Config` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.40.6...HEAD)
 
+- Make internal changes for the `Runners::Config` class [#1950](https://github.com/sider/runners/pull/1950) [#1951](https://github.com/sider/runners/pull/1951)
+
 ## 0.40.6
 
 [Full diff](https://github.com/sider/runners/compare/0.40.5...0.40.6)

--- a/lib/runners/config.rb
+++ b/lib/runners/config.rb
@@ -42,6 +42,17 @@ module Runners
     end
     alias validate content
 
+    def valid?
+      validate
+      true
+    rescue Error
+      false
+    end
+
+    def invalid?
+      !valid?
+    end
+
     def path_name
       path&.basename&.to_path || FILE_NAME
     end

--- a/sig/runners/config.rbs
+++ b/sig/runners/config.rbs
@@ -28,6 +28,10 @@ module Runners
 
     alias validate content
 
+    def valid?: () -> bool
+
+    def invalid?: () -> bool
+
     def path_name: () -> String
 
     def path_exist?: () -> bool

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -279,12 +279,12 @@ class ConfigTest < Minitest::Test
   end
 
   def test_valid
-    assert_equal true, Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "").valid?
-    assert_equal false, Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "`").valid?
+    assert Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "").valid?
+    refute Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "`").valid?
   end
 
   def test_invalid
-    assert_equal true, Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "`").invalid?
-    assert_equal false, Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "").invalid?
+    assert Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "`").invalid?
+    refute Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "").invalid?
   end
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -277,4 +277,14 @@ class ConfigTest < Minitest::Test
     assert config.exclude_branch?("features/123")
     refute config.exclude_branch?("features/")
   end
+
+  def test_valid
+    assert_equal true, Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "").valid?
+    assert_equal false, Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "`").valid?
+  end
+
+  def test_invalid
+    assert_equal true, Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "`").invalid?
+    assert_equal false, Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "").invalid?
+  end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change is for the internal API as a gem.

> Link related issues or pull requests.

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
