### PR TITLE
Loosen the version constraint for clang-tidy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Misc:
 - **detekt** Add `parallel` and `target` options [#2131](https://github.com/sider/runners/pull/2131)
 - **PHP_CodeSniffer** Re-consider options (`target`, `standard`, `parallel`) [#2132](https://github.com/sider/runners/pull/2132)
 - **Metrics Code Clone** Report the total number of duplicated lines [#2146](https://github.com/sider/runners/pull/2146)
+- **Clang-Tidy** Loosen the version constraint for clang-tidy [#2153](https://github.com/sider/runners/pull/2153)
 
 ## 0.44.1
 

--- a/images/clang_tidy/Dockerfile
+++ b/images/clang_tidy/Dockerfile
@@ -6,13 +6,16 @@ FROM sider/devon_rex_base:master
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/clang_tidy/packages.list ${RUNNER_USER_HOME}/
 
+ARG LLVM_VERSION=10
+
 USER root
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    add-apt-repository "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-10 main" && \
+    add-apt-repository "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-${LLVM_VERSION} main" && \
     apt-get update && \
-    grep -v "^\s*#" "${RUNNER_USER_HOME}/packages.list" | xargs apt-get install -qq -y --no-install-recommends && \
+    grep -v "^\s*#" "${RUNNER_USER_HOME}/packages.list" | xargs apt-get install -qq -y --no-install-recommends "clang-tidy-${LLVM_VERSION}" && \
     apt-get clean && \
-    update-alternatives --install /usr/local/bin/clang-tidy clang-tidy /usr/lib/llvm-10/bin/clang-tidy 20
+    update-alternatives --install /usr/local/bin/clang-tidy clang-tidy "/usr/lib/llvm-${LLVM_VERSION}/bin/clang-tidy" 20 && \
+    clang-tidy --version | grep "LLVM version ${LLVM_VERSION}"
 USER $RUNNER_USER
 
 

--- a/images/clang_tidy/Dockerfile.erb
+++ b/images/clang_tidy/Dockerfile.erb
@@ -2,14 +2,16 @@ FROM sider/devon_rex_base:master
 
 COPY --chown=<%= chown %> images/clang_tidy/packages.list ${RUNNER_USER_HOME}/
 
+ARG LLVM_VERSION=10
+
 USER root
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    add-apt-repository "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-10 main" && \
+    add-apt-repository "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-${LLVM_VERSION} main" && \
     apt-get update && \
-    grep -v "^\s*#" "${RUNNER_USER_HOME}/packages.list" | xargs apt-get install -qq -y --no-install-recommends && \
+    grep -v "^\s*#" "${RUNNER_USER_HOME}/packages.list" | xargs apt-get install -qq -y --no-install-recommends "clang-tidy-${LLVM_VERSION}" && \
     apt-get clean && \
-    update-alternatives --install /usr/local/bin/clang-tidy clang-tidy /usr/lib/llvm-10/bin/clang-tidy 20 && \
-    clang-tidy --version | grep 'LLVM version 10'
+    update-alternatives --install /usr/local/bin/clang-tidy clang-tidy "/usr/lib/llvm-${LLVM_VERSION}/bin/clang-tidy" 20 && \
+    clang-tidy --version | grep "LLVM version ${LLVM_VERSION}"
 USER $RUNNER_USER
 
 <%= render_erb 'images/Dockerfile.base.erb' %>

--- a/images/clang_tidy/Dockerfile.erb
+++ b/images/clang_tidy/Dockerfile.erb
@@ -8,7 +8,8 @@ RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-get update && \
     grep -v "^\s*#" "${RUNNER_USER_HOME}/packages.list" | xargs apt-get install -qq -y --no-install-recommends && \
     apt-get clean && \
-    update-alternatives --install /usr/local/bin/clang-tidy clang-tidy /usr/lib/llvm-10/bin/clang-tidy 20
+    update-alternatives --install /usr/local/bin/clang-tidy clang-tidy /usr/lib/llvm-10/bin/clang-tidy 20 && \
+    clang-tidy --version | grep 'LLVM version 10'
 USER $RUNNER_USER
 
 <%= render_erb 'images/Dockerfile.base.erb' %>

--- a/images/clang_tidy/packages.list
+++ b/images/clang_tidy/packages.list
@@ -1,5 +1,5 @@
 # Main Clang-Tidy package
-clang-tidy-10=1:10.0.1~++20200708124224+ef32c611aa2-1~exp1~20200707224822.188
+clang-tidy-10
 
 # Popular packages of https://github.com/fffaraz/awesome-cpp
 libapr1-dev

--- a/images/clang_tidy/packages.list
+++ b/images/clang_tidy/packages.list
@@ -1,6 +1,3 @@
-# Main Clang-Tidy package
-clang-tidy-10
-
 # Popular packages of https://github.com/fffaraz/awesome-cpp
 libapr1-dev
 libasio-dev


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

At the time when choosing the apt(8) source, the major version of clang-tidy is fixed to `10`, so I loosened the version constraint in `packages.list`. In my opinion, it's sufficient for us to care about only the major version of LLVM.

http://blog.llvm.org/2016/12/llvms-new-versioning-scheme.html

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Fix #2152

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
