### PR TITLE
[Metrics Code Clone] Report the total number of duplicated lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Misc:
 - **Flake8** Add `parallel` option [#2130](https://github.com/sider/runners/pull/2130)
 - **detekt** Add `parallel` and `target` options [#2131](https://github.com/sider/runners/pull/2131)
 - **PHP_CodeSniffer** Re-consider options (`target`, `standard`, `parallel`) [#2132](https://github.com/sider/runners/pull/2132)
+- **Metrics Code Clone** Report the total number of duplicated lines [#2146](https://github.com/sider/runners/pull/2146)
 
 ## 0.44.1
 

--- a/lib/runners/processor/metrics_codeclone.rb
+++ b/lib/runners/processor/metrics_codeclone.rb
@@ -7,6 +7,7 @@ module Runners
 
       let :issue, object(
         clones: integer,
+        'total-clone-lines': integer,
       )
     end
 
@@ -57,6 +58,7 @@ module Runners
         message: msg,
         object: {
           clones: clones,
+          'total-clone-lines': sum_of_lines,
         },
         schema: Schema.issue,
       )

--- a/lib/runners/processor/metrics_codeclone.rb
+++ b/lib/runners/processor/metrics_codeclone.rb
@@ -7,7 +7,7 @@ module Runners
 
       let :issue, object(
         clones: integer,
-        'total-clone-lines': integer,
+        total_clone_lines: integer,
       )
     end
 
@@ -58,7 +58,7 @@ module Runners
         message: msg,
         object: {
           clones: clones,
-          'total-clone-lines': sum_of_lines,
+          total_clone_lines: sum_of_lines,
         },
         schema: Schema.issue,
       )

--- a/test/smokes/metrics_codeclone/expectations.rb
+++ b/test/smokes/metrics_codeclone/expectations.rb
@@ -13,7 +13,8 @@ s.add_test(
       message: "The number of code clones is 2 with total 56 lines.",
       links: [],
       object: {
-        clones: 2
+        clones: 2,
+        'total-clone-lines': 56
       },
       git_blame_info: nil
     }
@@ -53,7 +54,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 28 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 28
       },
       git_blame_info: nil
     },
@@ -64,7 +66,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 28 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 28
       },
       git_blame_info: nil
     }
@@ -83,7 +86,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 14 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 14
       },
       git_blame_info: nil
     },
@@ -94,7 +98,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 14 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 14
       },
       git_blame_info: nil
     }
@@ -113,7 +118,8 @@ s.add_test(
       message: "The number of code clones is 3 with total 10 lines.",
       links: [],
       object: {
-        clones: 3
+        clones: 3,
+        'total-clone-lines': 10
       },
       git_blame_info: nil
     },
@@ -124,7 +130,8 @@ s.add_test(
       message: "The number of code clones is 3 with total 10 lines.",
       links: [],
       object: {
-        clones: 3
+        clones: 3,
+        'total-clone-lines': 10
       },
       git_blame_info: nil
     }
@@ -143,7 +150,8 @@ s.add_test(
       message: "The number of code clones is 2 with total 22 lines.",
       links: [],
       object: {
-        clones: 2
+        clones: 2,
+        'total-clone-lines': 22
       },
       git_blame_info: nil
     }
@@ -162,7 +170,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 24 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 24
       },
       git_blame_info: nil
     },
@@ -173,7 +182,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 24 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 24
       },
       git_blame_info: nil
     }
@@ -211,7 +221,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 15 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 15
       },
       git_blame_info: nil
     },
@@ -222,7 +233,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 15 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 15
       },
       git_blame_info: nil
     }
@@ -251,7 +263,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 40 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 40
       },
       git_blame_info: nil
     },
@@ -262,7 +275,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 40 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 40
       },
       git_blame_info: nil
     }
@@ -281,7 +295,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 15 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 15
       },
       git_blame_info: nil
     },
@@ -292,7 +307,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 15 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 15
       },
       git_blame_info: nil
     }
