### PR TITLE
Install default npm dependencies via npm 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Misc:
 - **detekt** Add `parallel` and `target` options [#2131](https://github.com/sider/runners/pull/2131)
 - **PHP_CodeSniffer** Re-consider options (`target`, `standard`, `parallel`) [#2132](https://github.com/sider/runners/pull/2132)
 - **Metrics Code Clone** Report the total number of duplicated lines [#2146](https://github.com/sider/runners/pull/2146)
+- Install default npm dependencies via npm 7 [#2150](https://github.com/sider/runners/pull/2150)
 
 ## 0.44.1
 

--- a/images/Dockerfile.npm.erb
+++ b/images/Dockerfile.npm.erb
@@ -1,19 +1,15 @@
-# TODO: Wait for npm 7. See #1963
-USER root
-RUN npm install --global npm@6
-USER $RUNNER_USER
-
 # Install the default version
 COPY --chown=<%= chown %> images/<%= analyzer %>/package.json ${RUNNER_USER_HOME}/<%= analyzer %>_package.json
 RUN cd "${RUNNER_USER_HOME}" && \
     mkdir <%= analyzer %> && \
     mv <%= analyzer %>_package.json <%= analyzer %>/package.json && \
     cd <%= analyzer %> && \
-    npm config set ignore-scripts true && \
-    npm config set progress false && \
-    npm config set package-lock false && \
-    npm install && \
-    npm ls --depth 0 # Check required peer dependencies
+    npm install --strict-peer-deps --ignore-scripts --engine-strict --no-progress --no-save
 ENV PATH ${RUNNER_USER_HOME}/<%= analyzer %>/node_modules/.bin:${PATH}
 # See https://nodejs.org/api/cli.html#cli_node_path_path
 ENV NODE_PATH ${RUNNER_USER_HOME}/<%= analyzer %>/node_modules:${NODE_PATH}
+
+# TODO: Wait for npm 7. See #1963
+USER root
+RUN npm install --global npm@6
+USER $RUNNER_USER

--- a/images/coffeelint/Dockerfile
+++ b/images/coffeelint/Dockerfile
@@ -21,25 +21,21 @@ RUN cd "${RUNNERS_DIR}" && \
     lockfile_bundler_version=$(bundle exec ruby -e 'puts Bundler.locked_gems.bundler_version') && \
     bundle version | grep "Bundler version ${lockfile_bundler_version}"
 
-# TODO: Wait for npm 7. See #1963
-USER root
-RUN npm install --global npm@6
-USER $RUNNER_USER
-
 # Install the default version
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/coffeelint/package.json ${RUNNER_USER_HOME}/coffeelint_package.json
 RUN cd "${RUNNER_USER_HOME}" && \
     mkdir coffeelint && \
     mv coffeelint_package.json coffeelint/package.json && \
     cd coffeelint && \
-    npm config set ignore-scripts true && \
-    npm config set progress false && \
-    npm config set package-lock false && \
-    npm install && \
-    npm ls --depth 0 # Check required peer dependencies
+    npm install --strict-peer-deps --ignore-scripts --engine-strict --no-progress --no-save
 ENV PATH ${RUNNER_USER_HOME}/coffeelint/node_modules/.bin:${PATH}
 # See https://nodejs.org/api/cli.html#cli_node_path_path
 ENV NODE_PATH ${RUNNER_USER_HOME}/coffeelint/node_modules:${NODE_PATH}
+
+# TODO: Wait for npm 7. See #1963
+USER root
+RUN npm install --global npm@6
+USER $RUNNER_USER
 
 # Copy the main source code
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} exe ${RUNNERS_DIR}/exe

--- a/images/eslint/Dockerfile
+++ b/images/eslint/Dockerfile
@@ -21,25 +21,21 @@ RUN cd "${RUNNERS_DIR}" && \
     lockfile_bundler_version=$(bundle exec ruby -e 'puts Bundler.locked_gems.bundler_version') && \
     bundle version | grep "Bundler version ${lockfile_bundler_version}"
 
-# TODO: Wait for npm 7. See #1963
-USER root
-RUN npm install --global npm@6
-USER $RUNNER_USER
-
 # Install the default version
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/eslint/package.json ${RUNNER_USER_HOME}/eslint_package.json
 RUN cd "${RUNNER_USER_HOME}" && \
     mkdir eslint && \
     mv eslint_package.json eslint/package.json && \
     cd eslint && \
-    npm config set ignore-scripts true && \
-    npm config set progress false && \
-    npm config set package-lock false && \
-    npm install && \
-    npm ls --depth 0 # Check required peer dependencies
+    npm install --strict-peer-deps --ignore-scripts --engine-strict --no-progress --no-save
 ENV PATH ${RUNNER_USER_HOME}/eslint/node_modules/.bin:${PATH}
 # See https://nodejs.org/api/cli.html#cli_node_path_path
 ENV NODE_PATH ${RUNNER_USER_HOME}/eslint/node_modules:${NODE_PATH}
+
+# TODO: Wait for npm 7. See #1963
+USER root
+RUN npm install --global npm@6
+USER $RUNNER_USER
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/eslint/sider_eslintrc.yml ${RUNNER_USER_HOME}/eslint/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/eslint/custom-eslint-json-formatter.js ${RUNNER_USER_HOME}/eslint/

--- a/images/eslint/package.json
+++ b/images/eslint/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "4.16.1",
-    "@typescript-eslint/parser": "4.16.1",
     "@vue/eslint-config-typescript": "7.0.0",
     "babel-eslint": "10.1.0",
     "eslint": "7.21.0",
@@ -17,8 +16,6 @@
     "eslint-plugin-prettier": "3.3.1",
     "eslint-plugin-react": "7.22.0",
     "eslint-plugin-react-hooks": "4.2.0",
-    "eslint-plugin-vue": "7.7.0",
-    "prettier": "2.2.1",
-    "typescript": "4.2.3"
+    "eslint-plugin-vue": "7.7.0"
   }
 }

--- a/images/jshint/Dockerfile
+++ b/images/jshint/Dockerfile
@@ -21,25 +21,21 @@ RUN cd "${RUNNERS_DIR}" && \
     lockfile_bundler_version=$(bundle exec ruby -e 'puts Bundler.locked_gems.bundler_version') && \
     bundle version | grep "Bundler version ${lockfile_bundler_version}"
 
-# TODO: Wait for npm 7. See #1963
-USER root
-RUN npm install --global npm@6
-USER $RUNNER_USER
-
 # Install the default version
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/jshint/package.json ${RUNNER_USER_HOME}/jshint_package.json
 RUN cd "${RUNNER_USER_HOME}" && \
     mkdir jshint && \
     mv jshint_package.json jshint/package.json && \
     cd jshint && \
-    npm config set ignore-scripts true && \
-    npm config set progress false && \
-    npm config set package-lock false && \
-    npm install && \
-    npm ls --depth 0 # Check required peer dependencies
+    npm install --strict-peer-deps --ignore-scripts --engine-strict --no-progress --no-save
 ENV PATH ${RUNNER_USER_HOME}/jshint/node_modules/.bin:${PATH}
 # See https://nodejs.org/api/cli.html#cli_node_path_path
 ENV NODE_PATH ${RUNNER_USER_HOME}/jshint/node_modules:${NODE_PATH}
+
+# TODO: Wait for npm 7. See #1963
+USER root
+RUN npm install --global npm@6
+USER $RUNNER_USER
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/jshint/sider_jshintignore images/jshint/sider_jshintrc $RUNNER_USER_HOME/
 

--- a/images/remark_lint/Dockerfile
+++ b/images/remark_lint/Dockerfile
@@ -21,25 +21,21 @@ RUN cd "${RUNNERS_DIR}" && \
     lockfile_bundler_version=$(bundle exec ruby -e 'puts Bundler.locked_gems.bundler_version') && \
     bundle version | grep "Bundler version ${lockfile_bundler_version}"
 
-# TODO: Wait for npm 7. See #1963
-USER root
-RUN npm install --global npm@6
-USER $RUNNER_USER
-
 # Install the default version
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/remark_lint/package.json ${RUNNER_USER_HOME}/remark_lint_package.json
 RUN cd "${RUNNER_USER_HOME}" && \
     mkdir remark_lint && \
     mv remark_lint_package.json remark_lint/package.json && \
     cd remark_lint && \
-    npm config set ignore-scripts true && \
-    npm config set progress false && \
-    npm config set package-lock false && \
-    npm install && \
-    npm ls --depth 0 # Check required peer dependencies
+    npm install --strict-peer-deps --ignore-scripts --engine-strict --no-progress --no-save
 ENV PATH ${RUNNER_USER_HOME}/remark_lint/node_modules/.bin:${PATH}
 # See https://nodejs.org/api/cli.html#cli_node_path_path
 ENV NODE_PATH ${RUNNER_USER_HOME}/remark_lint/node_modules:${NODE_PATH}
+
+# TODO: Wait for npm 7. See #1963
+USER root
+RUN npm install --global npm@6
+USER $RUNNER_USER
 
 # Copy the main source code
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} exe ${RUNNERS_DIR}/exe

