### PR TITLE
Remove needless `continue-on-error: true` on Steep check

### DIFF
--- a/.github/workflows/steep.yml
+++ b/.github/workflows/steep.yml
@@ -22,7 +22,6 @@ jobs:
       - run: |
           bundle exec rake steep:check | ruby -pe 'sub(/^\+ (.+):(\d+):(\d+): (.+)$/, %q{::error file=\1,line=\2,col=\3::\4})'
         shell: bash
-        continue-on-error: true
 
   stats:
     runs-on: ubuntu-latest


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

If there are Steep errors, the CI should fail. So, `continue-on-error: true` is needless.

> Link related issues or pull requests.

Follow up of #2032

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
