### PR TITLE
Save and check `steep_expectations.yml`

### DIFF
--- a/.github/workflows/steep.yml
+++ b/.github/workflows/steep.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           bundler-cache: true
       - run: |
-          bundle exec steep check | ruby -pe 'sub(/^(.+):(\d+):(\d+): (.+)$/, %q{::error file=\1,line=\2,col=\3::\4})'
+          bundle exec rake steep:check | ruby -pe 'sub(/^\+ (.+):(\d+):(\d+): (.+)$/, %q{::error file=\1,line=\2,col=\3::\4})'
         shell: bash
         continue-on-error: true
 

--- a/.github/workflows/steep.yml
+++ b/.github/workflows/steep.yml
@@ -22,6 +22,7 @@ jobs:
       - run: |
           bundle exec steep check | ruby -pe 'sub(/^(.+):(\d+):(\d+): (.+)$/, %q{::error file=\1,line=\2,col=\3::\4})'
         shell: bash
+        continue-on-error: true
 
   stats:
     runs-on: ubuntu-latest

--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -105,8 +105,6 @@ module Runners
 
         # @see https://docs.bugsnag.com/platforms/ruby/customizing-error-reports/#adding-callbacks
         config.add_on_error(proc do |report|
-          # TODO: Ignored Steep error
-          # @type var report: untyped
           report.add_tab :task_guid, guid
           report.add_tab :arguments, argv
         end)

--- a/lib/runners/issue.rb
+++ b/lib/runners/issue.rb
@@ -10,7 +10,7 @@ module Runners
 
     def initialize(path:, location:, id:, message:, links: [], object: nil, schema: nil)
       path.is_a?(Pathname) or
-        raise ArgumentError, "`path` must be a #{Pathname}: #{(_ = path).inspect}" # TODO: Ignored Steep error
+        raise ArgumentError, "`path` must be a #{Pathname}: #{path.inspect}"
 
       (message && !message.empty?) or
         raise ArgumentError, "`message` must be required: #{message.inspect}"

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -119,8 +119,7 @@ module Runners
       cmd_opts = command_line.drop(1).tap do |opts|
         raise ArgumentError, "Unspecified command: `#{command_line.inspect}`" if opts.empty?
       end
-      # TODO: Ignored Steep error
-      outputs = capture3!(_ = cmd, *(_ = cmd_opts))
+      outputs = capture3!(cmd, *cmd_opts)
       outputs.each do |output|
         pattern.match(output) do |match|
           found = match[1]
@@ -306,8 +305,7 @@ module Runners
     end
 
     def comma_separated_list(value)
-      # TODO: Ignored Steep error
-      values = Array(value).flat_map { |s| (_ = s).split(/\s*,\s*/) }
+      values = Array(value).flat_map { |s| s.split(/\s*,\s*/) }
       values.empty? ? nil : values.join(",")
     end
 

--- a/lib/runners/processor/checkstyle.rb
+++ b/lib/runners/processor/checkstyle.rb
@@ -160,8 +160,6 @@ module Runners
 
     def excluded_directories
       Array(config_linter[:exclude]).map do |dir|
-        # TODO: Ignored Steep error
-        # @type var dir: untyped
         case dir
         when String
           { string: dir }

--- a/lib/runners/processor/misspell.rb
+++ b/lib/runners/processor/misspell.rb
@@ -58,7 +58,7 @@ module Runners
               start_line: line,
               start_column: col,
               end_line: line,
-              end_column: Integer(col) + (_ = incorrect).size, # TODO: Ignored Steep error
+              end_column: Integer(col) + incorrect.size,
             ),
             id: correct,
             message: message,

--- a/lib/runners/processor/shellcheck.rb
+++ b/lib/runners/processor/shellcheck.rb
@@ -97,7 +97,8 @@ module Runners
       targets = Array(config_linter[:target] || DEFAULT_TARGET)
 
       # Via glob
-      globs = _ = targets.select { |glob| glob.is_a? String } # TODO: Ignored Steep error
+      # @type var globs: Array[String]
+      globs = targets.filter { |glob| glob.is_a? String }
       files_via_glob = Dir.glob(globs, File::FNM_EXTGLOB, base: current_dir.to_path).filter { |path| File.file?(path) }
 
       # Via shebang

--- a/lib/runners/ruby/gem_installer/spec.rb
+++ b/lib/runners/ruby/gem_installer/spec.rb
@@ -29,8 +29,7 @@ module Runners
 
         def self.from_gems(gems_items)
           gems_items.map do |item|
-            # TODO: Ignored Steep error
-            gem = _ =
+            gem =
               case item
               when Hash
                 item

--- a/sig/bugsnag.rbs
+++ b/sig/bugsnag.rbs
@@ -8,7 +8,7 @@ module Bugsnag
     attr_accessor app_version: String
     attr_accessor release_stage: String
 
