### PR TITLE
[Metrics FileInfo] refine log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.44.0...HEAD)
 
+Misc:
+
+- **Metrics FileInfo** Refine log message [#2127](https://github.com/sider/runners/pull/2127)
+
 ## 0.44.0
 
 [Full diff](https://github.com/sider/runners/compare/0.43.0...0.44.0)

--- a/lib/runners/processor/metrics_fileinfo.rb
+++ b/lib/runners/processor/metrics_fileinfo.rb
@@ -62,19 +62,21 @@ module Runners
     end
 
     def analyze_lines_of_code(targets)
-      text_files = targets.select { |f| text_file?(f) }
-      text_files.each_slice(1000) do |files|
-        stdout, _ = capture3!("wc", "-l", *files, trace_stdout: false)
-        lines = stdout.lines(chomp: true)
+      trace_writer.message "Analyzing line of code..." do
+        text_files = targets.select { |f| text_file?(f) }
+        text_files.each_slice(1000) do |files|
+          stdout, _ = capture3!("wc", "-l", *files, trace_stdout: false, trace_command_line: false)
+          lines = stdout.lines(chomp: true)
 
-        # `wc` command outputs total count when we pass multiple targets. remove it if exist
-        lines.pop if lines.last&.match?(/^\d+ total$/)
+          # `wc` command outputs total count when we pass multiple targets. remove it if exist
+          lines.pop if lines.last&.match?(/^\d+ total$/)
 
-        lines.each do |line|
-          fields = line.split(" ")
-          loc = (fields[0] or raise)
-          fname = (fields[1] or raise)
-          lines_of_code[Pathname(fname)] = Integer(loc)
+          lines.each do |line|
+            fields = line.split(" ")
+            loc = (fields[0] or raise)
+            fname = (fields[1] or raise)
+            lines_of_code[Pathname(fname)] = Integer(loc)
+          end
         end
       end
     end

--- a/lib/runners/processor/metrics_fileinfo.rb
+++ b/lib/runners/processor/metrics_fileinfo.rb
@@ -22,7 +22,9 @@ module Runners
       # Generate pre-computed cache for Git metadata access (https://git-scm.com/docs/git-commit-graph)
       # This improves the performance of access to Git metadata for a large repository.
       # You can see the efficacy here: https://github.com/sider/runners/issues/2028#issuecomment-776534408
-      capture3!("git", "commit-graph", "write", "--reachable", "--changed-paths", "--no-progress")
+      trace_writer.message "Generating pre-computed Git metadata cache..." do
+        capture3!("git", "commit-graph", "write", "--reachable", "--changed-paths", trace_stdout: false, trace_command_line: false)
+      end
 
       target_files = Pathname.glob("**/*", File::FNM_DOTMATCH).filter do |path|
         path.file? && !path.fnmatch?(".git/**", File::FNM_DOTMATCH)
@@ -130,7 +132,7 @@ module Runners
     #  * A text file having a non-well-known extension. (e.g. foo.my_original_extension )
     def text_files
       @text_files ||= Set[].tap do |result|
-        stdout, _ = capture3!("git", "ls-files", "--eol", "--error-unmatch", trace_stdout: false)
+        stdout, _ = capture3!("git", "ls-files", "--eol", "--error-unmatch", trace_stdout: false, trace_command_line:false)
         stdout.each_line(chomp: true) do |line|
           fields = line.split(" ")
           type = (fields[1] or raise)


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Now, the log message from `metrics_fileinfo` is redundant because it contains command line options for `wc -l`. This PR suppress that. In addition, I refine other log messages.

Before:
![before](https://user-images.githubusercontent.com/48303198/109599791-25ba2d80-7b5f-11eb-8e2f-77f53c4d308f.PNG)

After:
![after](https://user-images.githubusercontent.com/48303198/109599799-2ce13b80-7b5f-11eb-9186-84f37883fb58.PNG)

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
