### PR TITLE
Bump rbs from 1.0.4 to 1.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbs (1.0.4)
+    rbs (1.0.5)
     regexp_parser (2.0.3)
     retryable (3.0.5)
     rexml (3.2.4)

--- a/sig/uri.rbs
+++ b/sig/uri.rbs
@@ -1,3 +1,0 @@
-class URI::RFC2396_Parser
-  def make_regexp: (?Array[String] schemes) -> Regexp
-end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- https://github.com/ruby/rbs/blob/v1.0.5/CHANGELOG.md
- https://github.com/ruby/rbs/compare/v1.0.4...v1.0.5

We no longer need the `URI` polyfill thanks to this update.

> Link related issues or pull requests.

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