-    def add_on_error: (untyped) -> void
+    def add_on_error: (^(Report) -> void) -> void
   end
 
   class Report

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -1,0 +1,150 @@
+---
+- file: lib/runners/cli.rb
+  diagnostics:
+  - range:
+      start:
+        line: 107
+        character: 28
+      end:
+        line: 110
+        character: 11
+    severity: ERROR
+    message: |-
+      Cannot pass a value of type `::Proc` as an argument of type `^(::Bugsnag::Report) -> void`
+        ::Proc <: ^(::Bugsnag::Report) -> void
+    code: Ruby::ArgumentTypeMismatch
+  - range:
+      start:
+        line: 108
+        character: 17
+      end:
+        line: 108
+        character: 24
+    severity: ERROR
+    message: Type `nil` does not have method `add_tab`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 109
+        character: 17
+      end:
+        line: 109
+        character: 24
+    severity: ERROR
+    message: Type `nil` does not have method `add_tab`
+    code: Ruby::NoMethod
+- file: lib/runners/issue.rb
+  diagnostics:
+  - range:
+      start:
+        line: 13
+        character: 67
+      end:
+        line: 13
+        character: 74
+    severity: ERROR
+    message: Type `bot` does not have method `inspect`
+    code: Ruby::NoMethod
+- file: lib/runners/processor/checkstyle.rb
+  diagnostics:
+  - range:
+      start:
+        line: 167
+        character: 10
+      end:
+        line: 167
+        character: 13
+    severity: ERROR
+    message: The branch is unreachable because the condition is exhaustive
+    code: Ruby::ElseOnExhaustiveCase
+- file: lib/runners/processor/misspell.rb
+  diagnostics:
+  - range:
+      start:
+        line: 61
+        character: 51
+      end:
+        line: 61
+        character: 55
+    severity: ERROR
+    message: Type `bot` does not have method `size`
+    code: Ruby::NoMethod
+- file: lib/runners/processor/shellcheck.rb
+  diagnostics:
+  - range:
+      start:
+        line: 101
+        character: 6
+      end:
+        line: 101
+        character: 57
+    severity: ERROR
+    message: |-
+      Cannot assign a value of type `::Array[::Runners::Processor::ShellCheck::target]` to a variable of type `::Array[::String]`
+        ::Array[::Runners::Processor::ShellCheck::target] <: ::Array[::String]
+          ::Runners::Processor::ShellCheck::target <: ::String
+            (::String | ::Hash[::Symbol, bool]) <: ::String
+              ::Hash[::Symbol, bool] <: ::String
+                ::Object <: ::String
+                  ::BasicObject <: ::String
+    code: Ruby::IncompatibleAssignment
+- file: lib/runners/processor.rb
+  diagnostics:
+  - range:
+      start:
+        line: 122
+        character: 26
+      end:
+        line: 122
+        character: 29
+    severity: ERROR
+    message: |-
+      Cannot pass a value of type `(::String | ::Array[::String])` as an argument of type `::String`
+        (::String | ::Array[::String]) <: ::String
+          ::Array[::String] <: ::String
+            ::Object <: ::String
+              ::BasicObject <: ::String
+    code: Ruby::ArgumentTypeMismatch
+  - range:
+      start:
+        line: 122
+        character: 31
+      end:
+        line: 122
+        character: 40
+    severity: ERROR
+    message: |-
+      Cannot pass a value of type `::Array[(::String | ::Array[::String])]` as an argument of type `::Array[::Runners::Shell::command_argument]`
+        ::Array[(::String | ::Array[::String])] <: ::Array[::Runners::Shell::command_argument]
+          (::String | ::Array[::String]) <: ::Runners::Shell::command_argument
+            (::String | ::Array[::String]) <: (::String | ::Pathname)
+              ::Array[::String] <: (::String | ::Pathname)
+                ::Array[::String] <: ::String
+                  ::Object <: ::String
+                    ::BasicObject <: ::String
+    code: Ruby::ArgumentTypeMismatch
+  - range:
+      start:
+        line: 308
+        character: 45
+      end:
+        line: 308
+        character: 50
+    severity: ERROR
+    message: Type `(::String | ::Array[::String] | nil)` does not have method `split`
+    code: Ruby::NoMethod
+- file: lib/runners/ruby/gem_installer/spec.rb
+  diagnostics:
+  - range:
+      start:
+        line: 41
+        character: 20
+      end:
+        line: 41
+        character: 36
+    severity: ERROR
+    message: |-
+      Cannot assign a value of type `(::String | nil | ::Runners::Ruby::GemInstaller::git_source)` to an expression of type `::String`
+        (::String | nil | ::Runners::Ruby::GemInstaller::git_source) <: ::String
+          nil <: ::String
+    code: Ruby::IncompatibleAssignment

--- a/tasks/steep/check.rake
+++ b/tasks/steep/check.rake
@@ -1,7 +1,10 @@
 namespace :steep do
   desc "Run type-check by Steep"
-  task :check do
+  task :check, [:save] do |_task, args|
+    # @see https://github.com/soutaro/steep/pull/303
+    opts = args[:save] ? ["--save-expectations"] : ["--with-expectations"]
+
     # NOTE: Suppress too many log via `fatal` level.
-    sh "bundle", "exec", "steep", "check", "--log-level=fatal"
+    sh "bundle", "exec", "steep", "check", "--log-level=fatal", *opts
   end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Steep 0.41.0 has introduced `--with-expectations` and `--save-expectations` options.
They should improve our management of Steep errors.

If we encounter new errors of Steep in the future, we should run `rake steep:check'[true]'`.

See also <https://github.com/soutaro/steep/pull/303>.

> Link related issues or pull requests.

Related to #2031

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
