### PR TITLE
Bump bundler from 2.2.6 to 2.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 Updated environments:
 
 - **devon_rex** 2.30.1 -> master [#1954](https://github.com/sider/runners/pull/1954)
-- **Bundler** 2.2.3 -> 2.2.6 [#1960](https://github.com/sider/runners/pull/1960)
+- **Bundler** 2.2.3 -> 2.2.7 [#1960](https://github.com/sider/runners/pull/1960) [#1975](https://github.com/sider/runners/pull/1975)
 
 Updated tools:
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,4 +136,4 @@ DEPENDENCIES
   unification_assertion
 
 BUNDLED WITH
-   2.2.6
+   2.2.7


### PR DESCRIPTION
Via `bundle update --bundler`.

> Explain a summary, purpose, or background for this change.

Via `bundle update --bundler`. This update aims to fix the failed CI on HEAD.

> Link related issues or pull requests.

See <https://github.com/sider/devon_rex/pull/398>.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
