### PR TITLE
Use `Gem::Requirement` for Ruby runners

### DIFF
--- a/lib/runners/processor/brakeman.rb
+++ b/lib/runners/processor/brakeman.rb
@@ -16,7 +16,7 @@ module Runners
 
     GEM_NAME = "brakeman".freeze
     CONSTRAINTS = {
-      GEM_NAME => [">= 4.0.0", "< 6.0.0"]
+      GEM_NAME => Gem::Requirement.new(">= 4.0.0", "< 6.0.0").freeze,
     }.freeze
 
     def self.config_example

--- a/lib/runners/processor/coffeelint.rb
+++ b/lib/runners/processor/coffeelint.rb
@@ -19,8 +19,8 @@ module Runners
     register_config_schema(name: :coffeelint, schema: Schema.runner_config)
 
     CONSTRAINTS = {
-      "coffeelint" => Gem::Requirement.new(">= 1.16.0", "< 3.0.0"),
-      "@coffeelint/cli" => Gem::Requirement.new(">= 4.0.0", "< 5.0.0"),
+      "coffeelint" => Gem::Requirement.new(">= 1.16.0", "< 3.0.0").freeze,
+      "@coffeelint/cli" => Gem::Requirement.new(">= 4.0.0", "< 5.0.0").freeze,
     }.freeze
 
     def self.config_example

--- a/lib/runners/processor/eslint.rb
+++ b/lib/runners/processor/eslint.rb
@@ -41,7 +41,7 @@ module Runners
     register_config_schema(name: :eslint, schema: Schema.runner_config)
 
     CONSTRAINTS = {
-      "eslint" => Gem::Requirement.new(">= 5.0.0", "< 8.0.0")
+      "eslint" => Gem::Requirement.new(">= 5.0.0", "< 8.0.0").freeze,
     }.freeze
 
     CUSTOM_FORMATTER = (Pathname(Dir.home) / "eslint" / "custom-eslint-json-formatter.js").to_path.freeze

--- a/lib/runners/processor/goodcheck.rb
+++ b/lib/runners/processor/goodcheck.rb
@@ -23,7 +23,7 @@ module Runners
 
     GEM_NAME = "goodcheck".freeze
     CONSTRAINTS = {
-      GEM_NAME => [">= 1.0.0", "< 3.0"]
+      GEM_NAME => Gem::Requirement.new(">= 1.0.0", "< 3.0.0").freeze,
     }.freeze
 
     DEFAULT_TARGET = ".".freeze

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -36,7 +36,7 @@ module Runners
     GEM_NAME = "haml_lint".freeze
     REQUIRED_GEM_NAMES = ["rubocop"].freeze
     CONSTRAINTS = {
-      GEM_NAME => [">= 0.26.0", "< 1.0.0"]
+      GEM_NAME => Gem::Requirement.new(">= 0.26.0", "< 1.0.0").freeze,
     }.freeze
     DEFAULT_TARGET = ".".freeze
     DEFAULT_CONFIG_FILE = (Pathname(Dir.home) / "sider_recommended_haml_lint.yml").to_path.freeze

--- a/lib/runners/processor/querly.rb
+++ b/lib/runners/processor/querly.rb
@@ -28,7 +28,7 @@ module Runners
 
     GEM_NAME = "querly".freeze
     CONSTRAINTS = {
-      GEM_NAME => [">= 0.5.0", "< 2.0.0"]
+      GEM_NAME => Gem::Requirement.new(">= 0.5.0", "< 2.0.0").freeze,
     }.freeze
 
     CONFIG_FILE = "querly.yml".freeze

--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -42,7 +42,7 @@ module Runners
 
     GEM_NAME = "rails_best_practices".freeze
     CONSTRAINTS = {
-      GEM_NAME => [">= 1.19.1", "< 2.0"]
+      GEM_NAME => Gem::Requirement.new(">= 1.19.1", "< 2.0").freeze,
     }.freeze
 
     def self.config_example

--- a/lib/runners/processor/reek.rb
+++ b/lib/runners/processor/reek.rb
@@ -17,7 +17,7 @@ module Runners
 
     GEM_NAME = "reek".freeze
     CONSTRAINTS = {
-      GEM_NAME => [">= 4.4.0", "< 7.0.0"]
+      GEM_NAME => Gem::Requirement.new(">= 4.4.0", "< 7.0.0").freeze,
     }.freeze
 
     DEFAULT_TARGET = ".".freeze

