### PR TITLE
Remove needless Querly rule: `sider.runners.exitstatus`

### DIFF
--- a/querly.yml
+++ b/querly.yml
@@ -1,20 +1,4 @@
 rules:
-  - id: sider.runners.exitstatus
-    pattern:
-      - _.exitstatus()
-    message: |
-      Be careful that `Process#exitstatus` may return `nil`.
-
-      `Process#exitstatus` returns `nil` when the process does not exit normally.
-      This means the process may be abort(2)-ed or core-dumped.
-      If you want to know if it is aborted, consider using also `Process#exited?`.
-
-      See also:
-      * https://ruby-doc.org/core/Process/Status.html#method-i-exitstatus
-    justification:
-      - When you are not interested in aborted or core-dumped.
-      - When you confirm that `NoMethodError` on `NilClass` will not occur.
-
   - id: sider.runners.trace_writer_status
     pattern:
       - status(_, ...)


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

We now can check the return value via Steep.
Querly may detect false positives, so It seems that rule is needless and Steep is suitable.

> Link related issues or pull requests.

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
