### PR TITLE
Not support alpha, beta, and rc versions for `rake bump:analyzers`

### DIFF
--- a/tasks/bump/analyzers.rake
+++ b/tasks/bump/analyzers.rake
@@ -10,7 +10,7 @@ namespace :bump do
     BumpAnalyzers.each do |t|
       puts "Bumping #{t.analyzer}..."
 
-      if t.latest_version.match? /(alpha|beta|rc)/i
+      if t.latest_version.match?(/(alpha|beta|rc)/i)
         puts "  --> #{t.latest_version.inspect} unsupported"
         next
       end

--- a/tasks/bump/analyzers.rake
+++ b/tasks/bump/analyzers.rake
@@ -20,7 +20,7 @@ namespace :bump do
         puts "  --> #{t.current_version} => #{t.latest_version}"
         next if dry_run
       else
-        puts "  --> none"
+        puts "  --> #{t.current_version} is up-to-date"
         next
       end
 

--- a/tasks/bump/analyzers.rake
+++ b/tasks/bump/analyzers.rake
@@ -10,6 +10,11 @@ namespace :bump do
     BumpAnalyzers.each do |t|
       puts "Bumping #{t.analyzer}..."
 
+      if t.latest_version.match? /(alpha|beta|rc)/i
+        puts "  --> #{t.latest_version.inspect} unsupported"
+        next
+      end
+
       t.update_version! dry_run: dry_run
       if t.updated
         puts "  --> #{t.current_version} => #{t.latest_version}"


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Like #2024, this change aims to prevent updating to unstable versions.

> Link related issues or pull requests.

For example, related to #2024

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
