### PR TITLE
Use `Processor#analyzer_github` to reduce duplication

### DIFF
--- a/lib/runners/processor/hadolint.rb
+++ b/lib/runners/processor/hadolint.rb
@@ -100,9 +100,9 @@ module Runners
 
     def link_to_wiki(id)
       if id.start_with? "DL"
-        ["https://github.com/hadolint/hadolint/wiki/#{id}"]
+        ["#{analyzer_github}/wiki/#{id}"]
       else
-        ["https://github.com/koalaman/shellcheck/wiki/#{id}"]
+        ["#{analyzers.github(:shellcheck)}/wiki/#{id}"]
       end
     end
   end

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -157,7 +157,7 @@ module Runners
       # NOTE: Syntax errors are produced by HAML itself, not HAML-Lint.
       return [] if issue_id == "Syntax"
 
-      ["https://github.com/sds/haml-lint/blob/v#{analyzer_version}/lib/haml_lint/linter##{issue_id.downcase}"]
+      ["#{analyzer_github}/blob/v#{analyzer_version}/lib/haml_lint/linter##{issue_id.downcase}"]
     end
 
     # NOTE: HAML-Lint exits successfully even if RuboCop fails.

--- a/lib/runners/processor/scss_lint.rb
+++ b/lib/runners/processor/scss_lint.rb
@@ -32,7 +32,7 @@ module Runners
     def setup
       add_warning_for_deprecated_linter(
         alternative: analyzers.name(:stylelint),
-        ref: "https://github.com/sds/scss-lint/blob/master/README.md#notice-consider-other-tools-before-adopting-scss-lint",
+        ref: "#{analyzer_github}#readme",
       )
 
       yield

--- a/lib/runners/processor/shellcheck.rb
+++ b/lib/runners/processor/shellcheck.rb
@@ -140,7 +140,7 @@ module Runners
             end_column: comment[:endColumn],
           ),
           message: comment[:message],
-          links: ["https://github.com/koalaman/shellcheck/wiki/#{id}"],
+          links: ["#{analyzer_github}/wiki/#{id}"],
           object: {
             code: comment[:code],
             severity: comment[:level],

--- a/lib/runners/processor/stylelint.rb
+++ b/lib/runners/processor/stylelint.rb
@@ -180,7 +180,7 @@ module Runners
               .filter(&:directory?)
               .each_with_object({}) do |dir, hash|
                 rule = dir.basename.to_s
-                hash[rule] = "https://github.com/stylelint/stylelint/tree/#{analyzer_version}/lib/rules/#{rule}"
+                hash[rule] = "#{analyzer_github}/tree/#{analyzer_version}/lib/rules/#{rule}"
               end
           else
             {}

--- a/lib/runners/processor/tslint.rb
+++ b/lib/runners/processor/tslint.rb
@@ -35,7 +35,7 @@ module Runners
 
     def setup
       add_warning_for_deprecated_linter(alternative: "ESLint",
-                                        ref: "https://github.com/palantir/tslint/issues/4534",
+                                        ref: "#{analyzer_github}/issues/4534",
                                         deadline: Time.new(2020, 12, 1))
 
       begin

--- a/test/smokes/scss_lint/expectations.rb
+++ b/test/smokes/scss_lint/expectations.rb
@@ -56,7 +56,7 @@ s.add_test(
       message: <<~MSG.strip,
         DEPRECATION WARNING!!!
         The support for SCSS-Lint is deprecated and will be removed in the near future.
-        Please migrate to stylelint as an alternative. See https://github.com/sds/scss-lint/blob/master/README.md#notice-consider-other-tools-before-adopting-scss-lint
+        Please migrate to stylelint as an alternative. See https://github.com/sds/scss-lint#readme
       MSG
       file: "sider.yml"
     }


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The `Runners::Processor#analyzer_github` method can reduce duplication in some `Processor` classes.

> Link related issues or pull requests.

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
