### PR TITLE
[Metrics File Info] Improve analysis performance with pre-computed git metadata cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Misc:
 - **RuboCop** Set up default config only when no user config [#2020](https://github.com/sider/runners/pull/2020)
 - **Metrics Complexity** Run lizard as single thread to avoid timeout error [#2019](https://github.com/sider/runners/pull/2019)
 - **Metrics Code Clone** Force to set the option `--skip-lexical-errors` of PMD CPD to avoid Lexical error [#2050](https://github.com/sider/runners/pull/2050)
-- **Metrics FileInfo** Improvement analysis performance with pre-computed git metadata cache [#2051](https://github.com/sider/runners/pull/2051)
+- **Metrics File Info** Improve analysis performance with pre-computed git metadata cache [#2051](https://github.com/sider/runners/pull/2051)
 
 ## 0.41.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Misc:
 - Verify gem installation in Dockerfiles [#2010](https://github.com/sider/runners/pull/2010)
 - **RuboCop** Set up default config only when no user config [#2020](https://github.com/sider/runners/pull/2020)
 - **Metrics Complexity** Run lizard as single thread to avoid timeout error [#2019](https://github.com/sider/runners/pull/2019)
+- **Metrics FileInfo** Improvement analysis performance with pre-computed git metadata cache [#2051](https://github.com/sider/runners/pull/2051)
 
 ## 0.41.1
 

--- a/lib/runners/processor/metrics_fileinfo.rb
+++ b/lib/runners/processor/metrics_fileinfo.rb
@@ -83,7 +83,7 @@ module Runners
 
     def analyze_last_committed_at(targets)
       targets.each do |target|
-        stdout, _ = capture3!("git", "log", "-1", "--format=format:%aI", target)
+        stdout, _ = capture3!("git", "log", "-1", "--format=format:%aI", target, trace_stdout: false)
         last_committed_at[target] = stdout
       end
     end

--- a/lib/runners/processor/metrics_fileinfo.rb
+++ b/lib/runners/processor/metrics_fileinfo.rb
@@ -23,7 +23,7 @@ module Runners
       # Generate pre-computed cache for Git metadata access (https://git-scm.com/docs/git-commit-graph)
       # This improves the performance of access to Git metadata for a large repository.
       # You can see the efficacy here: https://github.com/sider/runners/issues/2028#issuecomment-776534408
-      capture3!("git","commit-graph" , "write", "--reachable", "--changed-paths")
+      capture3!("git","commit-graph", "write", "--reachable", "--changed-paths")
 
       target_files = changes.changed_paths.map(&:to_path)
       analyze_last_committed_at(target_files)

--- a/lib/runners/processor/metrics_fileinfo.rb
+++ b/lib/runners/processor/metrics_fileinfo.rb
@@ -20,9 +20,9 @@ module Runners
     end
 
     def analyze(changes)
-      # generate pre-computed cache for git metadata access (https://git-scm.com/docs/git-commit-graph)
-      # This shows a significant effect to improve metadata access performance for large repository.
-      # See: https://github.com/sider/runners/issues/2028#issuecomment-776534408
+      # Generate pre-computed cache for Git metadata access (https://git-scm.com/docs/git-commit-graph)
+      # This improves the performance of access to Git metadata for a large repository.
+      # You can see the efficacy here: https://github.com/sider/runners/issues/2028#issuecomment-776534408
       capture3!("git","commit-graph" , "write", "--reachable", "--changed-paths")
 
       target_files = changes.changed_paths.map(&:to_path)

--- a/lib/runners/processor/metrics_fileinfo.rb
+++ b/lib/runners/processor/metrics_fileinfo.rb
@@ -20,6 +20,11 @@ module Runners
     end
 
     def analyze(changes)
+      # generate pre-computed cache for git metadata access (https://git-scm.com/docs/git-commit-graph)
+      # This shows a significant effect to improve metadata access performance for large repository.
+      # See: https://github.com/sider/runners/issues/2028#issuecomment-776534408
+      capture3!("git","commit-graph" , "write", "--reachable", "--changed-paths")
+
       target_files = changes.changed_paths.map(&:to_path)
       analyze_last_committed_at(target_files)
       analyze_lines_of_code(target_files)

--- a/lib/runners/processor/metrics_fileinfo.rb
+++ b/lib/runners/processor/metrics_fileinfo.rb
@@ -23,7 +23,7 @@ module Runners
       # Generate pre-computed cache for Git metadata access (https://git-scm.com/docs/git-commit-graph)
       # This improves the performance of access to Git metadata for a large repository.
       # You can see the efficacy here: https://github.com/sider/runners/issues/2028#issuecomment-776534408
-      capture3!("git", "commit-graph", "write", "--reachable", "--changed-paths")
+      capture3!("git", "commit-graph", "write", "--reachable", "--changed-paths", "--no-progress")
 
       target_files = changes.changed_paths.map(&:to_path)
       analyze_last_committed_at(target_files)

--- a/lib/runners/processor/metrics_fileinfo.rb
+++ b/lib/runners/processor/metrics_fileinfo.rb
@@ -23,7 +23,7 @@ module Runners
       # Generate pre-computed cache for Git metadata access (https://git-scm.com/docs/git-commit-graph)
       # This improves the performance of access to Git metadata for a large repository.
       # You can see the efficacy here: https://github.com/sider/runners/issues/2028#issuecomment-776534408
-      capture3!("git","commit-graph", "write", "--reachable", "--changed-paths")
+      capture3!("git", "commit-graph", "write", "--reachable", "--changed-paths")
 
       target_files = changes.changed_paths.map(&:to_path)
       analyze_last_committed_at(target_files)


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

fix: #2028 
..and suppress too many useless stdout tracing for `git log -1` 
https://github.com/sider/runners/pull/2051/commits/78b01f289d628196b1083579484daca3a8f83efd

> Link related issues or pull requests.

#2028 

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
