### PR TITLE
[Metrics Code Clone] Fix analysis failure with Lexical error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Misc:
 - Verify gem installation in Dockerfiles [#2010](https://github.com/sider/runners/pull/2010)
 - **RuboCop** Set up default config only when no user config [#2020](https://github.com/sider/runners/pull/2020)
 - **Metrics Complexity** Run lizard as single thread to avoid timeout error [#2019](https://github.com/sider/runners/pull/2019)
+- **Metrics Code Clone** Force to set the option `--skip-lexical-errors` of PMD CPD to avoid Lexical error [#2050](https://github.com/sider/runners/pull/2050)
 
 ## 0.41.1
 

--- a/lib/runners/processor/metrics_codeclone.rb
+++ b/lib/runners/processor/metrics_codeclone.rb
@@ -22,7 +22,7 @@ module Runners
 
     def initialize(**params)
       super(**params)
-      @pmd_cpd = PmdCpd.new(**params)
+      @pmd_cpd = PmdCpd.new(**params).tap { _1.force_option_skip_lexical_errors }
     end
 
     def analyze(changes)

--- a/lib/runners/processor/metrics_codeclone.rb
+++ b/lib/runners/processor/metrics_codeclone.rb
@@ -22,7 +22,7 @@ module Runners
 
     def initialize(**params)
       super(**params)
-      @pmd_cpd = PmdCpd.new(**params).tap { _1.force_option_skip_lexical_errors }
+      @pmd_cpd = PmdCpd.new(**params).tap { _1.force_option_skip_lexical_errors = true }
     end
 
     def analyze(changes)

--- a/lib/runners/processor/pmd_cpd.rb
+++ b/lib/runners/processor/pmd_cpd.rb
@@ -71,7 +71,7 @@ module Runners
 
     register_config_schema(name: :pmd_cpd, schema: Schema.runner_config)
 
-    attr_writer :force_option_skip_lexical_errors
+    attr_accessor :force_option_skip_lexical_errors
 
     def analyzer_version
       @analyzer_version ||= capture3!("show_pmd_version").yield_self { |stdout,| stdout.strip }
@@ -193,7 +193,7 @@ module Runners
     end
 
     def option_skip_lexical_errors
-      (@force_option_skip_lexical_errors || config_linter[:'skip-lexical-errors']).then { |v| v ? ["--skip-lexical-errors"] : [] }
+      (force_option_skip_lexical_errors || config_linter[:'skip-lexical-errors']).then { |v| v ? ["--skip-lexical-errors"] : [] }
     end
 
     def option_ignore_annotations

--- a/lib/runners/processor/pmd_cpd.rb
+++ b/lib/runners/processor/pmd_cpd.rb
@@ -71,6 +71,10 @@ module Runners
 
     register_config_schema(name: :pmd_cpd, schema: Schema.runner_config)
 
+    def force_option_skip_lexical_errors
+      @force_option_skip_lexical_errors = true
+    end
+
     def analyzer_version
       @analyzer_version ||= capture3!("show_pmd_version").yield_self { |stdout,| stdout.strip }
     end
@@ -191,7 +195,7 @@ module Runners
     end
 
     def option_skip_lexical_errors
-      config_linter[:'skip-lexical-errors'].then { |v| v ? ["--skip-lexical-errors"] : [] }
+      (@force_option_skip_lexical_errors || config_linter[:'skip-lexical-errors']).then { |v| v ? ["--skip-lexical-errors"] : [] }
     end
 
     def option_ignore_annotations

--- a/lib/runners/processor/pmd_cpd.rb
+++ b/lib/runners/processor/pmd_cpd.rb
@@ -71,9 +71,7 @@ module Runners
 
     register_config_schema(name: :pmd_cpd, schema: Schema.runner_config)
 
-    def force_option_skip_lexical_errors
-      @force_option_skip_lexical_errors = true
-    end
+    attr_writer :force_option_skip_lexical_errors
 
     def analyzer_version
       @analyzer_version ||= capture3!("show_pmd_version").yield_self { |stdout,| stdout.strip }

--- a/sig/runners/processor/pmd_cpd.rbs
+++ b/sig/runners/processor/pmd_cpd.rbs
@@ -13,6 +13,8 @@ module Runners
     DEFAULT_FILES: String
     DEFAULT_LANGUAGE: Array[String]
 
+    def force_option_skip_lexical_errors: () -> bool
+
     private
 
     def raise_warnings: (String) -> void

--- a/sig/runners/processor/pmd_cpd.rbs
+++ b/sig/runners/processor/pmd_cpd.rbs
@@ -13,7 +13,7 @@ module Runners
     DEFAULT_FILES: String
     DEFAULT_LANGUAGE: Array[String]
 
-    attr_writer force_option_skip_lexical_errors: bool
+    attr_accessor force_option_skip_lexical_errors: bool
 
     private
 

--- a/sig/runners/processor/pmd_cpd.rbs
+++ b/sig/runners/processor/pmd_cpd.rbs
@@ -13,7 +13,7 @@ module Runners
     DEFAULT_FILES: String
     DEFAULT_LANGUAGE: Array[String]
 
-    def force_option_skip_lexical_errors: () -> bool
+    attr_writer force_option_skip_lexical_errors: bool
 
     private
 

--- a/test/smokes/metrics_codeclone/expectations.rb
+++ b/test/smokes/metrics_codeclone/expectations.rb
@@ -189,10 +189,14 @@ s.add_test(
 
 s.add_test(
   "option_encoding_error",
-  type: "error",
-  class: "Runners::Shell::ExecError",
-  backtrace: :_,
-  inspect: :_,
+  type: "success",
+  issues: [],
+  warnings: [
+    {
+      message: "Skipping ./hello.eucjp.cs. Reason: Lexical error in file ./hello.eucjp.cs at line 20, column 13.  Encountered: token recognition error at: '｣'",
+      file: nil
+    }
+  ],
   analyzer: { name: "Metrics Code Clone", version: default_version }
 )
 


### PR DESCRIPTION
This change aims to fix an analysis failure with Lexical error thrown by `pmd_cpd`.
Fix #2049

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
