### PR TITLE
Bump bundler from 2.2.13 to 2.2.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,7 @@ jobs:
         analyzer:
           - brakeman
           - checkstyle
-          # TODO: https://github.com/sider/runners/issues/2152
-          # - clang_tidy
+          - clang_tidy
           - code_sniffer
           - coffeelint
           - cppcheck

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ jobs:
         analyzer:
           - brakeman
           - checkstyle
-          - clang_tidy
+          # TODO: https://github.com/sider/runners/issues/2152
+          # - clang_tidy
           - code_sniffer
           - coffeelint
           - cppcheck

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
     runners (0.44.1)
       aws-sdk-s3 (>= 1.87)
       bugsnag (>= 6.18)
-      bundler (>= 2.2.13, < 2.3.0)
+      bundler (>= 2.2.14, < 2.3.0)
       erb (>= 2.2)
       fileutils (>= 1.5)
       forwardable (>= 1.3)
@@ -138,4 +138,4 @@ DEPENDENCIES
   unification_assertion
 
 BUNDLED WITH
-   2.2.13
+   2.2.14

--- a/runners.gemspec
+++ b/runners.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # standard libraries
-  spec.add_dependency "bundler", ">= 2.2.13", "< 2.3.0" # NOTE: It must be same as devon_rex.
+  spec.add_dependency "bundler", ">= 2.2.14", "< 2.3.0" # NOTE: It must be same as devon_rex.
   spec.add_dependency "erb", ">= 2.2"
   spec.add_dependency "fileutils", ">= 1.5"
   spec.add_dependency "forwardable", ">= 1.3"


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

devon_rex `master` has bumped Bundler to 2.2.14.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

See sider/devon_rex#439

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