@@ -325,7 +341,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 15 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 15
       },
       git_blame_info: nil
     },
@@ -336,7 +353,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 12 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 12
       },
       git_blame_info: nil
     },
@@ -347,7 +365,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 5 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 5
       },
       git_blame_info: nil
     },
@@ -358,7 +377,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 10 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 10
       },
       git_blame_info: nil
     },
@@ -369,7 +389,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 13 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 13
       },
       git_blame_info: nil
     },
@@ -380,7 +401,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 7 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 7
       },
       git_blame_info: nil
     },
@@ -391,7 +413,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 8 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 8
       },
       git_blame_info: nil
     },
@@ -402,7 +425,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 7 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 7
       },
       git_blame_info: nil
     },
@@ -413,7 +437,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 24 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 24
       },
       git_blame_info: nil
     },
@@ -424,7 +449,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 9 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 9
       },
       git_blame_info: nil
     },
@@ -435,7 +461,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 15 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 15
       },
       git_blame_info: nil
     },
@@ -446,7 +473,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 12 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 12
       },
       git_blame_info: nil
     },
@@ -457,7 +485,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 5 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 5
       },
       git_blame_info: nil
     },
@@ -468,7 +497,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 10 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 10
       },
       git_blame_info: nil
     },
@@ -479,7 +509,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 13 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 13
       },
       git_blame_info: nil
     },
@@ -490,7 +521,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 7 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 7
       },
       git_blame_info: nil
     },
@@ -501,7 +533,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 8 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 8
       },
       git_blame_info: nil
     },
@@ -512,7 +545,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 7 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 7
       },
       git_blame_info: nil
     },
@@ -523,7 +557,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 24 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 24
       },
       git_blame_info: nil
     },
@@ -534,7 +569,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 9 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 9
       },
       git_blame_info: nil
     }
@@ -553,7 +589,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 7 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 7
       },
       git_blame_info: nil
     },
@@ -564,7 +601,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 9 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 9
       },
       git_blame_info: nil
     },
@@ -575,7 +613,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 7 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 7
       },
       git_blame_info: nil
     },
@@ -586,7 +625,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 7 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 7
       },
       git_blame_info: nil
     },
@@ -597,7 +637,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 9 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 9
       },
       git_blame_info: nil
     },
@@ -608,7 +649,8 @@ s.add_test(
       message: "The number of code clones is 1 with total 7 lines.",
       links: [],
       object: {
-        clones: 1
+        clones: 1,
+        'total-clone-lines': 7
       },
       git_blame_info: nil
     }

--- a/test/smokes/metrics_codeclone/expectations.rb
+++ b/test/smokes/metrics_codeclone/expectations.rb
@@ -14,7 +14,7 @@ s.add_test(
       links: [],
       object: {
         clones: 2,
-        'total-clone-lines': 56
+        total_clone_lines: 56
       },
       git_blame_info: nil
     }
@@ -55,7 +55,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 28
+        total_clone_lines: 28
       },
       git_blame_info: nil
     },
@@ -67,7 +67,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 28
+        total_clone_lines: 28
       },
       git_blame_info: nil
     }
@@ -87,7 +87,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 14
+        total_clone_lines: 14
       },
       git_blame_info: nil
     },
@@ -99,7 +99,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 14
+        total_clone_lines: 14
       },
       git_blame_info: nil
     }
@@ -119,7 +119,7 @@ s.add_test(
       links: [],
       object: {
         clones: 3,
-        'total-clone-lines': 10
+        total_clone_lines: 10
       },
       git_blame_info: nil
     },
@@ -131,7 +131,7 @@ s.add_test(
       links: [],
       object: {
         clones: 3,
-        'total-clone-lines': 10
+        total_clone_lines: 10
       },
       git_blame_info: nil
     }
@@ -151,7 +151,7 @@ s.add_test(
       links: [],
       object: {
         clones: 2,
-        'total-clone-lines': 22
+        total_clone_lines: 22
       },
       git_blame_info: nil
     }
