### PR TITLE
[Metrics File Info] add an argument separator for `git log -1` 

### DIFF
--- a/lib/runners/processor/metrics_fileinfo.rb
+++ b/lib/runners/processor/metrics_fileinfo.rb
@@ -83,7 +83,7 @@ module Runners
 
     def analyze_last_committed_at(targets)
       targets.each do |target|
-        stdout, _ = capture3!("git", "log", "-1", "--format=format:%aI", target, trace_stdout: false)
+        stdout, _ = capture3!("git", "log", "-1", "--format=format:%aI", "--", target, trace_stdout: false)
         last_committed_at[target] = stdout
       end
     end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

`Metrics File Info` runner use `git log -1` command to get the last commit datetime for each file. Here is an example.
```bash
git log -1 --format=format:%aI <target file name>
```

We sometimes face `fatal: ambiguous argument XXX: unknown revision or path not in the working tree.` with the command line. This is because git command cannot identify revision parameter and file path parameter. Here is a example.
```
$ git init
Initialized empty Git repository in [masked]/.git/
$ touch foo
$ git add .
$ git commit -m "add foo"
[master (root-commit) a50110a] add foo
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 foo
$ rm foo
$ git log -1 foo
fatal: ambiguous argument 'foo': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
$
```

This PR adds an [argument separator (`--`)](https://git-scm.com/docs/git-log#Documentation/git-log.txt---ltpathgt82308203) for the command. e.g.,
```bash
git log -1 --format=format:%aI -- <target file name>
```

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
