### PR TITLE
Move `Runners::GemInstaller::Spec.merge` into `Runners::Ruby`

### DIFF
--- a/lib/runners/ruby/gem_installer/spec.rb
+++ b/lib/runners/ruby/gem_installer/spec.rb
@@ -26,37 +26,6 @@ module Runners
           new_version = locked_version ? [locked_version] : version
           Spec.new(name: name, version: new_version, source: source)
         end
-
-        def self.merge(default_gems, user_gems)
-          specs = []
-
-          default_gems_hash = default_gems.each.with_object({}) do |spec, hash|
-            hash[spec.name] = spec
-          end
-          user_gems_hash = user_gems.each.with_object({}) do |spec, hash|
-            hash[spec.name] = spec
-          end
-
-          default_gems_hash.each do |_, spec|
-            if (user_spec = user_gems_hash[spec.name])
-              specs << GemInstaller::Spec.new(
-                name: spec.name,
-                version: user_spec.version,
-                source: user_spec.source
-              )
-            else
-              specs << spec
-            end
-          end
-
-          user_gems_hash.each do |_, spec|
-            unless default_gems_hash.key?(spec.name)
-              specs << spec
-            end
-          end
-
-          specs
-        end
       end
     end
   end

--- a/sig/runners/ruby.rbs
+++ b/sig/runners/ruby.rbs
@@ -36,5 +36,7 @@ module Runners
     def user_specs: (Array[GemInstaller::Spec] specs, LockfileLoader::Lockfile) -> Array[GemInstaller::Spec]
 
     def config_gems: () -> Array[GemInstaller::Spec]
+
+    def merge_specs: (Array[GemInstaller::Spec], Array[GemInstaller::Spec]) -> Array[GemInstaller::Spec]
   end
 end

--- a/sig/runners/ruby/gem_installer/spec.rbs
+++ b/sig/runners/ruby/gem_installer/spec.rbs
@@ -9,8 +9,6 @@ module Runners
         def initialize: (name: String, version: Array[String], ?source: Source) -> void
 
         def override_by_lockfile: (LockfileLoader::Lockfile) -> Spec
-
-        def self.merge: (Array[Spec], Array[Spec]) -> Array[Spec]
       end
     end
   end

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -240,10 +240,10 @@
   diagnostics:
   - range:
       start:
-        line: 122
+        line: 124
         character: 46
       end:
-        line: 122
+        line: 124
         character: 49
     severity: ERROR
     message: |-
@@ -252,3 +252,31 @@
           (::Hash[untyped, untyped] | ::Hash[::Symbol, (::String | nil)]) <: { :git => (::Runners::Ruby::git_source | nil), :name => ::String, :source => (::String | nil), :version => (::String | nil) }
             ::Hash[untyped, untyped] <: { :git => (::Runners::Ruby::git_source | nil), :name => ::String, :source => (::String | nil), :version => (::String | nil) }
     code: Ruby::ArgumentTypeMismatch
+  - range:
+      start:
+        line: 130
+        character: 22
+      end:
+        line: 130
+        character: 64
+    severity: ERROR
+    message: |-
+      Cannot find compatible overloading of method `to_h` of type `::Array[::Runners::Ruby::GemInstaller::Spec]`
+      Method types:
+        def to_h: () -> ::Hash[untyped, untyped]
+                | [T, S] () { (::Runners::Ruby::GemInstaller::Spec) -> [T, S] } -> ::Hash[T, S]
+    code: Ruby::UnresolvedOverloading
+  - range:
+      start:
+        line: 131
+        character: 19
+      end:
+        line: 131
+        character: 58
+    severity: ERROR
+    message: |-
+      Cannot find compatible overloading of method `to_h` of type `::Array[::Runners::Ruby::GemInstaller::Spec]`
+      Method types:
+        def to_h: () -> ::Hash[untyped, untyped]
+                | [T, S] () { (::Runners::Ruby::GemInstaller::Spec) -> [T, S] } -> ::Hash[T, S]
+    code: Ruby::UnresolvedOverloading

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -486,22 +486,25 @@ EOF
   end
 
   def test_merge_specs
-    default_specs = [
-      Spec.new(name: "rubocop", version: ["0.4.0"]),
-      Spec.new(name: "strong_json", version: ["0.4.0"])
-    ]
+    with_workspace do |workspace|
+      processor = new_processor(workspace: workspace)
 
-    user_specs = [
-      Spec.new(name: "rubocop", version: ["0.5.0"], source: "https://some.source.org"),
-      Spec.new(name: "rubocop-rspec", version: ["1.2.3"])
-    ]
+      defaults = [
+        Spec.new(name: "rubocop", version: ["0.4.0"]),
+        Spec.new(name: "strong_json", version: ["0.4.0"]),
+      ]
 
-    assert_equal [
-                   Spec.new(name: "rubocop", version: ["0.5.0"], source: "https://some.source.org"),
-                   Spec.new(name: "strong_json", version: ["0.4.0"]),
-                   Spec.new(name: "rubocop-rspec", version: ["1.2.3"])
-                 ],
-                 Spec.merge(default_specs, user_specs)
+      users = [
+        Spec.new(name: "rubocop", version: ["0.5.0"], source: "https://some.source.org"),
+        Spec.new(name: "rubocop-rspec", version: ["1.2.3"]),
+      ]
+
+      assert_equal [
+        Spec.new(name: "rubocop", version: ["0.5.0"], source: "https://some.source.org"),
+        Spec.new(name: "strong_json", version: ["0.4.0"]),
+        Spec.new(name: "rubocop-rspec", version: ["1.2.3"]),
+      ], processor.send(:merge_specs, defaults, users)
+    end
   end
 
   def test_install_no_gems


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring aims to narrow the scope of the `Runners::GemInstaller::Spec.merge` method
by moving it into the private method in the `Runners::Ruby` class.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Related to #2166

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