--- a/lib/runners/processor/remark_lint.rb
+++ b/lib/runners/processor/remark_lint.rb
@@ -23,7 +23,7 @@ module Runners
     register_config_schema(name: :remark_lint, schema: Schema.runner_config)
 
     CONSTRAINTS = {
-      "remark-cli" => Gem::Requirement.new(">= 7.0.0", "< 10.0.0"),
+      "remark-cli" => Gem::Requirement.new(">= 7.0.0", "< 10.0.0").freeze,
     }.freeze
 
     DEFAULT_TARGET = ".".freeze

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -29,7 +29,7 @@ module Runners
 
     GEM_NAME = "rubocop".freeze
     CONSTRAINTS = {
-      GEM_NAME => [">= 0.61.0", "< 2.0.0"]
+      GEM_NAME => Gem::Requirement.new(">= 0.61.0", "< 2.0.0").freeze,
     }.freeze
 
     def self.config_example

--- a/lib/runners/processor/slim_lint.rb
+++ b/lib/runners/processor/slim_lint.rb
@@ -23,7 +23,7 @@ module Runners
     GEM_NAME = "slim_lint".freeze
     REQUIRED_GEM_NAMES = ["rubocop"].freeze
     CONSTRAINTS = {
-      GEM_NAME => [">= 0.20.2", "< 1.0.0"]
+      GEM_NAME => Gem::Requirement.new(">= 0.20.2", "< 1.0.0").freeze,
     }.freeze
     DEFAULT_TARGET = ".".freeze
     DEFAULT_CONFIG_FILE = (Pathname(Dir.home) / "sider_recommended_slim_lint.yml").to_path.freeze

--- a/lib/runners/processor/stylelint.rb
+++ b/lib/runners/processor/stylelint.rb
@@ -35,7 +35,7 @@ module Runners
     register_config_schema(name: :stylelint, schema: Schema.runner_config)
 
     CONSTRAINTS = {
-      "stylelint" => Gem::Requirement.new(">= 8.3.0", "< 14.0.0"),
+      "stylelint" => Gem::Requirement.new(">= 8.3.0", "< 14.0.0").freeze,
     }.freeze
 
     DEFAULT_TARGET_FILES = "*.{css,less,sass,scss,sss}".freeze

--- a/lib/runners/processor/tslint.rb
+++ b/lib/runners/processor/tslint.rb
@@ -28,7 +28,7 @@ module Runners
     register_config_schema(name: :tslint, schema: Schema.runner_config)
 
     CONSTRAINTS = {
-      "tslint" => Gem::Requirement.new(">= 5.0.0", "< 7.0.0"),
+      "tslint" => Gem::Requirement.new(">= 5.0.0", "< 7.0.0").freeze,
     }.freeze
 
     DEFAULT_TARGET = "**/*.ts{,x}".freeze

--- a/lib/runners/processor/tyscan.rb
+++ b/lib/runners/processor/tyscan.rb
@@ -22,7 +22,7 @@ module Runners
     register_config_schema(name: :tyscan, schema: Schema.runner_config)
 
     CONSTRAINTS = {
-      "tyscan" => Gem::Requirement.new(">= 0.2.1", "< 1.0.0")
+      "tyscan" => Gem::Requirement.new(">= 0.2.1", "< 1.0.0").freeze,
     }.freeze
 
     DEFAULT_CONFIG_FILE = "tyscan.yml".freeze

--- a/lib/runners/ruby.rb
+++ b/lib/runners/ruby.rb
@@ -33,10 +33,9 @@ module Runners
             spec.override_by_lockfile(lockfile)
           else
             locked_version = lockfile.locked_version!(spec)
-            constraints_text = constraints.fetch(spec.name).join(", ")
             add_warning <<~MESSAGE
               `#{spec.name} #{spec.version.first}` is installed instead of `#{locked_version}` in your `Gemfile.lock`.
-              Because `#{locked_version}` does not satisfy our constraints `#{constraints_text}`.
+              Because `#{locked_version}` does not satisfy our constraints `#{constraints.fetch(spec.name)}`.
 
               If you want to use a different version of `#{spec.name}`, please do either:
               - Update your `Gemfile.lock` to satisfy the constraint

--- a/lib/runners/ruby/gem_installer.rb
+++ b/lib/runners/ruby/gem_installer.rb
@@ -96,17 +96,22 @@ module Runners
           end
       end
 
