### PR TITLE
Extract `Runners::Config#field_path` method

### DIFF
--- a/lib/runners/config.rb
+++ b/lib/runners/config.rb
@@ -95,12 +95,12 @@ module Runners
     end
 
     def check_unsupported_linters(linter_ids)
-      list = linter_ids.filter { |id| linter?(id) }
+      ids = linter_ids.filter { |id| linter?(id) }
 
-      if list.empty?
+      if ids.empty?
         ""
       else
-        list = list.map { |id| "- `linter.#{id}`" }.join("\n")
+        list = ids.map { |id| "- `#{linter_field_path(id)}`" }.join("\n")
         <<~MSG
           The following linters in your `#{path_name}` are no longer supported. Please remove them.
           #{list}
@@ -135,6 +135,14 @@ module Runners
           path_name: path_name, raw_content: yaml, line: exn.line, column: exn.column, problem: exn.problem,
         )
       end
+    end
+
+    def field_path(*fields)
+      fields.map(&:to_s).join(".")
+    end
+
+    def linter_field_path(*fields)
+      field_path(:linter, *fields)
     end
 
     private

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -165,9 +165,8 @@ module Runners
       Results::Success.new(guid: guid, analyzer: analyzer)
     end
 
-    # Returns e.g. "linter.rubocop.gems"
     def config_field_path(*fields)
-      "linter.#{analyzer_id}.#{fields.join('.')}"
+      config.linter_field_path(analyzer_id, *fields)
     end
 
     def delete_unchanged_files(changes, except: [], only: [])

--- a/sig/runners/config.rbs
+++ b/sig/runners/config.rbs
@@ -57,6 +57,10 @@ module Runners
 
     def parse: () -> untyped
 
+    def field_path: (*(Symbol | String)) -> String
+
+    def linter_field_path: (*(Symbol | String)) -> String
+
     private
 
     def check_schema: (untyped) -> Hash[Symbol, untyped]

--- a/sig/runners/processor.rbs
+++ b/sig/runners/processor.rbs
@@ -76,7 +76,7 @@ module Runners
 
     def missing_config_file_result: (String) -> Results::Success
 
-    def config_field_path: (*Symbol) -> String
+    def config_field_path: (*(Symbol | String)) -> String
 
     def delete_unchanged_files: (Changes, ?except: Array[String], ?only: Array[String]) -> void
 

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -125,10 +125,10 @@
     code: Ruby::ArgumentTypeMismatch
   - range:
       start:
-        line: 308
+        line: 307
         character: 45
       end:
-        line: 308
+        line: 307
         character: 50
     severity: ERROR
     message: Type `(::String | ::Array[::String] | nil)` does not have method `split`

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -308,4 +308,16 @@ class ConfigTest < Minitest::Test
       Runners::Config.new(path: Pathname(FILE_NAME), raw_content: "`").parse
     end
   end
+
+  def test_field_path
+    config = Runners::Config.new(path: Pathname(FILE_NAME), raw_content: nil)
+    assert_equal "", config.field_path
+    assert_equal "foo.bar", config.field_path(:foo, "bar")
+  end
+
+  def test_linter_field_path
+    config = Runners::Config.new(path: Pathname(FILE_NAME), raw_content: nil)
+    assert_equal "linter", config.linter_field_path
+    assert_equal "linter.foo.bar", config.linter_field_path(:foo, "bar")
+  end
 end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to reduce the duplication about *field paths* in `sider.yml`.

> Link related issues or pull requests.

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
