### PR TITLE
Bump aws-sdk-s3 from 1.88.1 to 1.89.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
     aws-sdk-kms (1.42.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.88.2)
+    aws-sdk-s3 (1.89.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- https://github.com/aws/aws-sdk-ruby/blob/HEAD/gems/aws-sdk-s3/CHANGELOG.md
- https://my.diffend.io/gems/aws-sdk-s3/1.88.2/1.89.0

> Link related issues or pull requests.

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
