### PR TITLE
Suppress `git init` verbose output on smoke tests

### DIFF
--- a/test/smoke.rb
+++ b/test/smoke.rb
@@ -177,7 +177,7 @@ module Runners
       def prepare_new_git_repository(workdir:, smoke_target:, out:)
         # Create a bare repository
         bare_dir = workdir.join("bare").to_path
-        sh! "git", "init", "--bare", bare_dir, out: out
+        sh! "git", "init", "--initial-branch=main", "--bare", bare_dir, out: out
 
         # Push a smoke test project to the bare directory
         smoke_dir = workdir.join("smoke").to_path


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

In some environments, the following message is output on running `git init`. This is verbose.

```
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint: 
hint: 	git config --global init.defaultBranch <name>
hint: 
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint: 
hint: 	git branch -m <name>
```

> Link related issues or pull requests.

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
