### PR TITLE
Add attributes to `Runners::Config::BrokenYAML` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Updated tools:
 Misc:
 
 - Improve behavior about `Changes` class [#1955](https://github.com/sider/runners/pull/1955)
-- Improve `Runners::Config::Error` classes [#1959](https://github.com/sider/runners/pull/1959)
+- Improve `Runners::Config::Error` classes [#1959](https://github.com/sider/runners/pull/1959) [#1961](https://github.com/sider/runners/pull/1961)
 
 ## 0.40.7
 

--- a/lib/runners/config.rb
+++ b/lib/runners/config.rb
@@ -11,7 +11,16 @@ module Runners
       end
     end
 
-    class BrokenYAML < Error; end
+    class BrokenYAML < Error
+      attr_reader :line
+      attr_reader :column
+
+      def initialize(message, path_name:, raw_content:, line:, column:)
+        super(message, path_name: path_name, raw_content: raw_content)
+        @line = line
+        @column = column
+      end
+    end
 
     class InvalidConfiguration < Error
       attr_reader :attribute
@@ -121,7 +130,7 @@ module Runners
       rescue Psych::SyntaxError => exn
         raise BrokenYAML.new(
           "`#{exn.file}` is broken at line #{exn.line} and column #{exn.column}",
-          path_name: path_name, raw_content: yaml,
+          path_name: path_name, raw_content: yaml, line: exn.line, column: exn.column,
         )
       end
     end

--- a/sig/runners/config.rbs
+++ b/sig/runners/config.rbs
@@ -8,6 +8,10 @@ module Runners
     end
 
     class BrokenYAML < Error
+      attr_reader line: Integer
+      attr_reader column: Integer
+
+      def initialize: (String, path_name: String, raw_content: String, line: Integer, column: Integer) -> void
     end
 
     class InvalidConfiguration < Error

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -157,11 +157,13 @@ class ConfigTest < Minitest::Test
 
   def test_content_with_broken_yaml
     exn = assert_raises Runners::Config::BrokenYAML do
-      Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "@").content
+      Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "\n  @\n").content
     end
-    assert_equal "`sider.yml` is broken at line 1 and column 1", exn.message
+    assert_equal "`sider.yml` is broken at line 2 and column 3", exn.message
     assert_equal "sider.yml", exn.path_name
-    assert_equal "@", exn.raw_content
+    assert_equal "\n  @\n", exn.raw_content
+    assert_equal 2, exn.line
+    assert_equal 3, exn.column
   end
 
   def test_path_name


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The new attributes (`line` and `column`) will be used by the `runners` gem client.

> Link related issues or pull requests.

Related to #1959

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
