### PR TITLE
[Flake8] Enable Sider's recommended set of rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Misc:
 - Install default npm dependencies via npm 7 [#2150](https://github.com/sider/runners/pull/2150)
 - **Clang-Tidy** Loosen the version constraint for clang-tidy [#2153](https://github.com/sider/runners/pull/2153)
 - **ESLint** Update pre-installed packages [#2155](https://github.com/sider/runners/pull/2155)
+- **Flake8** Enable new recommended configuration [#2157](https://github.com/sider/runners/pull/2157)
 
 ## 0.44.1
 

--- a/images/flake8/Dockerfile
+++ b/images/flake8/Dockerfile
@@ -29,7 +29,7 @@ RUN cd "${RUNNER_USER_HOME}" && \
     cd flake8 && \
     pipenv install --system --skip-lock
 
-COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/flake8/sider_config.ini ${RUNNER_USER_HOME}/.config/flake8
+COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/flake8/sider_recommended_flake8.ini ${RUNNER_USER_HOME}/.config/flake8
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/flake8/ignored-config.ini ${RUNNER_USER_HOME}/.config/ignored-config.ini
 
 

--- a/images/flake8/Dockerfile.erb
+++ b/images/flake8/Dockerfile.erb
@@ -3,7 +3,7 @@ FROM sider/devon_rex_python:master
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.python.erb' %>
 
-COPY --chown=<%= chown %> images/flake8/sider_config.ini ${RUNNER_USER_HOME}/.config/flake8
+COPY --chown=<%= chown %> images/flake8/sider_recommended_flake8.ini ${RUNNER_USER_HOME}/.config/flake8
 COPY --chown=<%= chown %> images/flake8/ignored-config.ini ${RUNNER_USER_HOME}/.config/ignored-config.ini
 
 <%= render_erb 'images/Dockerfile.end.erb' %>

--- a/test/smokes/flake8/expectations.rb
+++ b/test/smokes/flake8/expectations.rb
@@ -8,6 +8,28 @@ s.add_test(
   issues: [
     {
       path: "app1/views.py",
+      location: { start_line: 6, start_column: 13 },
+      id: "E113",
+      message: "unexpected indentation",
+      links: [],
+      object: nil,
+      git_blame_info: {
+        commit: :_, line_hash: "8d97b13e6750c908c25104463cd720d809a07218", original_line: 6, final_line: 6
+      }
+    },
+    {
+      path: "app1/views.py",
+      location: { start_line: 7, start_column: 17 },
+      id: "E113",
+      message: "unexpected indentation",
+      links: [],
+      object: nil,
+      git_blame_info: {
+        commit: :_, line_hash: "b3250f6063f80804987089c29421b404957cdf1f", original_line: 7, final_line: 7
+      }
+    },
+    {
+      path: "app1/views.py",
       location: { start_line: 6, start_column: 12 },
       id: "E999",
       message: "IndentationError: unexpected indent",
@@ -131,7 +153,19 @@ s.add_test(
 s.add_test(
   "no_user_config_enabled",
   type: "success",
-  issues: [], # W191 is not issued.
+  issues: [
+    {
+      path: "foo.py",
+      location: { start_line: 2, start_column: 1 },
+      id: "W191",
+      message: 'indentation contains tabs',
+      links: [],
+      object: nil,
+      git_blame_info: {
+        commit: :_, line_hash: "9d412fa2df982c5c605cc6bba5187bda2a476519", original_line: 2, final_line: 2
+      }
+    }
+  ],
   analyzer: { name: "Flake8", version: default_version }
 )
 
@@ -305,6 +339,17 @@ s.add_test(
   "option_parallel",
   type: "success",
   issues: [
+    {
+      message: "indentation is not a multiple of four",
+      links: [],
+      id: "E111",
+      path: "foo.py",
+      location: { start_line: 2, start_column: 3 },
+      object: nil,
+      git_blame_info: {
+        commit: :_, line_hash: "2195b5c8fadfde3b82ab9aecaf510b7dc1112d91", original_line: 2, final_line: 2
+      }
+    },
     {
       message: "local variable 'a' is assigned to but never used",
       links: [],


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

We enable Sider's recommended ruleset of Flake8.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.