### PR TITLE
[detekt] Add `parallel` and `target` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - **GolangCI-Lint** Set explicitly `GO111MODULE=auto` [#2129](https://github.com/sider/runners/pull/2129)
 - **Flake8** Add `parallel` option [#2130](https://github.com/sider/runners/pull/2130)
+- **detekt** Add `parallel` option [#2131](https://github.com/sider/runners/pull/2131)
 
 ## 0.44.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - **GolangCI-Lint** Set explicitly `GO111MODULE=auto` [#2129](https://github.com/sider/runners/pull/2129)
 - **Flake8** Add `parallel` option [#2130](https://github.com/sider/runners/pull/2130)
-- **detekt** Add `parallel` option [#2131](https://github.com/sider/runners/pull/2131)
+- **detekt** Add `parallel` and `target` options [#2131](https://github.com/sider/runners/pull/2131)
 
 ## 0.44.1
 

--- a/lib/runners/processor/detekt.rb
+++ b/lib/runners/processor/detekt.rb
@@ -5,6 +5,7 @@ module Runners
 
     Schema = _ = StrongJSON.new do
       # @type self: SchemaClass
+
       let :runner_config, Runners::Schema::BaseConfig.java.update_fields { |fields|
         fields.merge!({
           baseline: string?,
@@ -14,6 +15,7 @@ module Runners
           excludes: enum?(string, array(string)),
           includes: enum?(string, array(string)),
           input: enum?(string, array(string)),
+          parallel: boolean?,
         })
       }
 
@@ -42,6 +44,7 @@ module Runners
         input:
           - src/
           - test/
+        parallel: true
       YAML
     end
 
@@ -60,14 +63,15 @@ module Runners
 
       _stdout, stderr, status = capture3(
         analyzer_bin,
-        *cli_baseline,
-        *cli_config,
-        *cli_config_resource,
-        *cli_disable_default_rulesets,
-        *cli_excludes,
-        *cli_includes,
-        *cli_input,
-        *cli_report,
+        "--report", "xml:#{report_file}",
+        *(config_linter[:baseline].then { |value| value ? ["--baseline", value] : [] }),
+        *(comma_separated_list(config_linter[:config]).then { |list| list ? ["--config", list] : [] }),
+        *(comma_separated_list(config_linter[:"config-resource"]).then { |list| list ? ["--config-resource", list] : [] }),
+        *(config_linter[:"disable-default-rulesets"] ? ["--disable-default-rulesets"] : []),
+        *(config_linter[:parallel] ? ["--parallel"] : []),
+        *(comma_separated_list(config_linter[:excludes]).then { |list| list ? ["--excludes", list] : [] }),
+        *(comma_separated_list(config_linter[:includes]).then { |list| list ? ["--includes", list] : [] }),
+        *(comma_separated_list(config_linter[:input]).then { |list| list ? ["--input", list] : []}),
       )
 
       # detekt has some exit codes.
@@ -83,38 +87,6 @@ module Runners
     end
 
     private
-
-    def cli_baseline
-      config_linter[:baseline].then { |value| value ? ["--baseline", value] : [] }
-    end
-
-    def cli_config
-      Array(config_linter[:config]).then { |arr| arr.empty? ? [] : ["--config", arr.join(",")] }
-    end
-
-    def cli_config_resource
-      Array(config_linter[:"config-resource"]).then { |arr| arr.empty? ? [] : ["--config-resource", arr.join(",")] }
-    end
-
-    def cli_disable_default_rulesets
-      config_linter[:"disable-default-rulesets"] ? ["--disable-default-rulesets"] : []
-    end
-
-    def cli_excludes
-      Array(config_linter[:excludes]).then { |arr| arr.empty? ? [] : ["--excludes", arr.join(",")] }
-    end
-
-    def cli_includes
-      Array(config_linter[:includes]).then { |arr| arr.empty? ? [] : ["--includes", arr.join(",")] }
-    end
-
-    def cli_input
-      Array(config_linter[:input]).then { |arr| arr.empty? ? [] : ["--input", arr.join(",")] }
-    end
-
-    def cli_report
-      ["--report", "xml:#{report_file}"]
-    end
 
     def parse_output
       issues = []

--- a/lib/runners/processor/detekt.rb
+++ b/lib/runners/processor/detekt.rb
@@ -6,6 +6,8 @@ module Runners
     Schema = _ = StrongJSON.new do
       # @type self: SchemaClass
 
+      let :target, enum?(string, array(string))
+
       let :runner_config, Runners::Schema::BaseConfig.java.update_fields { |fields|
         fields.merge!({
           baseline: string?,
@@ -14,7 +16,8 @@ module Runners
           "disable-default-rulesets": boolean?,
           excludes: enum?(string, array(string)),
           includes: enum?(string, array(string)),
-          input: enum?(string, array(string)),
+          target: target,
+          input: target, # alias for `target`
           parallel: boolean?,
         })
       }
@@ -71,7 +74,7 @@ module Runners
         *(config_linter[:parallel] ? ["--parallel"] : []),
         *(comma_separated_list(config_linter[:excludes]).then { |list| list ? ["--excludes", list] : [] }),
         *(comma_separated_list(config_linter[:includes]).then { |list| list ? ["--includes", list] : [] }),
-        *(comma_separated_list(config_linter[:input]).then { |list| list ? ["--input", list] : []}),
+        *(comma_separated_list(config_linter[:target] || config_linter[:input]).then { |list| list ? ["--input", list] : []}),
       )
 
       # detekt has some exit codes.

--- a/lib/runners/processor/detekt.rb
+++ b/lib/runners/processor/detekt.rb
@@ -44,7 +44,7 @@ module Runners
           - "**/vendor/**"
         includes:
           - "**/important/**"
-        input:
+        target:
           - src/
           - test/
         parallel: true

--- a/sig/runners/processor/detekt.rbs
+++ b/sig/runners/processor/detekt.rbs
@@ -4,6 +4,7 @@ module Runners
     include Kotlin
 
     class SchemaClass < StrongJSON
+      def target: () -> StrongJSON::Type::Optional[untyped]
       def runner_config: () -> StrongJSON::Type::Object[untyped]
       def issue: () -> StrongJSON::Type::Object[untyped]
     end

--- a/sig/runners/processor/detekt.rbs
+++ b/sig/runners/processor/detekt.rbs
@@ -11,22 +11,6 @@ module Runners
 
     private
 
-    def cli_baseline: () -> Array[String]
-
-    def cli_config: () -> Array[String]
-
-    def cli_config_resource: () -> Array[String]
-
-    def cli_disable_default_rulesets: () -> Array[String]
-
-    def cli_excludes: () -> Array[String]
-
-    def cli_includes: () -> Array[String]
-
-    def cli_input: () -> Array[String]
-
-    def cli_report: () -> Array[String]
-
     def parse_output: () -> Array[Issue]
   end
 end

--- a/test/config_generator_test.rb
+++ b/test/config_generator_test.rb
@@ -20,9 +20,10 @@ class ConfigGeneratorTest < Minitest::Test
       end
     end
 
+    end_line = 405
     assert_yaml "test_generate_with_tools.yml",
                 tools: tools,
-                comment_out_lines: [9..404, 407..411, 414..418]
+                comment_out_lines: [9..end_line, (end_line + 3)..(end_line + 7), (end_line + 10)..(end_line + 14)]
   end
 
   private

--- a/test/data/test_generate_with_tools.yml
+++ b/test/data/test_generate_with_tools.yml
@@ -92,7 +92,7 @@ linter:
 #       - "**/vendor/**"
 #     includes:
 #       - "**/important/**"
-#     input:
+#     target:
 #       - src/
 #       - test/
 #     parallel: true

--- a/test/data/test_generate_with_tools.yml
+++ b/test/data/test_generate_with_tools.yml
@@ -95,6 +95,7 @@ linter:
 #     input:
 #       - src/
 #       - test/
+#     parallel: true
 
 #   # ESLint example. See https://help.sider.review/tools/javascript/eslint
 #   eslint:

--- a/test/smokes/detekt/expectations.rb
+++ b/test/smokes/detekt/expectations.rb
@@ -237,3 +237,22 @@ s.add_test(
     }
   ]
 )
+
+s.add_test(
+  "with_option_target",
+  type: "success",
+  analyzer: { name: "detekt", version: default_version },
+  issues: [
+    {
+      id: "detekt.EmptyClassBlock",
+      path: "src/Foo.kt",
+      location: { start_line: 1, start_column: 11 },
+      message: "The class or object Foo is empty.",
+      links: [],
+      object: { severity: "info" },
+      git_blame_info: {
+        commit: :_, line_hash: "313d20acfe186ea3594870fc6d56c119f658fef2", original_line: 1, final_line: 1
+      }
+    }
+  ]
+)

--- a/test/smokes/detekt/with_option_target/sider.yml
+++ b/test/smokes/detekt/with_option_target/sider.yml
@@ -1,0 +1,4 @@
+linter:
+  detekt:
+    target: src/
+    input: test/ # ignored

--- a/test/smokes/detekt/with_option_target/src/Foo.kt
+++ b/test/smokes/detekt/with_option_target/src/Foo.kt
@@ -1,0 +1,1 @@
+class Foo {}

--- a/test/smokes/detekt/with_option_target/test/Bar.kt
+++ b/test/smokes/detekt/with_option_target/test/Bar.kt
@@ -1,0 +1,1 @@
+class Bar {}

--- a/test/smokes/detekt/with_options/sider.yml
+++ b/test/smokes/detekt/with_options/sider.yml
@@ -4,9 +4,10 @@ linter:
       config: "default-detekt-config.yml"
       config-resource: []
       disable-default-rulesets: false
-      excludes: 
+      excludes:
         - "**/excludes_dir/**"
         - "**/excludes_dir_nothing/**"
       includes: []
-      input: 
+      input:
         - "src/"
+      parallel: true


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change adds the new options: `parallel` (disabled by default) and `target` (alias for `input`).

> Link related issues or pull requests.

Close #1958
Part of #2096 (`target` option)

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
