### PR TITLE
[HAML-Lint] Enable `parallel` option by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 [Full diff](https://github.com/sider/runners/compare/0.41.1...HEAD)
 
 - **HAML-Lint** Improve issue ID and links for RuboCop [#2009](https://github.com/sider/runners/pull/2009)
+- **HAML-Lint** Enable `parallel` option by default [#2012](https://github.com/sider/runners/pull/2012)
 - Verify gem installation in Dockerfiles [#2010](https://github.com/sider/runners/pull/2010)
 
 ## 0.41.1

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -119,7 +119,11 @@ module Runners
     end
 
     def config_parallel
-      config_linter[:parallel] ? ["--parallel"] : []
+      if Gem::Version.create(analyzer_version) >= Gem::Version.create("0.36.0")
+        config_linter.fetch(:parallel, true) ? ["--parallel"] : []
+      else
+        []
+      end
     end
 
     def parse_result(output)

--- a/test/smokes/haml_lint/option_parallel/sider.yml
+++ b/test/smokes/haml_lint/option_parallel/sider.yml
@@ -1,3 +1,3 @@
 linter:
   haml_lint:
-    parallel: true
+    parallel: false


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to enable the `parallel` option of HAML-Lint by default.
Note that this option has been added since [HAML-Lint 0.36.0](https://github.com/sds/haml-lint/blob/v0.36.0/CHANGELOG.md).

> Link related issues or pull requests.

Close #1731

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
