### PR TITLE
Bump Clang-Tidy from 10 to 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ Updated environments:
 
 Updated tools:
 
+- **Clang-Tidy** 10 -> 11 [#2154](https://github.com/sider/runners/pull/2154)
 - **GolangCI-Lint** 1.37.1 -> 1.38.0 [#2138](https://github.com/sider/runners/pull/2138)
 - **hadolint** 1.22.1 -> 1.23.0 [#2145](https://github.com/sider/runners/pull/2145)
 - **RuboCop** 1.10.0 -> 1.11.0 [#2140](https://github.com/sider/runners/pull/2140)
 - **stylelint** 13.11.0 -> 13.12.0 [#2143](https://github.com/sider/runners/pull/2143)
 - **SwiftLint** 0.42.0 -> 0.43.0 [#2133](https://github.com/sider/runners/pull/2133)
-- **Clang-Tidy** 10 -> 11 [#2154](https://github.com/sider/runners/pull/2154)
 
 Misc:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Updated tools:
 - **RuboCop** 1.10.0 -> 1.11.0 [#2140](https://github.com/sider/runners/pull/2140)
 - **stylelint** 13.11.0 -> 13.12.0 [#2143](https://github.com/sider/runners/pull/2143)
 - **SwiftLint** 0.42.0 -> 0.43.0 [#2133](https://github.com/sider/runners/pull/2133)
+- **Clang-Tidy** 10 -> 11 [#2154](https://github.com/sider/runners/pull/2154)
 
 Misc:
 

--- a/images/clang_tidy/Dockerfile
+++ b/images/clang_tidy/Dockerfile
@@ -6,7 +6,7 @@ FROM sider/devon_rex_base:master
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/clang_tidy/packages.list ${RUNNER_USER_HOME}/
 
-ARG LLVM_VERSION=10
+ARG LLVM_VERSION=11
 
 USER root
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \

--- a/images/clang_tidy/Dockerfile.erb
+++ b/images/clang_tidy/Dockerfile.erb
@@ -2,7 +2,7 @@ FROM sider/devon_rex_base:master
 
 COPY --chown=<%= chown %> images/clang_tidy/packages.list ${RUNNER_USER_HOME}/
 
-ARG LLVM_VERSION=10
+ARG LLVM_VERSION=11
 
 USER root
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \

--- a/test/smokes/clang_tidy/expectations.rb
+++ b/test/smokes/clang_tidy/expectations.rb
@@ -1,6 +1,6 @@
 s = Runners::Testing::Smoke
 
-default_version = /^11\./
+default_version = "11.1.0"
 
 s.add_test(
   "success",

--- a/test/smokes/clang_tidy/expectations.rb
+++ b/test/smokes/clang_tidy/expectations.rb
@@ -1,6 +1,6 @@
 s = Runners::Testing::Smoke
 
-default_version = "10.0.1"
+default_version = /^11\./
 
 s.add_test(
   "success",


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

LLVM 11 is publicly available, so I want to bump it in this repository.

https://lists.llvm.org/pipermail/llvm-announce/2020-October/000089.html
https://lists.llvm.org/pipermail/llvm-announce/2021-January/000090.html

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

See https://github.com/sider/runners/issues/2152#issuecomment-793429116

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
