### PR TITLE
Fix RuboCopUtilsTest#test_build_rubocop_links

### DIFF
--- a/test/rubocop_utils_test.rb
+++ b/test/rubocop_utils_test.rb
@@ -80,7 +80,7 @@ class RuboCopUtilsTest < Minitest::Test
       assert_links.call %w[
         https://www.rubydoc.info/gems/rubocop-sequel/RuboCop/Cop/Sequel/ColumnDefault
         https://github.com/rubocop-hq/rubocop-sequel
-      ], "Sequel/ColumnDefault"
+      ], "Sequel/ColumnDefault", additional_statuses: [301] # TODO: Remove `additional_statuses`
       assert_links.call %w[
         https://www.rubydoc.info/gems/rubocop-sketchup/RuboCop/Cop/SketchupBugs/RenderMode
         https://github.com/sketchup/rubocop-sketchup


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

```
RuboCopUtilsTest#test_build_rubocop_links [/home/runner/work/runners/runners/test/rubocop_utils_test.rb:12]:
rubocop-hq/rubocop-sequel.
Expected ["200", "202"] to include # encoding: ASCII-8BIT
#    valid: true
"301".
```

> Link related issues or pull requests.

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