-      def gem(spec, constraints)
-        declaration = "gem #{spec.name.inspect}"
-        constraint = constraints.map(&:inspect).join(", ")
-        (constraint.empty? ? declaration : "#{declaration}, #{constraint}")
+      def gem(spec, constraint)
+        declaration = %{gem "#{spec.name}"}
+        unless constraint.none?
+          declaration << ", "
+          declaration << constraint.to_s.split(",").map { |c| %{"#{c.strip}"} }.uniq.join(", ")
+        end
+        declaration
       end
 
       def gem_constraints(spec, source)
         # NOTE: Gems with Git source do not need constraints.
-        return [] if source.git?
+        return Gem::Requirement.create if source.git?
 
-        (spec.version + (constraints[spec.name] || [])).uniq
+        req = Gem::Requirement.create(*spec.version)
+        req.concat(constraints[spec.name].to_s.split(","))
+        req
       end
     end
   end

--- a/lib/runners/ruby/lockfile_loader/lockfile.rb
+++ b/lib/runners/ruby/lockfile_loader/lockfile.rb
@@ -32,7 +32,7 @@ module Runners
           found = find_spec(spec)
           version, = found&.version
           if found && version
-            Gem::Requirement.create(constraints[found.name]).satisfied_by?(Gem::Version.new(version))
+            Gem::Requirement.create(constraints[found.name]).satisfied_by?(Gem::Version.create(version))
           else
             raise "Spec not found: #{spec}, lockfile=#{specs.inspect}"
           end

--- a/lib/runners/ruby/lockfile_loader/lockfile.rb
+++ b/lib/runners/ruby/lockfile_loader/lockfile.rb
@@ -32,7 +32,7 @@ module Runners
           found = find_spec(spec)
           version, = found&.version
           if found && version
-            Gem::Requirement.create(constraints[found.name]).satisfied_by?(Gem::Version.create(version))
+            Gem::Requirement.create(constraints[found.name]).satisfied_by?(Gem::Version.new(version))
           else
             raise "Spec not found: #{spec}, lockfile=#{specs.inspect}"
           end

--- a/sig/rubygems.rbs
+++ b/sig/rubygems.rbs
@@ -1,7 +1,9 @@
 module Gem
   class Requirement
-    def self.create: (Array[String] | nil) -> instance
+    def self.create: (*(String | Gem::Version | Gem::Requirement | nil)) -> instance
     def initialize: (*String) -> instance
     def satisfied_by?: (Gem::Version) -> bool
+    def none?: () -> bool
+    def concat: (Array[String]) -> void
   end
 end

--- a/sig/runners/processor/rubocop.rbs
+++ b/sig/runners/processor/rubocop.rbs
@@ -10,7 +10,7 @@ module Runners
     Schema: SchemaClass
 
     GEM_NAME: String
-    CONSTRAINTS: Hash[String, Array[String]]
+    CONSTRAINTS: Ruby::constraints
 
     private
 

--- a/sig/runners/ruby.rbs
+++ b/sig/runners/ruby.rbs
@@ -1,6 +1,6 @@
 module Runners
   module Ruby : Processor
-    type constraints = Hash[String, Array[String]]
+    type constraints = Hash[String, Gem::Requirement]
 
     class InstallGemsFailure < UserError
     end

--- a/sig/runners/ruby/gem_installer.rbs
+++ b/sig/runners/ruby/gem_installer.rbs
@@ -46,9 +46,9 @@ module Runners
 
       def group_specs: () -> Array[[Source, Array[Spec]]]
 
-      def gem: (Spec, Array[String]) -> String
+      def gem: (Spec, Gem::Requirement) -> String
 
-      def gem_constraints: (Spec, Source) -> Array[String]
+      def gem_constraints: (Spec, Source) -> Gem::Requirement
     end
   end
 end

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -236,18 +236,3 @@
         (::String | nil | ::Runners::Ruby::GemInstaller::git_source) <: ::String
           nil <: ::String
     code: Ruby::IncompatibleAssignment
-- file: lib/runners/ruby/lockfile_loader/lockfile.rb
-  diagnostics:
-  - range:
-      start:
-        line: 35
-        character: 75
-      end:
-        line: 35
-        character: 103
-    severity: ERROR
-    message: |-
-      Cannot pass a value of type `(::Gem::Version | nil)` as an argument of type `::Gem::Version`
-        (::Gem::Version | nil) <: ::Gem::Version
-          nil <: ::Gem::Version
-    code: Ruby::ArgumentTypeMismatch

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -236,3 +236,18 @@
         (::String | nil | ::Runners::Ruby::GemInstaller::git_source) <: ::String
           nil <: ::String
     code: Ruby::IncompatibleAssignment
