### PR TITLE
[GolangCI-Lint] Fix too short timeout value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.42.0...HEAD)
 
+- **GolangCI-Lint** Fix too short timeout value [#2063](https://github.com/sider/runners/pull/2063)
+
 ## 0.42.0
 
 [Full diff](https://github.com/sider/runners/compare/0.41.1...0.42.0)

--- a/lib/runners/processor/golangci_lint.rb
+++ b/lib/runners/processor/golangci_lint.rb
@@ -96,10 +96,9 @@ module Runners
         opts << "--color=never"
         opts << "--concurrency=2"
 
-        # NOTE: The value should be less than the top-level timeout value.
-        #
-        # @see https://github.com/sider/runners/blob/1231de0ca047c7a23449ab1a7bb0751f39f16643/images/Dockerfile.end.erb#L11
-        opts << "--timeout=15m"
+        # NOTE: Set `--timeout` to prevent a user-defined timeout value via `.golangci.yml`.
+        #       This value should be less than the top-level timeout value `ENV['RUNNERS_TIMEOUT']`.
+        opts << "--timeout=10h"
 
         opts << "--tests=#{config_linter[:tests]}" unless config_linter[:tests].nil?
         opts << "--config=#{path_to_config}" if path_to_config

--- a/lib/runners/processor/golangci_lint.rb
+++ b/lib/runners/processor/golangci_lint.rb
@@ -97,7 +97,7 @@ module Runners
         opts << "--concurrency=2"
 
         # NOTE: Set `--timeout` to prevent a user-defined timeout value via `.golangci.yml`.
-        #       This value should be less than the top-level timeout value `ENV['RUNNERS_TIMEOUT']`.
+        #       This value should be enough greater than the top-level timeout value `ENV['RUNNERS_TIMEOUT']`.
         opts << "--timeout=10h"
 
         opts << "--tests=#{config_linter[:tests]}" unless config_linter[:tests].nil?


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

We now can change timeout via `ENV['RUNNERS_TIMEOUT']`, but a fixed value is set in the GolangCI-Lint runner.
This fixed value is too short, so this change extends it to high enough.

See also:
- https://github.com/sider/runners/blob/a0e468fcd3bc8b23ea47cafb31482860483e14dc/images/docker-entrypoint.sh#L39
- https://github.com/sider/runners/blob/a0e468fcd3bc8b23ea47cafb31482860483e14dc/lib/runners/shell.rb#L124

> Link related issues or pull requests.

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
