### PR TITLE
Suppress verbose message of `git init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.41.0...HEAD)
 
+- Suppress verbose message of `git init` [#2006](https://github.com/sider/runners/pull/2006)
+
 ## 0.41.0
 
 [Full diff](https://github.com/sider/runners/compare/0.40.7...0.41.0)

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -21,7 +21,7 @@ module Runners
     end
 
     def prepare_head_source
-      shell.capture3!("git", "init")
+      shell.capture3!("git", "init", "--initial-branch=main")
       shell.capture3!("git", "config", "gc.auto", "0")
       shell.capture3!("git", "config", "advice.detachedHead", "false")
       shell.capture3!("git", "config", "core.quotePath", "false")

--- a/test/workspace/git_test.rb
+++ b/test/workspace/git_test.rb
@@ -5,6 +5,8 @@ class WorkspaceGitTest < Minitest::Test
 
   GitBlameInfo = Runners::GitBlameInfo
 
+  private
+
   def with_workspace(**params)
     super(**params) do |workspace|
       workspace.stub :try_count, 1 do
@@ -14,6 +16,8 @@ class WorkspaceGitTest < Minitest::Test
       end
     end
   end
+
+  public
 
   def test_instance_class
     with_workspace do |workspace|
@@ -40,6 +44,9 @@ class WorkspaceGitTest < Minitest::Test
       assert_path_exists dest / "README.md"
       assert_path_exists dest / ".git"
       assert_path_exists dest / ".git" / "hooks" / "post-checkout"
+
+      # Suppress hint via `git init`
+      refute workspace.trace_writer.writer.find { _1[:string]&.include?("git config --global init.defaultBranch <name>") }
     end
   end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to suppress the following verbose message via the `git init` command.
This message consumes the log unnecessarily.

```
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint: 	git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint: 	git branch -m <name>
```

> Link related issues or pull requests.

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