--- a/images/stylelint/Dockerfile
+++ b/images/stylelint/Dockerfile
@@ -21,25 +21,21 @@ RUN cd "${RUNNERS_DIR}" && \
     lockfile_bundler_version=$(bundle exec ruby -e 'puts Bundler.locked_gems.bundler_version') && \
     bundle version | grep "Bundler version ${lockfile_bundler_version}"
 
-# TODO: Wait for npm 7. See #1963
-USER root
-RUN npm install --global npm@6
-USER $RUNNER_USER
-
 # Install the default version
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/stylelint/package.json ${RUNNER_USER_HOME}/stylelint_package.json
 RUN cd "${RUNNER_USER_HOME}" && \
     mkdir stylelint && \
     mv stylelint_package.json stylelint/package.json && \
     cd stylelint && \
-    npm config set ignore-scripts true && \
-    npm config set progress false && \
-    npm config set package-lock false && \
-    npm install && \
-    npm ls --depth 0 # Check required peer dependencies
+    npm install --strict-peer-deps --ignore-scripts --engine-strict --no-progress --no-save
 ENV PATH ${RUNNER_USER_HOME}/stylelint/node_modules/.bin:${PATH}
 # See https://nodejs.org/api/cli.html#cli_node_path_path
 ENV NODE_PATH ${RUNNER_USER_HOME}/stylelint/node_modules:${NODE_PATH}
