### PR TITLE
Improve `Runners::Config::Error` classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Updated tools:
 Misc:
 
 - Improve behavior about `Changes` class [#1955](https://github.com/sider/runners/pull/1955)
+- Improve `Runners::Config::Error` classes [#1959](https://github.com/sider/runners/pull/1959)
 
 ## 0.40.7
 

--- a/sig/runners/config.rbs
+++ b/sig/runners/config.rbs
@@ -1,15 +1,19 @@
 module Runners
   class Config
     class Error < UserError
-      attr_reader raw_content: untyped
+      attr_reader path_name: String
+      attr_reader raw_content: String
 
-      def initialize: (String, String) -> void
+      def initialize: (String, path_name: String, raw_content: String) -> void
     end
 
     class BrokenYAML < Error
     end
 
     class InvalidConfiguration < Error
+      attr_reader attribute: String
+
+      def initialize: (String, path_name: String, raw_content: String, attribute: String) -> void
     end
 
     FILE_NAME: String
@@ -21,6 +25,8 @@ module Runners
     attr_reader raw_content: String?
 
     def initialize: (path: (Pathname | String)?, raw_content: String?) -> void
+
+    def path!: () -> Pathname
 
     def raw_content!: () -> String
 

--- a/sig/runners/config.rbs
+++ b/sig/runners/config.rbs
@@ -26,8 +26,6 @@ module Runners
 
     def initialize: (path: (Pathname | String)?, raw_content: String?) -> void
 
-    def path!: () -> Pathname
-
     def raw_content!: () -> String
 
     def content: () -> Hash[Symbol, untyped]

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -111,8 +111,10 @@ class ConfigTest < Minitest::Test
     exn = assert_raises Runners::Config::InvalidConfiguration do
       Runners::Config.new(path: Pathname(FILE_NAME), raw_content: yaml).content
     end
-    assert_equal "The attribute `linter.unknown_linter` in your `sider.yml` is unsupported. Please fix and retry.", exn.message
+    assert_equal "`linter.unknown_linter` in `sider.yml` is unsupported", exn.message
+    assert_equal "sider.yml", exn.path_name
     assert_equal yaml, exn.raw_content
+    assert_equal "$.linter.unknown_linter", exn.attribute
   end
 
   def test_content_with_invalid_type_of_linter
@@ -123,8 +125,10 @@ class ConfigTest < Minitest::Test
     exn = assert_raises Runners::Config::InvalidConfiguration do
       Runners::Config.new(path: Pathname(FILE_NAME), raw_content: yaml).content
     end
-    assert_equal "The value of the attribute `linter` in your `sider.yml` is invalid. Please fix and retry.", exn.message
+    assert_equal "`linter` value in `sider.yml` is invalid", exn.message
+    assert_equal "sider.yml", exn.path_name
     assert_equal yaml, exn.raw_content
+    assert_equal "$.linter", exn.attribute
   end
 
   def test_content_with_ignore_section
@@ -156,6 +160,8 @@ class ConfigTest < Minitest::Test
       Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "@").content
     end
     assert_equal "`sider.yml` is broken at line 1 and column 1", exn.message
+    assert_equal "sider.yml", exn.path_name
+    assert_equal "@", exn.raw_content
   end
 
   def test_path_name

--- a/test/smokes/checkstyle/expectations.rb
+++ b/test/smokes/checkstyle/expectations.rb
@@ -139,7 +139,7 @@ s.add_test(
   "broken_sideci_yml",
   type: "failure",
   message:
-    "The value of the attribute `linter.checkstyle.exclude` in your `sideci.yml` is invalid. Please fix and retry.",
+    "`linter.checkstyle.exclude` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/checkstyle/expectations.rb
+++ b/test/smokes/checkstyle/expectations.rb
@@ -138,8 +138,7 @@ s.add_test(
 s.add_test(
   "broken_sideci_yml",
   type: "failure",
-  message:
-    "`linter.checkstyle.exclude` value in `sideci.yml` is invalid",
+  message: "`linter.checkstyle.exclude` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/code_sniffer/expectations.rb
+++ b/test/smokes/code_sniffer/expectations.rb
@@ -54,7 +54,7 @@ s.add_test(
   "broken_sideci_yml",
   type: "failure",
   analyzer: :_,
-  message: "The attribute `linter.code_sniffer.extension` in your `sideci.yml` is unsupported. Please fix and retry."
+  message: "`linter.code_sniffer.extension` in `sideci.yml` is unsupported"
 )
 
 s.add_test(

--- a/test/smokes/detekt/expectations.rb
+++ b/test/smokes/detekt/expectations.rb
@@ -5,7 +5,7 @@ default_version = "1.15.0"
 s.add_test(
   "with_broken_sider_yml",
   type: "failure",
-  message: "The attribute `linter.detekt.cli` in your `sider.yml` is unsupported. Please fix and retry.",
+  message: "`linter.detekt.cli` in `sider.yml` is unsupported",
   analyzer: :_
 )
 

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -163,7 +163,7 @@ s.add_test(
   "broken_sideci_yml",
   type: "failure",
   message:
-    "The value of the attribute `linter.eslint.npm_install` in your `sideci.yml` is invalid. Please fix and retry.",
+    "`linter.eslint.npm_install` in `sideci.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -162,8 +162,7 @@ s.add_test(
 s.add_test(
   "broken_sideci_yml",
   type: "failure",
-  message:
-    "`linter.eslint.npm_install` in `sideci.yml` is invalid",
+  message: "`linter.eslint.npm_install` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/flake8/expectations.rb
+++ b/test/smokes/flake8/expectations.rb
@@ -220,8 +220,7 @@ s.add_test(
 s.add_test(
   "broken_sideci_yml",
   type: "failure",
-  message:
-    "`linter.flake8.plugins` value in `sideci.yml` is invalid",
+  message: "`linter.flake8.plugins` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/flake8/expectations.rb
+++ b/test/smokes/flake8/expectations.rb
@@ -221,14 +221,14 @@ s.add_test(
   "broken_sideci_yml",
   type: "failure",
   message:
-    "The value of the attribute `linter.flake8.plugins` in your `sideci.yml` is invalid. Please fix and retry.",
+    "`linter.flake8.plugins` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 
 s.add_test(
   "python2",
   type: "failure",
-  message: "The attribute `linter.flake8.version` in your `sider.yml` is unsupported. Please fix and retry.",
+  message: "`linter.flake8.version` in `sider.yml` is unsupported",
   analyzer: :_
 )
 

--- a/test/smokes/goodcheck/expectations.rb
+++ b/test/smokes/goodcheck/expectations.rb
@@ -68,8 +68,7 @@ s.add_offline_test(
 s.add_offline_test(
   "with_invalid_ci_config",
   type: "failure",
-  message:
-    "`linter.goodcheck.config` value in `sideci.yml` is invalid",
+  message: "`linter.goodcheck.config` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/goodcheck/expectations.rb
+++ b/test/smokes/goodcheck/expectations.rb
@@ -69,7 +69,7 @@ s.add_offline_test(
   "with_invalid_ci_config",
   type: "failure",
   message:
-    "The value of the attribute `linter.goodcheck.config` in your `sideci.yml` is invalid. Please fix and retry.",
+    "`linter.goodcheck.config` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/haml_lint/expectations.rb
+++ b/test/smokes/haml_lint/expectations.rb
@@ -157,7 +157,7 @@ s.add_test(
   "broken_sideci_yml",
   type: "failure",
   message:
-    "The value of the attribute `linter.haml_lint.config` in your `sideci.yml` is invalid. Please fix and retry.",
+    "`linter.haml_lint.config` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/haml_lint/expectations.rb
+++ b/test/smokes/haml_lint/expectations.rb
@@ -156,8 +156,7 @@ s.add_test(
 s.add_test(
   "broken_sideci_yml",
   type: "failure",
-  message:
-    "`linter.haml_lint.config` value in `sideci.yml` is invalid",
+  message: "`linter.haml_lint.config` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/javasee/expectations.rb
+++ b/test/smokes/javasee/expectations.rb
@@ -51,7 +51,7 @@ s.add_test(
   "broken_sider_yml",
   type: "failure",
   analyzer: :_,
-  message: "The value of the attribute `linter.javasee.dir` in your `sider.yml` is invalid. Please fix and retry."
+  message: "`linter.javasee.dir` value in `sider.yml` is invalid"
 )
 
 s.add_test(

--- a/test/smokes/jshint/expectations.rb
+++ b/test/smokes/jshint/expectations.rb
@@ -85,7 +85,7 @@ s.add_test(
   "broken_sideci_yml",
   type: "failure",
   analyzer: :_,
-  message: "The value of the attribute `linter.jshint.config` in your `sideci.yml` is invalid. Please fix and retry."
+  message: "`linter.jshint.config` in `sideci.yml` is invalid"
 )
 
 s.add_test(

--- a/test/smokes/jshint/expectations.rb
+++ b/test/smokes/jshint/expectations.rb
@@ -85,7 +85,7 @@ s.add_test(
   "broken_sideci_yml",
   type: "failure",
   analyzer: :_,
-  message: "`linter.jshint.config` in `sideci.yml` is invalid"
+  message: "`linter.jshint.config` value in `sideci.yml` is invalid"
 )
 
 s.add_test(

--- a/test/smokes/ktlint/expectations.rb
+++ b/test/smokes/ktlint/expectations.rb
@@ -99,5 +99,5 @@ s.add_test(
   "broken_sider_yml",
   type: "failure",
   analyzer: :_,
-  message: "The attribute `linter.ktlint.cli` in your `sider.yml` is unsupported. Please fix and retry."
+  message: "`linter.ktlint.cli` in `sider.yml` is unsupported"
 )

--- a/test/smokes/misspell/expectations.rb
+++ b/test/smokes/misspell/expectations.rb
@@ -262,7 +262,7 @@ s.add_offline_test(
   "broken_sideci_yml",
   type: "failure",
   message:
-    "The value of the attribute `linter.misspell.locale` in your `sideci.yml` is invalid. Please fix and retry.",
+    "`linter.misspell.locale` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/misspell/expectations.rb
+++ b/test/smokes/misspell/expectations.rb
@@ -261,8 +261,7 @@ s.add_offline_test(
 s.add_offline_test(
   "broken_sideci_yml",
   type: "failure",
-  message:
-    "`linter.misspell.locale` value in `sideci.yml` is invalid",
+  message: "`linter.misspell.locale` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/phinder/expectations.rb
+++ b/test/smokes/phinder/expectations.rb
@@ -127,7 +127,7 @@ s.add_test(
 s.add_test(
   "invalid_runner_config",
   type: "failure",
-  message: "The attribute `linter.phinder.format` in your `sideci.yml` is unsupported. Please fix and retry.",
+  message: "`linter.phinder.format` in `sideci.yml` is unsupported",
   analyzer: :_
 )
 

--- a/test/smokes/phpmd/expectations.rb
+++ b/test/smokes/phpmd/expectations.rb
@@ -125,7 +125,7 @@ s.add_test(
   "broken_sideci_yml",
   type: "failure",
   message:
-    "The value of the attribute `linter.phpmd.minimumpriority` in your `sideci.yml` is invalid. Please fix and retry.",
+    "`linter.phpmd.minimumpriority` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/pmd_cpd/expectations.rb
+++ b/test/smokes/pmd_cpd/expectations.rb
@@ -131,7 +131,7 @@ s.add_test(
 s.add_test(
   "broken_sider_yml",
   type: "failure",
-  message: "The attribute `linter.pmd_cpd.files-path` in your `sider.yml` is unsupported. Please fix and retry.",
+  message: "`linter.pmd_cpd.files-path` in `sider.yml` is unsupported",
   analyzer: :_
 )
 
@@ -1701,7 +1701,7 @@ s.add_test(
 s.add_test(
   "option_multiple_languages_invalid",
   type: "failure",
-  message: "The value of the attribute `linter.pmd_cpd.language` in your `sider.yml` is invalid. Please fix and retry.",
+  message: "`linter.pmd_cpd.language` value in your `sider.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/pmd_cpd/expectations.rb
+++ b/test/smokes/pmd_cpd/expectations.rb
@@ -1701,7 +1701,7 @@ s.add_test(
 s.add_test(
   "option_multiple_languages_invalid",
   type: "failure",
-  message: "`linter.pmd_cpd.language` value in your `sider.yml` is invalid",
+  message: "`linter.pmd_cpd.language` value in `sider.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/pmd_java/expectations.rb
+++ b/test/smokes/pmd_java/expectations.rb
@@ -255,8 +255,7 @@ s.add_test(
   "broken_sideci_yml",
   type: "failure",
   analyzer: :_,
-  message:
-    "`linter.pmd_java.min_priority` value in `sideci.yml` is invalid"
+  message: "`linter.pmd_java.min_priority` value in `sideci.yml` is invalid"
 )
 
 s.add_test(

--- a/test/smokes/pmd_java/expectations.rb
+++ b/test/smokes/pmd_java/expectations.rb
@@ -256,7 +256,7 @@ s.add_test(
   type: "failure",
   analyzer: :_,
   message:
-    "The value of the attribute `linter.pmd_java.min_priority` in your `sideci.yml` is invalid. Please fix and retry."
+    "`linter.pmd_java.min_priority` value in `sideci.yml` is invalid"
 )
 
 s.add_test(

--- a/test/smokes/rails_best_practices/expectations.rb
+++ b/test/smokes/rails_best_practices/expectations.rb
@@ -59,7 +59,7 @@ s.add_test(
   type: "failure",
   analyzer: :_,
   message:
-    "The value of the attribute `linter.rails_best_practices.exclude` in your `sideci.yml` is invalid. Please fix and retry."
+    "`linter.rails_best_practices.exclude` value in `sideci.yml` is invalid"
 )
 
 s.add_test(

--- a/test/smokes/rails_best_practices/expectations.rb
+++ b/test/smokes/rails_best_practices/expectations.rb
@@ -58,8 +58,7 @@ s.add_test(
   "broken_sideci_yml",
   type: "failure",
   analyzer: :_,
-  message:
-    "`linter.rails_best_practices.exclude` value in `sideci.yml` is invalid"
+  message: "`linter.rails_best_practices.exclude` value in `sideci.yml` is invalid"
 )
 
 s.add_test(

--- a/test/smokes/remark_lint/expectations.rb
+++ b/test/smokes/remark_lint/expectations.rb
@@ -205,7 +205,7 @@ s.add_test(
   "broken_sider_yml",
   type: "failure",
   message:
-    "The value of the attribute `linter.remark_lint.rc-path` in your `sider.yml` is invalid. Please fix and retry.",
+    "`linter.remark_lint.rc-path` value in `sider.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/remark_lint/expectations.rb
+++ b/test/smokes/remark_lint/expectations.rb
@@ -204,8 +204,7 @@ s.add_test(
 s.add_test(
   "broken_sider_yml",
   type: "failure",
-  message:
-    "`linter.remark_lint.rc-path` value in `sider.yml` is invalid",
+  message: "`linter.remark_lint.rc-path` value in `sider.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -219,7 +219,7 @@ s.add_test(
   type: "failure",
   analyzer: :_,
   message:
-    "The value of the attribute `linter.rubocop.gems[0]` in your `sideci.yml` is invalid. Please fix and retry."
+    "`linter.rubocop.gems[0]` value in `sideci.yml` is invalid"
 )
 
 s.add_test(

--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -218,8 +218,7 @@ s.add_test(
   "broken_sideci_yml",
   type: "failure",
   analyzer: :_,
-  message:
-    "`linter.rubocop.gems[0]` value in `sideci.yml` is invalid"
+  message: "`linter.rubocop.gems[0]` value in `sideci.yml` is invalid"
 )
 
 s.add_test(

--- a/test/smokes/scss_lint/expectations.rb
+++ b/test/smokes/scss_lint/expectations.rb
@@ -140,7 +140,6 @@ s.add_test(
 s.add_test(
   "broken_sideci_yml",
   type: "failure",
-  message:
-    "`linter.scss_lint.config` in `sideci.yml` is invalid",
+  message: "`linter.scss_lint.config` value in `sideci.yml` is invalid",
   analyzer: :_
 )

--- a/test/smokes/scss_lint/expectations.rb
+++ b/test/smokes/scss_lint/expectations.rb
@@ -141,6 +141,6 @@ s.add_test(
   "broken_sideci_yml",
   type: "failure",
   message:
-    "The value of the attribute `linter.scss_lint.config` in your `sideci.yml` is invalid. Please fix and retry.",
+    "`linter.scss_lint.config` in `sideci.yml` is invalid",
   analyzer: :_
 )

--- a/test/smokes/stylelint/expectations.rb
+++ b/test/smokes/stylelint/expectations.rb
@@ -597,8 +597,7 @@ s.add_test(
   "broken_sideci_yml",
   analyzer: :_,
   type: "failure",
-  message:
-    "`linter.stylelint.options.ignore-path` value in `sideci.yml` is invalid"
+  message: "`linter.stylelint.options.ignore-path` value in `sideci.yml` is invalid"
 )
 
 s.add_test(

--- a/test/smokes/stylelint/expectations.rb
+++ b/test/smokes/stylelint/expectations.rb
@@ -598,7 +598,7 @@ s.add_test(
   analyzer: :_,
   type: "failure",
   message:
-    "The value of the attribute `linter.stylelint.options.ignore-path` in your `sideci.yml` is invalid. Please fix and retry."
+    "`linter.stylelint.options.ignore-path` value in `sideci.yml` is invalid"
 )
 
 s.add_test(

--- a/test/smokes/swiftlint/expectations.rb
+++ b/test/smokes/swiftlint/expectations.rb
@@ -176,8 +176,7 @@ s.add_test(
 s.add_test(
   "broken_sideci_yml",
   type: "failure",
-  message:
-    "`linter.swiftlint.lenient` value in `sideci.yml` is invalid",
+  message: "`linter.swiftlint.lenient` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/swiftlint/expectations.rb
+++ b/test/smokes/swiftlint/expectations.rb
@@ -177,7 +177,7 @@ s.add_test(
   "broken_sideci_yml",
   type: "failure",
   message:
-    "The value of the attribute `linter.swiftlint.lenient` in your `sideci.yml` is invalid. Please fix and retry.",
+    "`linter.swiftlint.lenient` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/tslint/expectations.rb
+++ b/test/smokes/tslint/expectations.rb
@@ -208,7 +208,7 @@ s.add_test(
 s.add_test(
   "broken_sideci_yml",
   type: "failure",
-  message: "The value of the attribute `linter.tslint.config` in your `sideci.yml` is invalid. Please fix and retry.",
+  message: "`linter.tslint.config` in `sideci.yml` is invalid",
   analyzer: :_
 )
 

--- a/test/smokes/tslint/expectations.rb
+++ b/test/smokes/tslint/expectations.rb
@@ -208,7 +208,7 @@ s.add_test(
 s.add_test(
   "broken_sideci_yml",
   type: "failure",
-  message: "`linter.tslint.config` in `sideci.yml` is invalid",
+  message: "`linter.tslint.config` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- Make the error messages simpler and more consistent.
  (because they will be shown on the Sider UI in a unified manner)
- Add attributes to the classes: `path_name` and `attribute`.
  They should improve the error expression on the UI.

> Link related issues or pull requests.

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
