### PR TITLE
Allow `Pathname` arguments for `Runners::Shell` methods

### DIFF
--- a/lib/runners/shell.rb
+++ b/lib/runners/shell.rb
@@ -95,23 +95,19 @@ module Runners
       end or raise "Unexpected result (tries=#{tries}): #{command} #{args.join(' ')}"
     end
 
-    # TODO: After migrating to Steep (>= 0.14), use keyword arguments like `trace_stdout: true, ...`
-    def capture3_trace(command, *args, **options)
-      # @type var options: untyped
-      trace_stdout = options.fetch(:trace_stdout, true)
-      trace_stderr = options.fetch(:trace_stderr, true)
-      trace_command_line = options.fetch(:trace_command_line, true)
-      raise_on_failure = options.fetch(:raise_on_failure, false)
-      chdir = options[:chdir] || current_dir
-      is_success = options.fetch(:is_success) { ->(status) { status.success? } }
-      stdin_data = options.fetch(:stdin_data, nil)
-      merge_output = options.fetch(:merge_output, false)
+    def capture3_trace(command, *args,
+                       trace_stdout: true, trace_stderr: true, trace_command_line: true,
+                       raise_on_failure: false, chdir: nil,
+                       is_success: ->(status) { status.success? },
+                       stdin_data: nil, merge_output: false)
+      chdir ||= current_dir
+      new_args = args.map { |arg| arg.is_a?(Pathname) ? arg.to_path : arg }
+      command_line = [command] + new_args
 
-      command_line = [command] + args
       trace_writer.command_line(command_line) if trace_command_line
 
       method = merge_output ? :capture2e : :capture3
-      Open3.public_send(method, env_hash, command, *args, chdir: chdir.to_s, stdin_data: stdin_data).then do |stdout_str, stderr_str, status|
+      Open3.public_send(method, env_hash, command, *new_args, chdir: chdir, stdin_data: stdin_data).then do |stdout_str, stderr_str, status|
         if merge_output
           status = stderr_str
           stderr_str = ""
@@ -138,7 +134,7 @@ module Runners
                                 stdout_str: trace_writer.filter.mask(stdout_str),
                                 stderr_str: trace_writer.filter.mask(stderr_str),
                                 status: status,
-                                dir: current_dir)
+                                dir: chdir)
           end
         end
 

--- a/lib/runners/shell.rb
+++ b/lib/runners/shell.rb
@@ -107,7 +107,7 @@ module Runners
       trace_writer.command_line(command_line) if trace_command_line
 
       method = merge_output ? :capture2e : :capture3
-      Open3.public_send(method, env_hash, command, *new_args, chdir: chdir&.to_path, stdin_data: stdin_data).then do |stdout_str, stderr_str, status|
+      Open3.public_send(method, env_hash, command, *new_args, chdir: chdir, stdin_data: stdin_data).then do |stdout_str, stderr_str, status|
         if merge_output
           status = stderr_str
           stderr_str = ""

--- a/lib/runners/shell.rb
+++ b/lib/runners/shell.rb
@@ -107,7 +107,7 @@ module Runners
       trace_writer.command_line(command_line) if trace_command_line
 
       method = merge_output ? :capture2e : :capture3
-      Open3.public_send(method, env_hash, command, *new_args, chdir: chdir, stdin_data: stdin_data).then do |stdout_str, stderr_str, status|
+      Open3.public_send(method, env_hash, command, *new_args, chdir: chdir&.to_path, stdin_data: stdin_data).then do |stdout_str, stderr_str, status|
         if merge_output
           status = stderr_str
           stderr_str = ""

--- a/sig/runners/processor.rbs
+++ b/sig/runners/processor.rbs
@@ -27,10 +27,10 @@ module Runners
     def chdir: [X] (Pathname) { (Pathname) -> X } -> X
     def push_env_hash: [X] (Hash[String, String?]) { () -> X } -> X
     def env_hash: () -> Hash[String, String?]
-    def capture3: (String, *String, **untyped) -> [String, String, Process::Status]
-    def capture3!: (String, *String, **untyped) -> [String, String]
-    def capture3_with_retry!: (String, *String, ?tries: Integer, ?sleep: ^(Numeric) -> Numeric) -> [String, String]
-    def capture3_trace: (String, *String, **untyped) -> [String, String, Process::Status]
+    def capture3: (String, *(String | Pathname), **untyped) -> [String, String, Process::Status]
+    def capture3!: (String, *(String | Pathname), **untyped) -> [String, String]
+    def capture3_with_retry!: (String, *(String | Pathname), ?tries: Integer, ?sleep: ^(Numeric) -> Numeric) -> [String, String]
+    def capture3_trace: (String, *(String | Pathname), **untyped) -> [String, String, Process::Status]
 
     def relative_path: (String | Pathname, ?from: Pathname) -> Pathname
 

