### PR TITLE
[remark-lint] Add file path to error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.42.1...HEAD)
 
+- **remark-lint** Add file path to error message [#2067](https://github.com/sider/runners/pull/2067)
+
 ## 0.42.1
 
 [Full diff](https://github.com/sider/runners/compare/0.42.0...0.42.1)

--- a/lib/runners/processor/remark_lint.rb
+++ b/lib/runners/processor/remark_lint.rb
@@ -132,7 +132,7 @@ module Runners
         file.fetch(:messages).each do |message|
           stack = message[:stack]
           if stack
-            errors << "#{message[:reason]}\n#{stack}"
+            errors << "#{message[:reason]} (at `#{path}`)\n#{stack}"
           else
             # NOTE: When `fatal` is `true`, then `severity` is `error`.
             #


### PR DESCRIPTION
This change aims to make our debugging easier.

> Link related issues or pull requests.

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
