### PR TITLE
[GolangCI-Lint] Set explicitly `GO111MODULE=auto`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.44.1...HEAD)
 
+- **GolangCI-Lint** Set explicitly `GO111MODULE=auto` [#2129](https://github.com/sider/runners/pull/2129)
+
 ## 0.44.1
 
 [Full diff](https://github.com/sider/runners/compare/0.44.0...0.44.1)

--- a/images/golangci_lint/Dockerfile
+++ b/images/golangci_lint/Dockerfile
@@ -40,3 +40,6 @@ WORKDIR $RUNNER_USER_HOME
 
 COPY images/docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh", "runners", "--analyzer=golangci_lint"]
+
+# NOTE: Make the `go.mod` file needless (compatible with Go 1.15). See https://golang.org/doc/go1.16#go-command
+ENV GO111MODULE auto

--- a/images/golangci_lint/Dockerfile
+++ b/images/golangci_lint/Dockerfile
@@ -41,5 +41,7 @@ WORKDIR $RUNNER_USER_HOME
 COPY images/docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh", "runners", "--analyzer=golangci_lint"]
 
-# NOTE: Make the `go.mod` file needless (compatible with Go 1.15). See https://golang.org/doc/go1.16#go-command
+# NOTE: Make the `go.mod` file needless (compatible with Go 1.15). See below:
+#       - https://golang.org/doc/go1.16#go-command
+#       - https://golang.org/ref/mod#mod-commands
 ENV GO111MODULE auto

--- a/images/golangci_lint/Dockerfile.erb
+++ b/images/golangci_lint/Dockerfile.erb
@@ -9,3 +9,8 @@ COPY --chown=<%= chown %> --from=golangci-lint /usr/bin/golangci-lint ${RUNNER_U
 COPY --chown=<%= chown %> images/golangci_lint/sider_golangci.yml ${RUNNER_USER_HOME}/
 
 <%= render_erb 'images/Dockerfile.end.erb' %>
+
+# NOTE: Make the `go.mod` file needless (compatible with Go 1.15). See below:
+#       - https://golang.org/doc/go1.16#go-command
+#       - https://golang.org/ref/mod#mod-commands
+ENV GO111MODULE auto


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This setting is compatible with Go 1.15.

See also:
- https://github.com/sider/devon_rex/pull/427
- https://golang.org/doc/go1.16#go-command
- https://golang.org/ref/mod#mod-commands

> Link related issues or pull requests.

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
