### PR TITLE
[HAML-Lint] Set up recommended ruleset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Misc:
 
 - **HAML-Lint** Improve issue ID and links for RuboCop [#2009](https://github.com/sider/runners/pull/2009)
 - **HAML-Lint** Enable `parallel` option by default [#2012](https://github.com/sider/runners/pull/2012) [#2042](https://github.com/sider/runners/pull/2042)
+- **HAML-Lint** Set up recommended ruleset [#2048](https://github.com/sider/runners/pull/2048)
 - Verify gem installation in Dockerfiles [#2010](https://github.com/sider/runners/pull/2010)
 - **RuboCop** Set up default config only when no user config [#2020](https://github.com/sider/runners/pull/2020)
 - **Metrics Complexity** Run lizard as single thread to avoid timeout error [#2019](https://github.com/sider/runners/pull/2019)

--- a/images/haml_lint/Dockerfile
+++ b/images/haml_lint/Dockerfile
@@ -34,7 +34,7 @@ RUN cd "${RUNNER_USER_HOME}" && \
     rm -rf haml_lint && \
     gem info --local --exact --quiet haml_lint | grep haml_lint
 
-COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/haml_lint/default_rubocop.yml ${RUNNER_USER_HOME}/
+COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/haml_lint/*.yml ${RUNNER_USER_HOME}/
 
 
 # Copy the main source code

--- a/images/haml_lint/Dockerfile.erb
+++ b/images/haml_lint/Dockerfile.erb
@@ -3,6 +3,6 @@ FROM sider/devon_rex_ruby:2.40.3
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.ruby.erb' %>
 
-COPY --chown=<%= chown %> images/haml_lint/default_rubocop.yml ${RUNNER_USER_HOME}/
+COPY --chown=<%= chown %> images/haml_lint/*.yml ${RUNNER_USER_HOME}/
 
 <%= render_erb 'images/Dockerfile.end.erb' %>

--- a/images/haml_lint/sider_recommended_haml_lint.yml
+++ b/images/haml_lint/sider_recommended_haml_lint.yml
@@ -1,0 +1,4 @@
+linters:
+  LineLength:
+    enabled: true
+    max: 200 # large enough

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -90,7 +90,7 @@ module Runners
     private
 
     def setup_haml_lint_config
-      return if config_linter[:config]
+      return unless haml_lint_config.empty?
 
       path = current_dir / ".haml-lint.yml"
       return if path.exist?

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -39,6 +39,7 @@ module Runners
       GEM_NAME => [">= 0.26.0", "< 1.0.0"]
     }.freeze
     DEFAULT_TARGET = ".".freeze
+    DEFAULT_CONFIG_FILE = (Pathname(Dir.home) / "sider_recommended_haml_lint.yml").to_path.freeze
 
     def analyzer_bin
       "haml-lint"
@@ -47,6 +48,8 @@ module Runners
     def setup
       add_warning_if_deprecated_options
       add_warning_for_deprecated_option :file, to: :target
+
+      setup_haml_lint_config
 
       default_gems = default_gem_specs(GEM_NAME, *REQUIRED_GEM_NAMES)
       if setup_default_rubocop_config
@@ -85,6 +88,16 @@ module Runners
     end
 
     private
+
+    def setup_haml_lint_config
+      return if config_linter[:config]
+
+      path = current_dir / ".haml-lint.yml"
+      return if path.exist?
+
+      FileUtils.copy_file DEFAULT_CONFIG_FILE, path
+      trace_writer.message "Set up the default #{analyzer_name} configuration file."
+    end
 
     def target
       Array(config_linter[:target] || config_linter[:file] ||

--- a/sig/runners/processor/haml_lint.rbs
+++ b/sig/runners/processor/haml_lint.rbs
@@ -13,8 +13,11 @@ module Runners
     REQUIRED_GEM_NAMES: Array[String]
     CONSTRAINTS: Ruby::constraints
     DEFAULT_TARGET: String
+    DEFAULT_CONFIG_FILE: String
 
     private
+
+    def setup_haml_lint_config: () -> void
 
     def target: () -> Array[String]
 

--- a/test/smokes/haml_lint/expectations.rb
+++ b/test/smokes/haml_lint/expectations.rb
@@ -16,6 +16,17 @@ s.add_test(
       git_blame_info: {
         commit: :_, line_hash: "2f024a2bdf291a1ab61e026140f7e709028266a8", original_line: 4, final_line: 4
       }
+    },
+    {
+      message: "Line is too long. [204/200]",
+      links: %W[https://github.com/sds/haml-lint/blob/v#{default_version}/lib/haml_lint/linter#linelength],
+      id: "LineLength",
+      path: "test.haml",
+      location: { start_line: 7 },
+      object: { severity: "warning" },
+      git_blame_info: {
+        commit: :_, line_hash: "416b409e6b7628da6f061cd2c159b03157c38192", original_line: 7, final_line: 7
+      }
     }
   ],
   analyzer: { name: "HAML-Lint", version: default_version }
@@ -141,6 +152,17 @@ s.add_test(
       object: { severity: "warning" },
       git_blame_info: {
         commit: :_, line_hash: "da7cbdf991191af285867e39fd1239b6a030b465", original_line: 2, final_line: 2
+      }
+    },
+    {
+      message: "Line is too long. [84/80]",
+      links: %W[https://github.com/sds/haml-lint/blob/v#{default_version}/lib/haml_lint/linter#linelength],
+      id: "LineLength",
+      path: "hello.haml",
+      location: { start_line: 7 },
+      object: { severity: "warning" },
+      git_blame_info: {
+        commit: :_, line_hash: "53d100be96dfb32b768bb472f9f7da2409f73ab6", original_line: 7, final_line: 7
       }
     },
     {

--- a/test/smokes/haml_lint/success/test.haml
+++ b/test/smokes/haml_lint/success/test.haml
@@ -2,3 +2,6 @@
   %p		Hello, world
   %span	This is visually aligned with its sibling's content using tabs
 %tag{ class: 'my-class' }
+
+%p
+  blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah...

--- a/test/smokes/haml_lint/with_exclude_files/hello.haml
+++ b/test/smokes/haml_lint/with_exclude_files/hello.haml
@@ -2,3 +2,6 @@
   - expression_one
   - expression_two
   - expression_three
+
+%p
+  blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah...


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

HAML-Lint's default value of the rule `LineLength` is too strict:
<https://github.com/sds/haml-lint/blob/v0.37.0/config/default.yml#L69-L71>

So, this change aims to loosen the value via our recommended ruleset.

> Link related issues or pull requests.

Related to #2046

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
