### PR TITLE
[HAML-Lint] Fix logic about `parallel` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Updated tools:
 Misc:
 
 - **HAML-Lint** Improve issue ID and links for RuboCop [#2009](https://github.com/sider/runners/pull/2009)
-- **HAML-Lint** Enable `parallel` option by default [#2012](https://github.com/sider/runners/pull/2012)
+- **HAML-Lint** Enable `parallel` option by default [#2012](https://github.com/sider/runners/pull/2012) [#2042](https://github.com/sider/runners/pull/2042)
 - Verify gem installation in Dockerfiles [#2010](https://github.com/sider/runners/pull/2010)
 - **RuboCop** Set up default config only when no user config [#2020](https://github.com/sider/runners/pull/2020)
 - **Metrics Complexity** Run lizard as single thread to avoid timeout error [#2019](https://github.com/sider/runners/pull/2019)

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -112,11 +112,18 @@ module Runners
     end
 
     def config_parallel
-      if Gem::Version.create(analyzer_version) >= Gem::Version.create("0.36.0")
-        config_linter.fetch(:parallel, true) ? ["--parallel"] : []
-      else
-        []
+      minimum_version = "0.36.0"
+      if Gem::Version.create(analyzer_version) >= Gem::Version.create(minimum_version)
+        parallel = config_linter[:parallel]
+        if parallel == true || parallel.nil?
+          return ["--parallel"]
+        end
+      elsif config_linter[:parallel] == true
+        add_warning "The option `#{config_field_path(:parallel)}` is ignored with #{analyzer_name} #{analyzer_version}. Please update it to **#{minimum_version}+** or use our default version.",
+                    file: config.path_name
       end
+
+      []
     end
 
     def parse_result(output)

--- a/test/processor/haml_lint_test.rb
+++ b/test/processor/haml_lint_test.rb
@@ -3,14 +3,20 @@ require "test_helper"
 class Runners::Processor::HamlLintTest < Minitest::Test
   include TestHelper
 
-  def test_config_parallel
+  def test_config_parallel_with_unsupported_versions
     with_subject do |subject|
       subject.stub :analyzer_version, "0.35.0" do
         assert_equal [], subject.send(:config_parallel)
       end
+    end
+  end
 
+  def test_config_parallel_with_supported_versions
+    with_subject do |subject|
       subject.stub :analyzer_version, "0.36.0" do
-        assert_equal ["--parallel"], subject.send(:config_parallel)
+        subject.stub :config_linter, {} do
+          assert_equal ["--parallel"], subject.send(:config_parallel)
+        end
 
         subject.stub :config_linter, { parallel: true } do
           assert_equal ["--parallel"], subject.send(:config_parallel)

--- a/test/processor/haml_lint_test.rb
+++ b/test/processor/haml_lint_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class Runners::Processor::HamlLintTest < Minitest::Test
+  include TestHelper
+
+  def test_config_parallel
+    with_subject do |subject|
+      subject.stub :analyzer_version, "0.35.0" do
+        assert_equal [], subject.send(:config_parallel)
+      end
+
+      subject.stub :analyzer_version, "0.36.0" do
+        assert_equal ["--parallel"], subject.send(:config_parallel)
+
+        subject.stub :config_linter, { parallel: true } do
+          assert_equal ["--parallel"], subject.send(:config_parallel)
+        end
+
+        subject.stub :config_linter, { parallel: nil } do
+          assert_equal ["--parallel"], subject.send(:config_parallel)
+        end
+
+        subject.stub :config_linter, { parallel: false } do
+          assert_equal [], subject.send(:config_parallel)
+        end
+      end
+    end
+  end
+
+  private
+
+  def trace_writer
+    @trace_writer ||= new_trace_writer
+  end
+
+  def with_subject
+    with_workspace do |workspace|
+      yield Runners::Processor::HamlLint.new(
+        guid: "test-guid",
+        working_dir: workspace.working_dir,
+        config: config,
+        shell: Runners::Shell.new(current_dir: workspace.working_dir, trace_writer: trace_writer),
+        trace_writer: trace_writer,
+      )
+    end
+  end
+end

--- a/test/smokes/haml_lint/expectations.rb
+++ b/test/smokes/haml_lint/expectations.rb
@@ -181,7 +181,8 @@ s.add_test(
       }
     }
   ],
-  analyzer: { name: "HAML-Lint", version: "0.26.0" }
+  analyzer: { name: "HAML-Lint", version: "0.26.0" },
+  warnings: [{ message: "The option `linter.haml_lint.parallel` is ignored with HAML-Lint 0.26.0. Please update it to **0.36.0+** or use our default version.", file: "sider.yml" }]
 )
 
 s.add_test(

--- a/test/smokes/haml_lint/lowest-deps/sider.yml
+++ b/test/smokes/haml_lint/lowest-deps/sider.yml
@@ -1,0 +1,3 @@
+linter:
+  haml_lint:
+    parallel: true


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

We should consider a case that the option `linter.haml_lint.parallel` is `nil`.
Also, this change warns when the option is ignored with unsupported HAML-Lint versions.

> Link related issues or pull requests.

Follow-up of #2012

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
