### PR TITLE
add an instruction to install RBS collection for type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ Then, install Git hooks via [Lefthook](https://github.com/Arkweid/lefthook):
 $ bundle exec lefthook install
 ```
 
+Install [RBS collection for RubyGems](https://github.com/ruby/gem_rbs_collection) via [git submodule](https://git-scm.com/docs/git-submodule):
+
+```shell-session
+$ git submodule init
+$ git submodule update
+```
+
 Last, run the following command to show available commands in the project:
 
 ```shell-session
@@ -190,6 +197,8 @@ To update the third-party gems' RBS, run:
 ```shell-session
 $ bundle exec rake rbs:update_gems
 ```
+
+If you get a `Unexpected error reported` error, ensure that you've got RBS for gems. See [Setup](#setup) section.
 
 ## License
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Developers are required to install [`gem_rbs_collection`](https://github.com/ruby/gem_rbs_collection) for type checking with `steep`. But there is no information about that in `README.md`. This PR adds an instruction to install `git submodule` .

> Link related issues or pull requests.

none

> Check the following if needed.

- ~[ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.~ This is a PR for documentation. No need to update CHANGELOG.
