### PR TITLE
Skip `Runners::Processor::RuboCopTest#test_build_cop_links` temporarily

### DIFF
--- a/test/processor/rubocop_test.rb
+++ b/test/processor/rubocop_test.rb
@@ -72,6 +72,7 @@ class Runners::Processor::RuboCopTest < Minitest::Test
       assert_links.call %w[https://docs.rubocop.org/rubocop-packaging/cops_packaging.html#packagingbundlersetupintests], "Packaging/BundlerSetupInTests"
 
       # extensions...
+      skip "<https://www.rubydoc.info> is unavailable now. Please remove this skip if the website will recover."
       assert_links.call %w[
         https://www.rubydoc.info/gems/chefstyle/RuboCop/Cop/Chef/Ruby/GemspecRequireRubygems
         https://github.com/chef/chefstyle


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

<https://www.rubydoc.info> is unavailable now.

```
Runners::Processor::RuboCopTest#test_build_cop_links [test/processor/rubocop_test.rb:39]:
https://www.rubydoc.info/gems/chefstyle/RuboCop/Cop/Chef/Ruby/GemspecRequireRubygems.
--- expected
+++ actual
@@ -1 +1,3 @@
-"200"
+# encoding: ASCII-8BIT
+#    valid: true
+"503"
```

> Link related issues or pull requests.

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
