### PR TITLE
Move `Runners::GemInstaller::Spec.from_gems` into `Runners::Ruby`

### DIFF
--- a/lib/runners/ruby/gem_installer/spec.rb
+++ b/lib/runners/ruby/gem_installer/spec.rb
@@ -27,24 +27,6 @@ module Runners
           Spec.new(name: name, version: new_version, source: source)
         end
 
-        def self.from_gems(gems_items)
-          gems_items.map do |item|
-            gem =
-              case item
-              when Hash
-                item
-              when String
-                { name: item.to_s, version: nil, source: nil, git: nil }
-              end
-
-            self.new(
-              name: gem.fetch(:name),
-              version: Array(gem[:version]),
-              source: Source.create(gem),
-            )
-          end
-        end
-
         def self.merge(default_gems, user_gems)
           specs = []
 

--- a/sig/runners/ruby.rbs
+++ b/sig/runners/ruby.rbs
@@ -2,6 +2,20 @@ module Runners
   module Ruby : Processor
     type constraints = Hash[String, Gem::Requirement]
 
+    type git_source = {
+      repo: String,
+      ref: String?,
+      branch: String?,
+      tag: String?,
+    }
+
+    type gems_item = {
+      name: String,
+      version: String?,
+      source: String?,
+      git: git_source?,
+    }
+
     class InstallGemsFailure < UserError
     end
 
@@ -20,5 +34,7 @@ module Runners
     def optional_specs: (Array[GemInstaller::Spec], LockfileLoader::Lockfile) -> Array[GemInstaller::Spec]
 
     def user_specs: (Array[GemInstaller::Spec] specs, LockfileLoader::Lockfile) -> Array[GemInstaller::Spec]
+
+    def config_gems: () -> Array[GemInstaller::Spec]
   end
 end

--- a/sig/runners/ruby/gem_installer.rbs
+++ b/sig/runners/ruby/gem_installer.rbs
@@ -1,20 +1,6 @@
 module Runners
   module Ruby
     class GemInstaller
-      type git_source = {
-        repo: String,
-        ref: String?,
-        branch: String?,
-        tag: String?
-      }
-
-      type gems_item = {
-        name: String,
-        version: String?,
-        source: String?,
-        git: git_source?
-      }
-
       class InstallationFailure < InstallGemsFailure
       end
 

--- a/sig/runners/ruby/gem_installer/source.rbs
+++ b/sig/runners/ruby/gem_installer/source.rbs
@@ -5,7 +5,7 @@ module Runners
 
       def self.default: () -> Source
 
-      def self.create: (gems_item) -> instance
+      def self.create: (Ruby::gems_item) -> instance
 
       def rubygems?: () -> bool
 
@@ -25,7 +25,7 @@ module Runners
         attr_reader branch: String?
         attr_reader tag: String?
 
-        def initialize: (git_source) -> void
+        def initialize: (Ruby::git_source) -> void
       end
     end
   end

--- a/sig/runners/ruby/gem_installer/spec.rbs
+++ b/sig/runners/ruby/gem_installer/spec.rbs
@@ -10,8 +10,6 @@ module Runners
 
         def override_by_lockfile: (LockfileLoader::Lockfile) -> Spec
 
-        def self.from_gems: (Array[gems_item | String]) -> Array[Spec]
-
         def self.merge: (Array[Spec], Array[Spec]) -> Array[Spec]
       end
     end

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -221,21 +221,6 @@
     severity: ERROR
     message: Type `(::String | ::Array[::String] | nil)` does not have method `split`
     code: Ruby::NoMethod
-- file: lib/runners/ruby/gem_installer/spec.rb
-  diagnostics:
-  - range:
-      start:
-        line: 41
-        character: 20
-      end:
-        line: 41
-        character: 36
-    severity: ERROR
-    message: |-
-      Cannot assign a value of type `(::String | nil | ::Runners::Ruby::GemInstaller::git_source)` to an expression of type `::String`
-        (::String | nil | ::Runners::Ruby::GemInstaller::git_source) <: ::String
-          nil <: ::String
-    code: Ruby::IncompatibleAssignment
 - file: lib/runners/ruby/lockfile_loader/lockfile.rb
   diagnostics:
   - range:
