### PR TITLE
Verify gem installation in Dockerfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.41.1...HEAD)
 
+- Verify gem installation in Dockerfiles [#2010](https://github.com/sider/runners/pull/2010)
+
 ## 0.41.1
 
 [Full diff](https://github.com/sider/runners/compare/0.41.0...0.41.1)

--- a/images/Dockerfile.ruby.erb
+++ b/images/Dockerfile.ruby.erb
@@ -9,4 +9,4 @@ RUN cd ${RUNNER_USER_HOME} && \
     bundle config unset --local system && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf <%= analyzer %> && \
-    gem info <%= analyzer %>
+    gem info --local --exact --quiet <%= analyzer %> | grep <%= analyzer %>

--- a/images/brakeman/Dockerfile
+++ b/images/brakeman/Dockerfile
@@ -32,7 +32,7 @@ RUN cd ${RUNNER_USER_HOME} && \
     bundle config unset --local system && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf brakeman && \
-    gem info brakeman
+    gem info --local --exact --quiet brakeman | grep brakeman
 
 # Copy the main source code
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} exe ${RUNNERS_DIR}/exe

--- a/images/goodcheck/Dockerfile
+++ b/images/goodcheck/Dockerfile
@@ -32,7 +32,7 @@ RUN cd ${RUNNER_USER_HOME} && \
     bundle config unset --local system && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf goodcheck && \
-    gem info goodcheck
+    gem info --local --exact --quiet goodcheck | grep goodcheck
 
 # Copy the main source code
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} exe ${RUNNERS_DIR}/exe

--- a/images/haml_lint/Dockerfile
+++ b/images/haml_lint/Dockerfile
@@ -32,7 +32,7 @@ RUN cd ${RUNNER_USER_HOME} && \
     bundle config unset --local system && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf haml_lint && \
-    gem info haml_lint
+    gem info --local --exact --quiet haml_lint | grep haml_lint
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/haml_lint/default_rubocop.yml ${RUNNER_USER_HOME}/
 

--- a/images/querly/Dockerfile
+++ b/images/querly/Dockerfile
@@ -32,7 +32,7 @@ RUN cd ${RUNNER_USER_HOME} && \
     bundle config unset --local system && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf querly && \
-    gem info querly
+    gem info --local --exact --quiet querly | grep querly
 
 # Copy the main source code
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} exe ${RUNNERS_DIR}/exe

--- a/images/rails_best_practices/Dockerfile
+++ b/images/rails_best_practices/Dockerfile
@@ -32,7 +32,7 @@ RUN cd ${RUNNER_USER_HOME} && \
     bundle config unset --local system && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf rails_best_practices && \
-    gem info rails_best_practices
+    gem info --local --exact --quiet rails_best_practices | grep rails_best_practices
 
 # For backward compatibility
 RUN gem install require_all:1.5.0

--- a/images/reek/Dockerfile
+++ b/images/reek/Dockerfile
@@ -32,7 +32,7 @@ RUN cd ${RUNNER_USER_HOME} && \
     bundle config unset --local system && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf reek && \
-    gem info reek
+    gem info --local --exact --quiet reek | grep reek
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/reek/v5.reek.yml ${RUNNER_USER_HOME}/.reek.yml
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/reek/v4.reek.yml ${RUNNER_USER_HOME}/config.reek

--- a/images/rubocop/Dockerfile
+++ b/images/rubocop/Dockerfile
@@ -32,7 +32,7 @@ RUN cd ${RUNNER_USER_HOME} && \
     bundle config unset --local system && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf rubocop && \
-    gem info rubocop
+    gem info --local --exact --quiet rubocop | grep rubocop
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/rubocop/default_rubocop.yml ${RUNNER_USER_HOME}/
 

--- a/images/scss_lint/Dockerfile
+++ b/images/scss_lint/Dockerfile
@@ -32,7 +32,7 @@ RUN cd ${RUNNER_USER_HOME} && \
     bundle config unset --local system && \
     cd ${RUNNER_USER_HOME} && \
     rm -rf scss_lint && \
-    gem info scss_lint
+    gem info --local --exact --quiet scss_lint | grep scss_lint
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/scss_lint/scss-lint.default.yml ${RUNNER_USER_HOME}/.scss-lint.yml
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to verify a gem installation in Dockerfiles.
`gem info` does **not** exit with an error even if a gem is not installed,
so this uses `grep` for the verification.

> Link related issues or pull requests.

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