--- a/sig/runners/processor.rbs
+++ b/sig/runners/processor.rbs
@@ -27,10 +27,10 @@ module Runners
     def chdir: [X] (Pathname) { (Pathname) -> X } -> X
     def push_env_hash: [X] (Hash[String, String?]) { () -> X } -> X
     def env_hash: () -> Hash[String, String?]
-    def capture3: (String, *(String | Pathname), **untyped) -> [String, String, Process::Status]
-    def capture3!: (String, *(String | Pathname), **untyped) -> [String, String]
-    def capture3_with_retry!: (String, *(String | Pathname), ?tries: Integer, ?sleep: ^(Numeric) -> Numeric) -> [String, String]
-    def capture3_trace: (String, *(String | Pathname), **untyped) -> [String, String, Process::Status]
+    def capture3: (String, *Shell::command_argument, **untyped) -> [String, String, Process::Status]
+    def capture3!: (String, *Shell::command_argument, **untyped) -> [String, String]
+    def capture3_with_retry!: (String, *Shell::command_argument, ?tries: Integer, ?sleep: ^(Numeric) -> Numeric) -> [String, String]
+    def capture3_trace: (String, *Shell::command_argument, **untyped) -> [String, String, Process::Status]
 
     def relative_path: (String | Pathname, ?from: Pathname) -> Pathname
 

--- a/sig/runners/shell.rbs
+++ b/sig/runners/shell.rbs
@@ -1,5 +1,7 @@
 module Runners
   class Shell
+    type command_argument = String | Pathname
+
     class ExecError < SystemError
       attr_reader type: Symbol
       attr_reader args: Array[String]
@@ -34,15 +36,15 @@ module Runners
 
     def env_hash: () -> Hash[String, String?]
 
-    def capture3: (String, *(String | Pathname), **untyped) -> [String, String, Process::Status]
+    def capture3: (String, *command_argument, **untyped) -> [String, String, Process::Status]
 
-    def capture3!: (String, *(String | Pathname), **untyped) -> [String, String]
+    def capture3!: (String, *command_argument, **untyped) -> [String, String]
 
-    def capture3_with_retry!: (String, *(String | Pathname),
+    def capture3_with_retry!: (String, *command_argument,
                                ?tries: Integer,
                                ?sleep: ^(Numeric) -> Numeric) -> [String, String]
 
-    def capture3_trace: (String, *(String | Pathname),
+    def capture3_trace: (String, *command_argument,
                          ?trace_stdout: boolish,
                          ?trace_stderr: boolish,
                          ?trace_command_line: boolish,

--- a/sig/runners/shell.rbs
+++ b/sig/runners/shell.rbs
@@ -29,11 +29,27 @@ module Runners
                      ?env_hash: Hash[String, String?]) -> void
 
     def chdir: [X] (Pathname) { (Pathname) -> X } -> X
+
     def push_env_hash: [X] (Hash[String, String?]) { () -> X } -> X
+
     def env_hash: () -> Hash[String, String?]
-    def capture3: (String, *String, **untyped) -> [String, String, Process::Status]
-    def capture3!: (String, *String, **untyped) -> [String, String]
-    def capture3_with_retry!: (String, *String, ?tries: Integer, ?sleep: ^(Numeric) -> Numeric) -> [String, String]
-    def capture3_trace: (String, *String, **untyped) -> [String, String, Process::Status]
+
+    def capture3: (String, *(String | Pathname), **untyped) -> [String, String, Process::Status]
+
+    def capture3!: (String, *(String | Pathname), **untyped) -> [String, String]
+
+    def capture3_with_retry!: (String, *(String | Pathname),
+                               ?tries: Integer,
+                               ?sleep: ^(Numeric) -> Numeric) -> [String, String]
+
+    def capture3_trace: (String, *(String | Pathname),
+                         ?trace_stdout: boolish,
+                         ?trace_stderr: boolish,
+                         ?trace_command_line: boolish,
+                         ?raise_on_failure: boolish,
+                         ?chdir: Pathname?,
+                         ?is_success: ^(Process::Status) -> boolish,
+                         ?stdin_data: String?,
+                         ?merge_output: boolish) -> [String, String, Process::Status]
   end
 end

--- a/test/harness_test.rb
+++ b/test/harness_test.rb
@@ -224,7 +224,7 @@ class HarnessTest < Minitest::Test
       mock_capture3.expect :call, ["", "", mock_status], [
         { "RUBYOPT" => nil, "GIT_SSH_COMMAND" => "ssh -F '#{git_ssh_path}'" },
         "ls",
-        chdir: working_dir.to_path, stdin_data: nil
+        chdir: working_dir, stdin_data: nil
       ]
 
       Open3.stub :capture3, mock_capture3 do


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change allows `Pathname` as command-line arguments for the `Runners::Shell` methods like `#capture3`.
This should make the code more flexible and simpler.

> Link related issues or pull requests.

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