+- file: lib/runners/ruby/lockfile_loader/lockfile.rb
+  diagnostics:
+  - range:
+      start:
+        line: 35
+        character: 75
+      end:
+        line: 35
+        character: 103
+    severity: ERROR
+    message: |-
+      Cannot pass a value of type `(::Gem::Version | nil)` as an argument of type `::Gem::Version`
+        (::Gem::Version | nil) <: ::Gem::Version
+          nil <: ::Gem::Version
+    code: Ruby::ArgumentTypeMismatch

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -56,7 +56,7 @@ class RubyTest < Minitest::Test
         specs: specs,
         home: path,
         config_path_name: "sider.yml",
-        constraints: { "strong_json" => ["<= 0.8"], "rubocop" => [">= 0.55.0"] },
+        constraints: { "strong_json" => Gem::Requirement.new("<= 0.8"), "rubocop" => Gem::Requirement.new(">= 0.55.0") },
         trace_writer: trace_writer,
         use_local: false,
       )
@@ -64,8 +64,8 @@ class RubyTest < Minitest::Test
       assert_equal <<~CONTENT, installer.gemfile_content
         source "https://rubygems.org"
 
-        gem "meowcop", "1.2.0"
-        gem "strong_json", "0.4.0", "<= 0.8"
+        gem "meowcop", "= 1.2.0"
+        gem "strong_json", "= 0.4.0", "<= 0.8"
 
         source "https://gems.sider.review" do
           gem "rubocop-sider"
@@ -150,7 +150,7 @@ class RubyTest < Minitest::Test
         home: path,
         config_path_name: "sider.yml",
         trace_writer: trace_writer,
-        constraints: { "strong_json" => ["<= 0.8.0"] },
+        constraints: { "strong_json" => Gem::Requirement.new("<= 0.8.0") },
         use_local: false,
       )
 
@@ -167,7 +167,7 @@ class RubyTest < Minitest::Test
         ### Auto-generated Gemfile ###
         source "https://rubygems.org"
 
-        gem "strong_json", "0.5.0", "<= 0.8.0"
+        gem "strong_json", "= 0.5.0", "<= 0.8.0"
 
         git "https://github.com/rubocop/rubocop-rails.git", tag: "v2.9.0" do
           gem "rubocop-rails"
@@ -192,7 +192,7 @@ class RubyTest < Minitest::Test
         home: path,
         config_path_name: "sider.yml",
         trace_writer: trace_writer,
-        constraints: { "strong_json" => ["> 0.6.0"] },
+        constraints: { "strong_json" => Gem::Requirement.new("> 0.6.0") },
         use_local: false,
       )
 
@@ -615,7 +615,7 @@ EOF
 
       processor.install_gems([Spec.new(name: "public_suffix", version: ["4.0.3"])],
                              optionals: [Spec.new(name: "meowcop", version: ["1.17.1"])],
-                             constraints: { "rubocop" => [">= 4.0.0"] }) do
+                             constraints: { "rubocop" => Gem::Requirement.new(">= 4.0.0") }) do
         stdout, _ = processor.shell.capture3!("bundle", "list")
         assert_match(/\* public_suffix \(4.0.0\)/, stdout)
         assert_match(/\* strong_json \(0.7.1\)/, stdout)
@@ -650,7 +650,7 @@ EOF
       YAML
 
       processor.install_gems([Spec.new(name: "multi_json", version: ["1.14.0"])],
-                             constraints: { "multi_json" => ["> 1.13.0", "< 2.0.0"] }) do
+                             constraints: { "multi_json" => Gem::Requirement.new("> 1.13.0", "< 2.0.0") }) do
         assert_equal 1, processor.warnings.count
         assert trace_writer.writer.find { |m| m[:trace] == :command_line && m[:command_line] == %w[bundle install] }
         assert_equal <<~MESSAGE.strip, processor.warnings.first[:message]
@@ -680,7 +680,7 @@ EOF
 
       assert_raises GemInstaller::InstallationFailure do
         processor.install_gems([Spec.new(name: "rubocop", version: ["0.66.0"])],
-                               constraints: { "rubocop" => ["> 0.65.0"] }) do
+                               constraints: { "rubocop" => Gem::Requirement.new("> 0.65.0") }) do
           # noop
         end
       end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring aims to prevent bugs by using the more type-safe class.
(`Array[String]` -> `Gem::Requirement`)

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

See also #2160

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
