### PR TITLE
Inline `Runners::Ruby#installed_gem_versions` method

### DIFF
--- a/lib/runners/ruby.rb
+++ b/lib/runners/ruby.rb
@@ -78,23 +78,18 @@ module Runners
       @analyzer_version ||= extract_version! ruby_analyzer_command.to_a
     end
 
-    def installed_gem_versions(gem_names, exception: true)
+    def default_gem_specs(*gem_names)
       # @see https://guides.rubygems.org/command-reference/#gem-list
       stdout, = capture3! "gem", "list", "--quiet", "--exact", *gem_names
-      gem_names.each_with_object({}) do |name, hash|
+
+      gem_names.map do |name|
         # NOTE: A format example: `rubocop (0.75.1, 0.75.0)`
-        version, = /#{Regexp.escape(name)} \((.+)\)/.match(stdout)&.captures
+        version = /#{Regexp.escape(name)} \((.+)\)/.match(stdout)&.captures&.first
         if version
-          hash[name] = version.split(/,\s*/)
-        elsif exception
+          GemInstaller::Spec.new(name: name, version: version.split(/,\s*/))
+        else
           raise "Not found installed gem #{name.inspect}"
         end
-      end
-    end
-
-    def default_gem_specs(gem_name, *gem_names)
-      installed_gem_versions([gem_name, *gem_names]).map do |name, versions|
-        GemInstaller::Spec.new(name: name, version: versions)
       end
     end
 

--- a/sig/runners/ruby.rbs
+++ b/sig/runners/ruby.rbs
@@ -9,9 +9,7 @@ module Runners
 
     def ruby_analyzer_command: (*String) -> Command
 
-    def installed_gem_versions: (Array[String], ?exception: bool) -> Hash[String, Array[String]]
-
-    def default_gem_specs: (String, *String) -> Array[GemInstaller::Spec]
+    def default_gem_specs: (*String) -> Array[GemInstaller::Spec]
 
     def gem_info: (String) -> String
 

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -818,40 +818,23 @@ EOF
     end
   end
 
-  def test_installed_gem_versions
-    with_workspace do |workspace|
-      processor = new_processor(workspace: workspace)
-
-      processor.stub :capture3!, "rubocop (0.75.1, 0.75.0)\nmeowcop (2.4.0)\n" do
-        assert_equal({ "rubocop" => ["0.75.1", "0.75.0"], "meowcop" => ["2.4.0"] },
-                     processor.installed_gem_versions(["rubocop", "meowcop"]))
-      end
-
-      processor.stub :capture3!, "" do
-        error = assert_raises(RuntimeError) { processor.installed_gem_versions(["foo"]) }
-        assert_equal 'Not found installed gem "foo"', error.message
-      end
-
-      processor.stub :capture3!, "meowcop (2.4.0)\n" do
-        assert_equal({ "meowcop" => ["2.4.0"] },
-                     processor.installed_gem_versions(["foo", "meowcop"], exception: false))
-      end
-    end
-  end
-
   def test_default_gem_specs
     with_workspace do |workspace|
       processor = new_processor(workspace: workspace)
 
       processor.stub :capture3!, "rubocop (0.75.1, 0.75.0)\n" do
-        assert_equal [Spec.new(name: "rubocop", version: ["0.75.1", "0.75.0"])], processor.default_gem_specs("rubocop")
+        assert_equal [Spec.new(name: "rubocop", version: ["0.75.1", "0.75.0"])],
+                     processor.default_gem_specs("rubocop")
       end
 
       processor.stub :capture3!, "foo (1.2.3)\nbar (4.5.6)\n" do
-        assert_equal [
-          Spec.new(name: "foo", version: ["1.2.3"]),
-          Spec.new(name: "bar", version: ["4.5.6"]),
-        ], processor.default_gem_specs("foo", "bar")
+        assert_equal [Spec.new(name: "foo", version: ["1.2.3"]), Spec.new(name: "bar", version: ["4.5.6"])],
+                     processor.default_gem_specs("foo", "bar")
+      end
+
+      processor.stub :capture3!, "" do
+        error = assert_raises(RuntimeError) { processor.default_gem_specs("foo") }
+        assert_equal 'Not found installed gem "foo"', error.message
       end
     end
   end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring aims to reduce the needles code in the `Runners::Ruby` class.
The `#installed_gem_versions` method is used only by the `#default_gem_specs` method.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
