### PR TITLE
[RuboCop] Set up default config only when no user config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Misc:
 - **HAML-Lint** Enable `parallel` option by default [#2012](https://github.com/sider/runners/pull/2012)
 - Verify gem installation in Dockerfiles [#2010](https://github.com/sider/runners/pull/2010)
 - **Slim-Lint** New support [#2014](https://github.com/sider/runners/pull/2014)
+- **RuboCop** Set up default config only when no user config [#2020](https://github.com/sider/runners/pull/2020)
 
 ## 0.41.1
 

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -36,7 +36,7 @@ module Runners
       add_warning_if_deprecated_options
 
       default_gems = default_gem_specs(GEM_NAME)
-      if setup_default_rubocop_config
+      if !rubocop_config_file && setup_default_rubocop_config
         # NOTE: The latest MeowCop requires usually the latest RuboCop.
         #       (e.g. MeowCop 2.4.0 requires RuboCop 0.75.0+)
         #       So, MeowCop versions must be unspecified because the installation will fail when a user's RuboCop is 0.60.0.
@@ -70,7 +70,7 @@ module Runners
         "--out=#{report_file}",
 
         *rails_option,
-        *config_file,
+        *rubocop_config_file_option,
         *safe,
       )
 
@@ -144,9 +144,12 @@ module Runners
       end
     end
 
-    def config_file
-      config_path = config_linter[:config] || config_linter.dig(:options, :config)
-      config_path ? ["--config=#{config_path}"] : []
+    def rubocop_config_file
+      config_linter[:config] || config_linter.dig(:options, :config)
+    end
+
+    def rubocop_config_file_option
+      rubocop_config_file.then { |path| path ? ["--config=#{path}"] : [] }
     end
 
     def safe

--- a/sig/runners/processor/rubocop.rbs
+++ b/sig/runners/processor/rubocop.rbs
@@ -16,7 +16,9 @@ module Runners
 
     def rails_option: () -> Array[String]
 
-    def config_file: () -> Array[String]
+    def rubocop_config_file: () -> String?
+
+    def rubocop_config_file_option: () -> Array[String]
 
     def safe: () -> Array[String]
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

When a user specifies a custom config file via `sider.yml`,

```yaml
linter:
  rubocop:
    config: my-rubocop.yml
```

the default config currently is copied to `.rubocop.yml` in the user's repository on staring analysis:
<https://github.com/sider/runners/blob/9239a21e2c38c69d3b03231fbe7201cb48c1bc14/images/rubocop/default_rubocop.yml>

But this copied config is ignored (because `rubocop --config my-rubocop.yml` is executed)
and `meowcop` is installed unnecessarily.
This change aims to fix that needless behavior.

Note that no smoke test cases are added because the following case satisfies them already:
<https://github.com/sider/runners/blob/9239a21e2c38c69d3b03231fbe7201cb48c1bc14/test/smokes/rubocop/with_safe_cops/sideci.yml#L5>

> Link related issues or pull requests.

Fix #2018

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