@@ -171,7 +171,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 24
+        total_clone_lines: 24
       },
       git_blame_info: nil
     },
@@ -183,7 +183,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 24
+        total_clone_lines: 24
       },
       git_blame_info: nil
     }
@@ -222,7 +222,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 15
+        total_clone_lines: 15
       },
       git_blame_info: nil
     },
@@ -234,7 +234,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 15
+        total_clone_lines: 15
       },
       git_blame_info: nil
     }
@@ -264,7 +264,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 40
+        total_clone_lines: 40
       },
       git_blame_info: nil
     },
@@ -276,7 +276,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 40
+        total_clone_lines: 40
       },
       git_blame_info: nil
     }
@@ -296,7 +296,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 15
+        total_clone_lines: 15
       },
       git_blame_info: nil
     },
@@ -308,7 +308,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 15
+        total_clone_lines: 15
       },
       git_blame_info: nil
     }
@@ -342,7 +342,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 15
+        total_clone_lines: 15
       },
       git_blame_info: nil
     },
@@ -354,7 +354,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 12
+        total_clone_lines: 12
       },
       git_blame_info: nil
     },
@@ -366,7 +366,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 5
+        total_clone_lines: 5
       },
       git_blame_info: nil
     },
@@ -378,7 +378,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 10
+        total_clone_lines: 10
       },
       git_blame_info: nil
     },
@@ -390,7 +390,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 13
+        total_clone_lines: 13
       },
       git_blame_info: nil
     },
@@ -402,7 +402,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 7
+        total_clone_lines: 7
       },
       git_blame_info: nil
     },
@@ -414,7 +414,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 8
+        total_clone_lines: 8
       },
       git_blame_info: nil
     },
@@ -426,7 +426,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 7
+        total_clone_lines: 7
       },
       git_blame_info: nil
     },
@@ -438,7 +438,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 24
+        total_clone_lines: 24
       },
       git_blame_info: nil
     },
@@ -450,7 +450,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 9
+        total_clone_lines: 9
       },
       git_blame_info: nil
     },
@@ -462,7 +462,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 15
+        total_clone_lines: 15
       },
       git_blame_info: nil
     },
@@ -474,7 +474,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 12
+        total_clone_lines: 12
       },
       git_blame_info: nil
     },
@@ -486,7 +486,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 5
+        total_clone_lines: 5
       },
       git_blame_info: nil
     },
@@ -498,7 +498,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 10
+        total_clone_lines: 10
       },
       git_blame_info: nil
     },
@@ -510,7 +510,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 13
+        total_clone_lines: 13
       },
       git_blame_info: nil
     },
@@ -522,7 +522,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 7
+        total_clone_lines: 7
       },
       git_blame_info: nil
     },
@@ -534,7 +534,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 8
+        total_clone_lines: 8
       },
       git_blame_info: nil
     },
@@ -546,7 +546,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 7
+        total_clone_lines: 7
       },
       git_blame_info: nil
     },
@@ -558,7 +558,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 24
+        total_clone_lines: 24
       },
       git_blame_info: nil
     },
@@ -570,7 +570,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 9
+        total_clone_lines: 9
       },
       git_blame_info: nil
     }
@@ -590,7 +590,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 7
+        total_clone_lines: 7
       },
       git_blame_info: nil
     },
@@ -602,7 +602,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 9
+        total_clone_lines: 9
       },
       git_blame_info: nil
     },
@@ -614,7 +614,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 7
+        total_clone_lines: 7
       },
       git_blame_info: nil
     },
@@ -626,7 +626,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 7
+        total_clone_lines: 7
       },
       git_blame_info: nil
     },
@@ -638,7 +638,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 9
+        total_clone_lines: 9
       },
       git_blame_info: nil
     },
@@ -650,7 +650,7 @@ s.add_test(
       links: [],
       object: {
         clones: 1,
-        'total-clone-lines': 7
+        total_clone_lines: 7
       },
       git_blame_info: nil
     }


### PR DESCRIPTION
The total number of duplicated lines is used to measure duplication ratio for each file.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
