### PR TITLE
Refactor `Runners::Nodejs#install_nodejs_deps` method

### DIFF
--- a/lib/runners/nodejs.rb
+++ b/lib/runners/nodejs.rb
@@ -48,7 +48,7 @@ module Runners
     end
 
     # Install Node.js dependencies by using given parameters.
-    def install_nodejs_deps(constraints:, install_option:)
+    def install_nodejs_deps(constraints:, install_option: config_linter[:npm_install])
       return if install_option == INSTALL_OPTION_NONE
 
       unless package_json_path.exist?

--- a/lib/runners/processor/coffeelint.rb
+++ b/lib/runners/processor/coffeelint.rb
@@ -35,7 +35,7 @@ module Runners
       add_warning_if_deprecated_options
 
       begin
-        install_nodejs_deps(constraints: CONSTRAINTS, install_option: config_linter[:npm_install])
+        install_nodejs_deps constraints: CONSTRAINTS
       rescue UserError => exn
         return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
       end

--- a/lib/runners/processor/eslint.rb
+++ b/lib/runners/processor/eslint.rb
@@ -70,7 +70,7 @@ module Runners
       add_warning_for_deprecated_option :dir, to: :target
 
       begin
-        install_nodejs_deps(constraints: CONSTRAINTS, install_option: config_linter[:npm_install])
+        install_nodejs_deps constraints: CONSTRAINTS
       rescue UserError => exn
         return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
       end

--- a/lib/runners/processor/remark_lint.rb
+++ b/lib/runners/processor/remark_lint.rb
@@ -53,7 +53,7 @@ module Runners
 
     def setup
       begin
-        install_nodejs_deps(constraints: CONSTRAINTS, install_option: config_linter[:npm_install])
+        install_nodejs_deps constraints: CONSTRAINTS
       rescue UserError => exn
         return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
       end

--- a/lib/runners/processor/stylelint.rb
+++ b/lib/runners/processor/stylelint.rb
@@ -64,7 +64,7 @@ module Runners
       prepare_ignore_file
 
       begin
-        install_nodejs_deps(constraints: CONSTRAINTS, install_option: config_linter[:npm_install])
+        install_nodejs_deps constraints: CONSTRAINTS
       rescue UserError => exn
         return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
       end

--- a/lib/runners/processor/tslint.rb
+++ b/lib/runners/processor/tslint.rb
@@ -39,7 +39,7 @@ module Runners
                                         deadline: Time.new(2020, 12, 1))
 
       begin
-        install_nodejs_deps(constraints: CONSTRAINTS, install_option: config_linter[:npm_install])
+        install_nodejs_deps constraints: CONSTRAINTS
       rescue UserError => exn
         return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
       end

--- a/lib/runners/processor/tyscan.rb
+++ b/lib/runners/processor/tyscan.rb
@@ -43,7 +43,7 @@ module Runners
       end
 
       begin
-        install_nodejs_deps(constraints: CONSTRAINTS, install_option: config_linter[:npm_install])
+        install_nodejs_deps constraints: CONSTRAINTS
       rescue UserError => exn
         return Results::Failure.new(guid: guid, message: exn.message)
       end

--- a/sig/runners/nodejs.rbs
+++ b/sig/runners/nodejs.rbs
@@ -39,7 +39,7 @@ module Runners
 
     def yarn_lock_path: () -> Pathname
 
-    def install_nodejs_deps: (constraints: constraints, install_option: install_option) -> void
+    def install_nodejs_deps: (constraints: constraints, ?install_option: install_option) -> void
 
     private
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring aims to reduce the code by giving the default value of `install_option` to the `install_nodejs_deps` method.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
