### PR TITLE
Remove *removed* Go tools from `sider.yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Misc:
 
 - **Flake8** Provide Sider's recommended ruleset [#1980](https://github.com/sider/runners/pull/1980)
 - **PHP_CodeSniffer** Provide Sider's recommended ruleset [#2084](https://github.com/sider/runners/pull/2084)
+- Remove *removed* Go tools from `sider.yml` [#2099](https://github.com/sider/runners/pull/2099)
 
 ## 0.43.0
 

--- a/lib/runners/config.rb
+++ b/lib/runners/config.rb
@@ -95,7 +95,8 @@ module Runners
     end
 
     def check_unsupported_linters(linter_ids)
-      ids = linter_ids.filter { |id| linter?(id) }
+      parsed_content = parse # must not do schema-check
+      ids = linter_ids.map(&:to_sym).filter { |id| parsed_content&.dig(:linter, id) }
 
       if ids.empty?
         ""

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -9,15 +9,6 @@ module Runners
       Schema::Config.register(name: name, schema: schema)
     end
 
-    # TODO: Keep the following schemas for the backward compatibility.
-    RemovedGoToolSchema = _ = StrongJSON.new do
-      # @type self: RemovedGoToolSchemaClass
-      let :config, any?
-    end
-    register_config_schema(name: :golint, schema: RemovedGoToolSchema.config)
-    register_config_schema(name: :go_vet, schema: RemovedGoToolSchema.config)
-    register_config_schema(name: :gometalinter, schema: RemovedGoToolSchema.config)
-
     attr_reader :guid, :working_dir, :config, :shell, :trace_writer, :warnings
 
     def_delegators :@shell,

--- a/sig/runners/processor.rbs
+++ b/sig/runners/processor.rbs
@@ -7,11 +7,6 @@ module Runners
     class CIConfigBroken < UserError
     end
 
-    class RemovedGoToolSchemaClass < StrongJSON
-      def config: () -> StrongJSON::_Schema[untyped]
-    end
-    RemovedGoToolSchema: RemovedGoToolSchemaClass
-
     def self.register_config_schema: (name: Symbol, schema: StrongJSON::_Schema[untyped]) -> void
 
     def self.children: () -> Hash[Symbol, singleton(Processor)]

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -92,10 +92,10 @@
   diagnostics:
   - range:
       start:
-        line: 122
+        line: 113
         character: 26
       end:
-        line: 122
+        line: 113
         character: 29
     severity: ERROR
     message: |-
@@ -107,10 +107,10 @@
     code: Ruby::ArgumentTypeMismatch
   - range:
       start:
-        line: 122
+        line: 113
         character: 31
       end:
-        line: 122
+        line: 113
         character: 40
     severity: ERROR
     message: |-
@@ -125,10 +125,10 @@
     code: Ruby::ArgumentTypeMismatch
   - range:
       start:
-        line: 307
+        line: 298
         character: 45
       end:
-        line: 307
+        line: 298
         character: 50
     severity: ERROR
     message: Type `(::String | ::Array[::String] | nil)` does not have method `split`

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -35,7 +35,6 @@ class ConfigTest < Minitest::Test
     YAML
     assert_equal(
       { linter: {
-        golint: nil, go_vet: nil, gometalinter: nil,
         brakeman: nil,
         checkstyle: nil,
         clang_tidy: nil,
@@ -227,34 +226,17 @@ class ConfigTest < Minitest::Test
     refute Runners::Config.new(path: file, raw_content: "").linter?("foo")
   end
 
-  def test_removed_go_tools_do_not_break
-    yaml = <<~YAML
-      linter:
-        golint:
-          root_dir: src/
-        go_vet:
-          root_dir: lib/
-        gometalinter:
-          root_dir: module/
-          import_path: foo
-    YAML
-    config = Runners::Config.new(path: Pathname(FILE_NAME), raw_content: yaml)
-    assert_equal({ root_dir: "src/" }, config.linter("golint"))
-    assert_equal({ root_dir: "lib/" }, config.linter("go_vet"))
-    assert_equal({ root_dir: "module/", import_path: "foo" }, config.linter("gometalinter"))
-  end
-
   def test_check_unsupported_linters
     yaml = <<~YAML
       linter:
-        golint: {}
-        go_vet: {}
+        foo: {}
+        baz: {}
     YAML
     config = Runners::Config.new(path: Pathname(FILE_NAME), raw_content: yaml)
-    assert_equal <<~MSG, config.check_unsupported_linters(%w[golint go_vet gometalinter])
+    assert_equal <<~MSG, config.check_unsupported_linters(%w[foo bar baz])
       The following linters in your `sider.yml` are no longer supported. Please remove them.
-      - `linter.golint`
-      - `linter.go_vet`
+      - `linter.foo`
+      - `linter.baz`
     MSG
   end
 

--- a/test/smokes/golangci_lint/deprecated_tools/sider.yml
+++ b/test/smokes/golangci_lint/deprecated_tools/sider.yml
@@ -1,4 +1,0 @@
-linter:
-  golint: {}
-  go_vet: {}
-  gometalinter: {}

--- a/test/smokes/golangci_lint/expectations.rb
+++ b/test/smokes/golangci_lint/expectations.rb
@@ -410,16 +410,3 @@ s.add_test(
   ],
   analyzer: { name: "GolangCI-Lint", version: default_version }
 )
-
-s.add_test(
-  "deprecated_tools",
-  type: "success",
-  issues: [],
-  analyzer: { name: "GolangCI-Lint", version: default_version },
-  warnings: [{ message: <<~MSG.strip, file: "sider.yml" }]
-    The following linters in your `sider.yml` are no longer supported. Please remove them.
-    - `linter.golint`
-    - `linter.go_vet`
-    - `linter.gometalinter`
-  MSG
-)


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

We have removed `golint`, `go_vet`, and `gometalinter` already, but they have been supported in `sider.yml` for backward compatibility.

I think it reasonable to remove the compatibility now.
(Maybe there remains in some `sider.yml` files but it should be few)

See also our [blog post](https://siderlabs.com/blog/siders-go-meta-linter-support-will-be-discontinued-at-the-end-of-may-2020-5985a2c5b5cb/).

> Link related issues or pull requests.

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
