### PR TITLE
Add `Runners::Config::BrokenYAML#problem` and more detailed message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Updated tools:
 Misc:
 
 - Improve behavior about `Changes` class [#1955](https://github.com/sider/runners/pull/1955)
-- Improve `Runners::Config::Error` classes [#1959](https://github.com/sider/runners/pull/1959) [#1961](https://github.com/sider/runners/pull/1961)
+- Improve `Runners::Config::Error` classes [#1959](https://github.com/sider/runners/pull/1959) [#1961](https://github.com/sider/runners/pull/1961) [#1972](https://github.com/sider/runners/pull/1972)
 
 ## 0.40.7
 

--- a/lib/runners/config.rb
+++ b/lib/runners/config.rb
@@ -14,11 +14,13 @@ module Runners
     class BrokenYAML < Error
       attr_reader :line
       attr_reader :column
+      attr_reader :problem
 
-      def initialize(message, path_name:, raw_content:, line:, column:)
+      def initialize(message, path_name:, raw_content:, line:, column:, problem:)
         super(message, path_name: path_name, raw_content: raw_content)
         @line = line
         @column = column
+        @problem = problem
       end
     end
 
@@ -129,8 +131,8 @@ module Runners
         YAML.safe_load(yaml, symbolize_names: true, filename: path_name)
       rescue Psych::SyntaxError => exn
         raise BrokenYAML.new(
-          "`#{exn.file}` is broken at line #{exn.line} and column #{exn.column}",
-          path_name: path_name, raw_content: yaml, line: exn.line, column: exn.column,
+          "`#{exn.file}` is broken at line #{exn.line} and column #{exn.column} (#{exn.problem})",
+          path_name: path_name, raw_content: yaml, line: exn.line, column: exn.column, problem: exn.problem,
         )
       end
     end

--- a/sig/runners/config.rbs
+++ b/sig/runners/config.rbs
@@ -10,8 +10,9 @@ module Runners
     class BrokenYAML < Error
       attr_reader line: Integer
       attr_reader column: Integer
+      attr_reader problem: String
 
-      def initialize: (String, path_name: String, raw_content: String, line: Integer, column: Integer) -> void
+      def initialize: (String, path_name: String, raw_content: String, line: Integer, column: Integer, problem: String) -> void
     end
 
     class InvalidConfiguration < Error

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -159,11 +159,12 @@ class ConfigTest < Minitest::Test
     exn = assert_raises Runners::Config::BrokenYAML do
       Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "\n  @\n").content
     end
-    assert_equal "`sider.yml` is broken at line 2 and column 3", exn.message
+    assert_equal "`sider.yml` is broken at line 2 and column 3 (found character that cannot start any token)", exn.message
     assert_equal "sider.yml", exn.path_name
     assert_equal "\n  @\n", exn.raw_content
     assert_equal 2, exn.line
     assert_equal 3, exn.column
+    assert_equal "found character that cannot start any token", exn.problem
   end
 
   def test_path_name

--- a/test/harness_test.rb
+++ b/test/harness_test.rb
@@ -138,7 +138,7 @@ class HarnessTest < Minitest::Test
       (harness.working_dir / "sider.yml").write('1: 1:')
       result = harness.run
       assert_instance_of Results::Failure, result
-      assert_equal "`sider.yml` is broken at line 1 and column 5", result.message
+      assert_equal "`sider.yml` is broken at line 1 and column 5 (mapping values are not allowed in this context)", result.message
     end
   end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change adds a new method `Runners::Config::BrokenYAML#problem` and makes the exception message more detailed.
This improvement of the error message about incorrect YAML should be helpful for users.

> Link related issues or pull requests.

Related to #1959, #1961

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
