### PR TITLE
Rename RuboCop organization: rubocop-hq -> rubocop

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ All **40** analyzers are provided as a Docker image:
 | Rails Best Practices | [docker](https://hub.docker.com/r/sider/runner_rails_best_practices), [source](https://github.com/flyerhzm/rails_best_practices), [doc](https://help.sider.review/tools/ruby/rails-best-practices), [website](https://rails-bestpractices.com) | ✅ |
 | Reek | [docker](https://hub.docker.com/r/sider/runner_reek), [source](https://github.com/troessner/reek), [doc](https://help.sider.review/tools/ruby/reek) | ✅ |
 | remark-lint | [docker](https://hub.docker.com/r/sider/runner_remark_lint), [source](https://github.com/remarkjs/remark-lint), [doc](https://help.sider.review/tools/markdown/remark-lint) | ✅ |
-| RuboCop | [docker](https://hub.docker.com/r/sider/runner_rubocop), [source](https://github.com/rubocop-hq/rubocop), [doc](https://help.sider.review/tools/ruby/rubocop), [website](https://rubocop.org) | ✅ |
+| RuboCop | [docker](https://hub.docker.com/r/sider/runner_rubocop), [source](https://github.com/rubocop/rubocop), [doc](https://help.sider.review/tools/ruby/rubocop), [website](https://rubocop.org) | ✅ |
 | SCSS-Lint | [docker](https://hub.docker.com/r/sider/runner_scss_lint), [source](https://github.com/sds/scss-lint), [doc](https://help.sider.review/tools/css/scss-lint) | ⚠️ *deprecated* |
 | ShellCheck | [docker](https://hub.docker.com/r/sider/runner_shellcheck), [source](https://github.com/koalaman/shellcheck), [doc](https://help.sider.review/tools/shellscript/shellcheck), [website](https://www.shellcheck.net) | ✅ |
 | Slim-Lint | [docker](https://hub.docker.com/r/sider/runner_slim_lint), [source](https://github.com/sds/slim-lint), [doc](https://help.sider.review/tools/ruby/slim-lint) | ✅ *beta* |

--- a/analyzers.yml
+++ b/analyzers.yml
@@ -164,7 +164,7 @@ analyzers:
     doc: tools/markdown/remark-lint
   rubocop:
     name: RuboCop
-    github: rubocop-hq/rubocop
+    github: rubocop/rubocop
     doc: tools/ruby/rubocop
     website: https://rubocop.org
   scss_lint:

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -58,7 +58,7 @@ module Runners
 
         # NOTE: `--parallel` requires a cache.
         #
-        # @see https://github.com/rubocop-hq/rubocop/blob/v1.3.1/lib/rubocop/options.rb#L353-L355
+        # @see https://github.com/rubocop/rubocop/blob/v1.3.1/lib/rubocop/options.rb#L353-L355
         "--parallel",
         "--cache=true",
         *cache_root,
@@ -158,13 +158,13 @@ module Runners
 
     def check_rubocop_yml_warning(stderr)
       patterns = [
-        # @see https://github.com/rubocop-hq/rubocop/blob/v0.89.1/lib/rubocop/cop/registry.rb#L263
+        # @see https://github.com/rubocop/rubocop/blob/v0.89.1/lib/rubocop/cop/registry.rb#L263
         /(?<file>.+): .+ has the wrong namespace/,
 
-        # @see https://github.com/rubocop-hq/rubocop/blob/v0.71.0/lib/rubocop/runner.rb#L30
+        # @see https://github.com/rubocop/rubocop/blob/v0.71.0/lib/rubocop/runner.rb#L30
         /Rails cops will be removed from RuboCop 0.72/,
 
-        # @see https://github.com/rubocop-hq/rubocop/blob/v0.89.1/lib/rubocop/cop/team.rb#L244
+        # @see https://github.com/rubocop/rubocop/blob/v0.89.1/lib/rubocop/cop/team.rb#L244
         /An error occurred while .+ inspecting (?<file>.+):.+:/,
       ]
 
@@ -193,13 +193,13 @@ module Runners
       original_message.delete_suffix("(" + links.join(", ") + ")").strip
     end
 
-    # @see https://github.com/rubocop-hq/rubocop/blob/v0.72.0/CHANGELOG.md
+    # @see https://github.com/rubocop/rubocop/blob/v0.72.0/CHANGELOG.md
     def rails_cops_removed?
       Gem::Version.create(analyzer_version) >= Gem::Version.create("0.72.0")
     end
 
     def cache_root
-      # @see https://github.com/rubocop-hq/rubocop/blob/v0.91.0/CHANGELOG.md
+      # @see https://github.com/rubocop/rubocop/blob/v0.91.0/CHANGELOG.md
       if Gem::Version.create(analyzer_version) >= Gem::Version.create("0.91.0")
         ["--cache-root=#{File.join(Dir.tmpdir, 'rubocop-cache')}"]
       else

--- a/lib/runners/rubocop_utils.rb
+++ b/lib/runners/rubocop_utils.rb
@@ -1,7 +1,7 @@
 module Runners
   module RuboCopUtils
-    # The followings are maintained by RuboCop Headquarters.
-    # @see https://github.com/rubocop-hq
+    # The followings are maintained by the RuboCop organization.
+    # @see https://github.com/rubocop
     def official_rubocop_plugins
       @official_rubocop_plugins ||= %w[
         rubocop-md

--- a/test/rubocop_utils_test.rb
+++ b/test/rubocop_utils_test.rb
@@ -6,10 +6,10 @@ class RuboCopUtilsTest < Minitest::Test
   def test_build_rubocop_links
     with_workspace do |workspace|
       processor = new_processor(workspace)
-      assert_links = ->(expected, actual) {
+      assert_links = ->(expected, actual, additional_statuses: []) {
         assert_equal expected, processor.build_rubocop_links(actual)
         expected.each do |url|
-          assert_includes ["200", "202"], Net::HTTP.get_response(URI(url)).code, url
+          assert_includes ["200", "202", *additional_statuses.map(&:to_s)], Net::HTTP.get_response(URI(url)).code, url
         end
       }
 
@@ -72,11 +72,11 @@ class RuboCopUtilsTest < Minitest::Test
       assert_links.call %w[
         https://www.rubydoc.info/gems/rubocop-rake/RuboCop/Cop/Rake/Desc
         https://github.com/rubocop-hq/rubocop-rake
-      ], "Rake/Desc"
+      ], "Rake/Desc", additional_statuses: [301] # TODO: Remove `additional_statuses`
       assert_links.call %w[
         https://www.rubydoc.info/gems/rubocop-rubycw/RuboCop/Cop/Rubycw/Rubycw
         https://github.com/rubocop-hq/rubocop-rubycw
-      ], "Rubycw/Rubycw"
+      ], "Rubycw/Rubycw", additional_statuses: [301] # TODO: Remove `additional_statuses`
       assert_links.call %w[
         https://www.rubydoc.info/gems/rubocop-sequel/RuboCop/Cop/Sequel/ColumnDefault
         https://github.com/rubocop-hq/rubocop-sequel

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -40,10 +40,10 @@ class RubyTest < Minitest::Test
 
   def test_gemfile_content
     specs = [
-      Spec.new(name: "rubocop", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop-hq/rubocop.git", branch: "master" } })),
+      Spec.new(name: "rubocop", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop.git", branch: "master" } })),
       Spec.new(name: "runners", version: [], source: Source.create({ git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" } })),
-      Spec.new(name: "rubocop-rails", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop-hq/rubocop-rails.git", branch: "dev" } })),
-      Spec.new(name: "rubocop-rspec", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop-hq/rubocop-rspec.git", tag: "v1.13.0" } })),
+      Spec.new(name: "rubocop-rails", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" } })),
+      Spec.new(name: "rubocop-rspec", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" } })),
       Spec.new(name: "rubocop-sider", version: [], source: Source.create({ source: "https://gems.sider.review" })),
       Spec.new(name: "rubocop-nyan", version: [], source: Source.create({ source: "https://gems.sider.review" })),
       Spec.new(name: "meowcop", version: ["1.2.0"]),
@@ -72,7 +72,7 @@ class RubyTest < Minitest::Test
           gem "rubocop-nyan"
         end
 
-        git "https://github.com/rubocop-hq/rubocop.git", branch: "master" do
+        git "https://github.com/rubocop/rubocop.git", branch: "master" do
           gem "rubocop"
         end
 
@@ -80,11 +80,11 @@ class RubyTest < Minitest::Test
           gem "runners"
         end
 
-        git "https://github.com/rubocop-hq/rubocop-rails.git", branch: "dev" do
+        git "https://github.com/rubocop/rubocop-rails.git", branch: "dev" do
           gem "rubocop-rails"
         end
 
-        git "https://github.com/rubocop-hq/rubocop-rspec.git", tag: "v1.13.0" do
+        git "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" do
           gem "rubocop-rspec"
         end
       CONTENT
@@ -139,8 +139,8 @@ class RubyTest < Minitest::Test
   def test_install_success
     specs = [
       Spec.new(name: "strong_json", version: ["0.5.0"]),
-      Spec.new(name: "rubocop-rspec", version: ["1.32.0"],
-               source: Source.create({ git: { repo: "https://github.com/rubocop-hq/rubocop-rspec.git", tag: "v1.32.0" } })),
+      Spec.new(name: "rubocop-rails", version: ["2.9.0"],
+               source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop-rails.git", tag: "v2.9.0" } })),
     ]
 
     mktmpdir do |path|
@@ -158,9 +158,9 @@ class RubyTest < Minitest::Test
         stdout, _ = shell.capture3("bundle", "exec", "gem", "list")
         lines = stdout.lines(chomp: true)
         assert_includes lines, "strong_json (0.5.0)"
-        assert_includes lines, "rubocop-rspec (1.32.0)"
+        assert_includes lines, "rubocop-rails (2.9.0)"
         assert_equal "0.5.0", hash["strong_json"]
-        assert_equal "1.32.0", hash["rubocop-rspec"]
+        assert_equal "2.9.0", hash["rubocop-rails"]
       end
 
       gemfile_content_log = <<~RUBY.strip
@@ -169,8 +169,8 @@ class RubyTest < Minitest::Test
 
         gem "strong_json", "0.5.0", "<= 0.8.0"
 
-        git "https://github.com/rubocop-hq/rubocop-rspec.git", tag: "v1.32.0" do
-          gem "rubocop-rspec"
+        git "https://github.com/rubocop/rubocop-rails.git", tag: "v2.9.0" do
+          gem "rubocop-rails"
         end
       RUBY
       assert system("ruby", "-ce", gemfile_content_log)
@@ -209,8 +209,8 @@ class RubyTest < Minitest::Test
       { name: "strong_json", version: "0.7.0", source: "https://my.gems.org" },
       { name: "rubocop-sider", git: { repo: "https://github.com/sider/rubocop-sider.git" } },
       { name: "runners", git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" } },
-      { name: "rubocop-rails", git: { repo: "https://github.com/rubocop-hq/rubocop-rails.git", branch: "dev" } },
-      { name: "rubocop-rspec", git: { repo: "https://github.com/rubocop-hq/rubocop-rspec.git", tag: "v1.13.0" } },
+      { name: "rubocop-rails", git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" } },
+      { name: "rubocop-performance", git: { repo: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" } },
     ])
 
     assert_equal [
@@ -218,8 +218,8 @@ class RubyTest < Minitest::Test
       Spec.new(name: "strong_json", version: ["0.7.0"], source: Source.create({ source: "https://my.gems.org" })),
       Spec.new(name: "rubocop-sider", version: [], source: Source.create({ git: { repo: "https://github.com/sider/rubocop-sider.git" } })),
       Spec.new(name: "runners", version: [], source: Source.create({ git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" } })),
-      Spec.new(name: "rubocop-rails", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop-hq/rubocop-rails.git", branch: "dev" } })),
-      Spec.new(name: "rubocop-rspec", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop-hq/rubocop-rspec.git", tag: "v1.13.0" } })),
+      Spec.new(name: "rubocop-rails", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" } })),
+      Spec.new(name: "rubocop-performance", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" } })),
     ], specs
   end
 

--- a/test/smokes/rubocop/unexpected_error/backtrace_silencers.rb
+++ b/test/smokes/rubocop/unexpected_error/backtrace_silencers.rb
@@ -1,3 +1,3 @@
-# https://github.com/rubocop-hq/rubocop/issues/8674
+# https://github.com/rubocop/rubocop/issues/8674
 
 Rails.backtrace_cleaner.remove_silencers! if ENV['CI']


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

See <https://github.com/rubocop/rubocop/discussions/9517> for details.

Note: Some plugins like [`rubocop-rspec`](https://github.com/rubocop-hq/rubocop-rspec) are hosted under `rubocop-hq`.

> Link related issues or pull requests.

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