+
+# TODO: Wait for npm 7. See #1963
+USER root
+RUN npm install --global npm@6
+USER $RUNNER_USER
 
 # NOTE: Install the older version to run `stylelint-config-recommended` with stylelint v8.
 RUN cd "${RUNNER_USER_HOME}" && \

--- a/images/stylelint/package.json
+++ b/images/stylelint/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "prettier": "2.2.1",
     "stylelint": "13.12.0",
     "stylelint-config-prettier": "8.0.2",
     "stylelint-config-recommended": "4.0.0",

--- a/images/tslint/Dockerfile
+++ b/images/tslint/Dockerfile
@@ -21,25 +21,21 @@ RUN cd "${RUNNERS_DIR}" && \
     lockfile_bundler_version=$(bundle exec ruby -e 'puts Bundler.locked_gems.bundler_version') && \
     bundle version | grep "Bundler version ${lockfile_bundler_version}"
 
-# TODO: Wait for npm 7. See #1963
-USER root
-RUN npm install --global npm@6
-USER $RUNNER_USER
-
 # Install the default version
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/tslint/package.json ${RUNNER_USER_HOME}/tslint_package.json
 RUN cd "${RUNNER_USER_HOME}" && \
     mkdir tslint && \
     mv tslint_package.json tslint/package.json && \
     cd tslint && \
-    npm config set ignore-scripts true && \
-    npm config set progress false && \
-    npm config set package-lock false && \
-    npm install && \
-    npm ls --depth 0 # Check required peer dependencies
+    npm install --strict-peer-deps --ignore-scripts --engine-strict --no-progress --no-save
 ENV PATH ${RUNNER_USER_HOME}/tslint/node_modules/.bin:${PATH}
 # See https://nodejs.org/api/cli.html#cli_node_path_path
 ENV NODE_PATH ${RUNNER_USER_HOME}/tslint/node_modules:${NODE_PATH}
+
+# TODO: Wait for npm 7. See #1963
+USER root
+RUN npm install --global npm@6
+USER $RUNNER_USER
 
 # By default, TSLint looks for a configuration file named tslint.json in the directory of the file being linted and, if not found, searches ancestor directories.
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/tslint/default_tslint.json ${RUNNER_USER_HOME}/tslint.json

--- a/images/tyscan/Dockerfile
+++ b/images/tyscan/Dockerfile
@@ -21,25 +21,21 @@ RUN cd "${RUNNERS_DIR}" && \
     lockfile_bundler_version=$(bundle exec ruby -e 'puts Bundler.locked_gems.bundler_version') && \
     bundle version | grep "Bundler version ${lockfile_bundler_version}"
 
-# TODO: Wait for npm 7. See #1963
-USER root
-RUN npm install --global npm@6
-USER $RUNNER_USER
-
 # Install the default version
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/tyscan/package.json ${RUNNER_USER_HOME}/tyscan_package.json
 RUN cd "${RUNNER_USER_HOME}" && \
     mkdir tyscan && \
     mv tyscan_package.json tyscan/package.json && \
     cd tyscan && \
-    npm config set ignore-scripts true && \
-    npm config set progress false && \
-    npm config set package-lock false && \
-    npm install && \
-    npm ls --depth 0 # Check required peer dependencies
+    npm install --strict-peer-deps --ignore-scripts --engine-strict --no-progress --no-save
 ENV PATH ${RUNNER_USER_HOME}/tyscan/node_modules/.bin:${PATH}
 # See https://nodejs.org/api/cli.html#cli_node_path_path
 ENV NODE_PATH ${RUNNER_USER_HOME}/tyscan/node_modules:${NODE_PATH}
+
+# TODO: Wait for npm 7. See #1963
+USER root
+RUN npm install --global npm@6
+USER $RUNNER_USER
 
 # Copy the main source code
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} exe ${RUNNERS_DIR}/exe

--- a/images/tyscan/package.json
+++ b/images/tyscan/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "tyscan": "0.3.2",
-    "typescript": "3.9.9"
+    "tyscan": "0.3.2"
   }
 }


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

npm 7 is now available in the Docker images (sider/devon_rex#430), so we can install automatically peer dependencies for `images/**/package.json`.

This will reduce the excessive `package.json` updates via Dependabot.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Related to #1963 

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
