### PR TITLE
Refactor loading `Runners::Processor` classes

### DIFF
--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -68,8 +68,22 @@ module Runners
       @analyzers ||= Analyzers.new
     end
 
-    # NOTE: This method should be defined dynamically.
-    # def analyzer_id; end
+    def self.children
+      @children ||= ObjectSpace.each_object(Class)
+        .filter { |cls| cls.name && cls < self }
+        .to_h { |cls| [cls.analyzer_id, cls] }
+        .freeze
+    end
+
+    def self.analyzer_id
+      # Naming convention
+      source_file, _ = Module.const_source_location(self.name.to_s)
+      File.basename(source_file, ".rb").to_sym
+    end
+
+    def analyzer_id
+      @analyzer_id ||= self.class.analyzer_id
+    end
 
     def analyzer_name
       analyzers.name(analyzer_id)
@@ -88,7 +102,7 @@ module Runners
     end
 
     def analyzer_bin
-      analyzer_id
+      analyzer_id.to_s
     end
 
     def analyzer_version

--- a/sig/optparse.rbs
+++ b/sig/optparse.rbs
@@ -4,6 +4,8 @@ class OptionParser
   def initialize: { (OptionParser) -> void } -> void
   def on: (String, String, Array[untyped]) { (String) -> void } -> void
   def parse!: (Array[String]) -> void
+  def help: () -> String
+  def abort: (?String) -> void
 end
 
 class OptionParser::ParseError < RuntimeError

--- a/sig/runners/cli.rbs
+++ b/sig/runners/cli.rbs
@@ -5,7 +5,7 @@ module Runners
     attr_reader stdout: ::IO
     attr_reader stderr: ::IO
     attr_reader guid: String
-    attr_reader analyzer: String
+    attr_reader analyzer: Symbol
     attr_reader options: Options
 
     def initialize: (argv: Array[String], stdout: ::IO, stderr: ::IO, options_json: String) -> void
@@ -19,8 +19,6 @@ module Runners
     def setup_aws!: () -> void
 
     def with_working_dir: [X] () { (Pathname) -> X } -> X
-
-    def all_processor_classes: () -> Hash[String, Class]
 
     def processor_class: () -> Class
 

--- a/sig/runners/processor.rbs
+++ b/sig/runners/processor.rbs
@@ -7,12 +7,16 @@ module Runners
     class CIConfigBroken < UserError
     end
 
-    def self.register_config_schema: (name: Symbol, schema: StrongJSON::_Schema[untyped]) -> void
-
     class RemovedGoToolSchemaClass < StrongJSON
       def config: () -> StrongJSON::_Schema[untyped]
     end
     RemovedGoToolSchema: RemovedGoToolSchemaClass
+
+    def self.register_config_schema: (name: Symbol, schema: StrongJSON::_Schema[untyped]) -> void
+
+    def self.children: () -> Hash[Symbol, Class]
+
+    def self.analyzer_id: () -> Symbol
 
     attr_reader guid: String
     attr_reader working_dir: Pathname
@@ -42,7 +46,7 @@ module Runners
 
     def analyzers: () -> Analyzers
 
-    def analyzer_id: () -> String
+    def analyzer_id: () -> Symbol
 
     def analyzer_name: () -> String
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -22,33 +22,13 @@ class CLITest < Minitest::Test
   def test_parsing_options
     cli = CLI.new(argv: ["--analyzer=rubocop", "test-guid"], stdout: stdout, stderr: stderr, options_json: options_json)
     assert_equal "test-guid", cli.guid
-    assert_equal 'rubocop', cli.analyzer
+    assert_equal :rubocop, cli.analyzer
     assert_instance_of Runners::Options, cli.options
-  end
-
-  def test_validate_options
-    assert_raises OptionParser::MissingArgument do
-      CLI.new(argv: ["test-guid"], stdout: stdout, stderr: stderr, options_json: options_json)
-    end.tap do |error|
-      assert_equal "missing argument: --analyzer is required", error.message
-    end
-
-    assert_raises OptionParser::InvalidArgument do
-      CLI.new(argv: ["--analyzer=FOO", "test-guid"], stdout: stdout, stderr: stderr, options_json: options_json)
-    end.tap do |error|
-      assert_equal "invalid argument: --analyzer=FOO", error.message
-    end
-
-    assert_raises OptionParser::MissingArgument do
-      CLI.new(argv: ["--analyzer=rubocop"], stdout: stdout, stderr: stderr, options_json: options_json)
-    end.tap do |error|
-      assert_equal "missing argument: GUID is required", error.message
-    end
   end
 
   class TestProcessor < Runners::Processor
     def analyzer_id
-      "rubocop"
+      :rubocop
     end
 
     def analyzer_version

--- a/test/harness_test.rb
+++ b/test/harness_test.rb
@@ -31,7 +31,7 @@ class HarnessTest < Minitest::Test
 
   class TestProcessor < Processor
     def analyzer_id
-      "test"
+      :test
     end
 
     def analyzer_name
@@ -74,7 +74,7 @@ class HarnessTest < Minitest::Test
   def test_run_filters_issues
     processor_class = Class.new(Processor) do
       def analyzer_id
-        'test'
+        :test
       end
 
       def analyzer_name

--- a/test/java_test.rb
+++ b/test/java_test.rb
@@ -102,8 +102,7 @@ class JavaTest < Minitest::Test
   def new_processor(workspace, config_yaml:)
     klass = Class.new(Runners::Processor) do
       include Runners::Java
-      def analyzer_id; "checkstyle"; end
-      def analyzer_bin; "checkstyle"; end
+      def analyzer_id; :checkstyle; end
       def analyzer_name; "Checkstyle"; end
       def jvm_deps_dir
         (working_dir / "deps").tap { _1.mkpath }

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -17,14 +17,14 @@ class ProcessorTest < Minitest::Test
   def processor_class
     @processor_class ||= Class.new(Runners::Processor) do
       def analyzer_id
-        "eslint"
+        :eslint
       end
     end
   end
 
   def new_processor(workspace:, config_yaml: nil)
     processor_class.new(
-      guid: SecureRandom.uuid,
+      guid: "test-guid",
       working_dir: workspace.working_dir,
       config: config(config_yaml),
       shell: Shell.new(current_dir: workspace.working_dir, trace_writer: trace_writer),
@@ -561,5 +561,11 @@ class ProcessorTest < Minitest::Test
                    processor.extract_urls("(https://example.com/foo, https://example.com/bar)")
       assert_equal [], processor.extract_urls("ftp://example.com foo@example.com")
     end
+  end
+
+  def test_children
+    assert_equal Runners::Processor::Eslint, Runners::Processor.children[:eslint]
+    assert_equal Runners::Processor::RuboCop, Runners::Processor.children[:rubocop]
+    assert_nil Runners::Processor.children[:unknown]
   end
 end

--- a/test/rubocop_utils_test.rb
+++ b/test/rubocop_utils_test.rb
@@ -114,7 +114,7 @@ class RuboCopUtilsTest < Minitest::Test
         include Runners::Ruby
 
         def analyzer_id
-          "rubocop"
+          :rubocop
         end
       end
       klass.new(

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -21,7 +21,7 @@ class RubyTest < Minitest::Test
       include Runners::Ruby
 
       def analyzer_id
-        "rubocop"
+        :rubocop
       end
     end
   end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring moves the `Processor` related code from the `CLI` class to the `Processor` class.
I believe this change can reduce such tricky code.

> Link related issues or pull requests.

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
