### PR TITLE
Suppress `git commit` verbose message on smoke tests

### DIFF
--- a/test/smoke.rb
+++ b/test/smoke.rb
@@ -191,7 +191,7 @@ module Runners
 
           FileUtils.copy_entry "#{smoke_target}/.", smoke_dir
           sh! "git", "add", ".", out: out
-          sh! "git", "commit", "-m", "add all test files", out: out
+          sh! "git", "commit", "--quiet", "-m", "add all test files", out: out
 
           sh! "git", "push", out: out
           head_commit, _ = sh! "git", "rev-parse", "HEAD", out: out


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

When many files are used on a smoke test, a `git commit` success message is too long. This is verbose.

> Link related issues or pull requests.

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