@@ -250,4 +235,20 @@
       Cannot pass a value of type `(::Gem::Version | nil)` as an argument of type `::Gem::Version`
         (::Gem::Version | nil) <: ::Gem::Version
           nil <: ::Gem::Version
+    code: Ruby::ArgumentTypeMismatch
+- file: lib/runners/ruby.rb
+  diagnostics:
+  - range:
+      start:
+        line: 122
+        character: 46
+      end:
+        line: 122
+        character: 49
+    severity: ERROR
+    message: |-
+      Cannot pass a value of type `(::Hash[untyped, untyped] | ::Hash[::Symbol, (::String | nil)])` as an argument of type `::Runners::Ruby::gems_item`
+        (::Hash[untyped, untyped] | ::Hash[::Symbol, (::String | nil)]) <: ::Runners::Ruby::gems_item
+          (::Hash[untyped, untyped] | ::Hash[::Symbol, (::String | nil)]) <: { :git => (::Runners::Ruby::git_source | nil), :name => ::String, :source => (::String | nil), :version => (::String | nil) }
+            ::Hash[untyped, untyped] <: { :git => (::Runners::Ruby::git_source | nil), :name => ::String, :source => (::String | nil), :version => (::String | nil) }
     code: Ruby::ArgumentTypeMismatch

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -203,24 +203,29 @@ class RubyTest < Minitest::Test
     end
   end
 
-  def test_from_gems
-    specs = Spec.from_gems([
-      "rubocop",
-      { name: "strong_json", version: "0.7.0", source: "https://my.gems.org" },
-      { name: "rubocop-sider", git: { repo: "https://github.com/sider/rubocop-sider.git" } },
-      { name: "runners", git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" } },
-      { name: "rubocop-rails", git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" } },
-      { name: "rubocop-performance", git: { repo: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" } },
-    ])
+  def test_config_gems
+    with_workspace do |workspace|
+      processor = new_processor(workspace: workspace, config_yaml: <<~YAML)
+        linter:
+          rubocop:
+            gems:
+              - rubocop
+              - { name: "strong_json", version: "0.7.0", source: "https://my.gems.org" }
+              - { name: "runners", git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" } }
+              - { name: "rubocop-rails", git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" } }
+              - { name: "rubocop-performance", git: { repo: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" } }
+      YAML
 
-    assert_equal [
-      Spec.new(name: "rubocop", version: []),
-      Spec.new(name: "strong_json", version: ["0.7.0"], source: Source.create({ source: "https://my.gems.org" })),
-      Spec.new(name: "rubocop-sider", version: [], source: Source.create({ git: { repo: "https://github.com/sider/rubocop-sider.git" } })),
-      Spec.new(name: "runners", version: [], source: Source.create({ git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" } })),
-      Spec.new(name: "rubocop-rails", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" } })),
-      Spec.new(name: "rubocop-performance", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" } })),
-    ], specs
+      assert_equal [
+        Spec.new(name: "rubocop", version: []),
+        Spec.new(name: "strong_json", version: ["0.7.0"], source: Source.create({ source: "https://my.gems.org" })),
+        Spec.new(name: "runners", version: [], source: Source.create({ git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" } })),
+        Spec.new(name: "rubocop-rails", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" } })),
+        Spec.new(name: "rubocop-performance", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" } })),
+      ], processor.send(:config_gems)
+
+      assert_empty new_processor(workspace: workspace).send(:config_gems)
+    end
   end
 
   def test_ensure_lockfile_with_gemfile_lock


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring aims to narrow the scope of the `Runners::GemInstaller::Spec.from_gems` method
by moving it into a private method in the `Runners::Ruby` class.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
