### PR TITLE
Simplify generated `Gemfile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Misc:
 - **Clang-Tidy** Loosen the version constraint for clang-tidy [#2153](https://github.com/sider/runners/pull/2153)
 - **ESLint** Update pre-installed packages [#2155](https://github.com/sider/runners/pull/2155)
 - **Flake8** Enable new recommended configuration [#2157](https://github.com/sider/runners/pull/2157)
+- Simplify generated `Gemfile` [#2168](https://github.com/sider/runners/pull/2168)
 
 ## 0.44.1
 

--- a/lib/runners/ruby.rb
+++ b/lib/runners/ruby.rb
@@ -121,7 +121,7 @@ module Runners
         GemInstaller::Spec.new(
           name: gem.fetch(:name),
           version: Array(gem[:version]),
-          source: GemInstaller::Source.create(gem),
+          source: GemInstaller::Source.new(uri: gem[:source], git: gem[:git]),
         )
       end
     end

--- a/lib/runners/ruby/gem_installer.rb
+++ b/lib/runners/ruby/gem_installer.rb
@@ -51,27 +51,17 @@ module Runners
         end
       end
 
+      # @see https://bundler.io/man/gemfile.5.html
       def gemfile_content
         trace_writer.message "Generating optimized Gemfile..."
 
         # @type var lines: Array[String]
         lines = []
-        lines << Source.default.to_s
+        lines << %{source "#{Gem::DEFAULT_HOST}"}
         lines << ""
 
-        group_specs.each do |source, specs|
-          if source.default?
-            specs.each do |spec|
-              lines << gem(spec, gem_constraints(spec, source))
-            end
-          else
-            lines << "" if !lines.last&.empty?
-            lines << "#{source} do"
-            specs.each do |spec|
-              lines << "  #{gem(spec, gem_constraints(spec, source))}"
-            end
-            lines << "end"
-          end
+        specs.sort_by(&:name).each do |spec|
+          lines << gem(spec, gem_constraints(spec))
         end
 
         (lines.join("\n") + "\n").tap do |content|
@@ -84,33 +74,34 @@ module Runners
 
       private
 
-      def group_specs
-        specs
-          .group_by(&:source)
-          .sort_by do |source,|
-            case
-            when source.default? then 0
-            when source.rubygems? then 1
-            else 2
-            end
-          end
-      end
-
       def gem(spec, constraint)
-        declaration = %{gem "#{spec.name}"}
-        unless constraint.none?
-          declaration << ", "
-          declaration << constraint.to_s.split(",").map { |c| %{"#{c.strip}"} }.uniq.join(", ")
+        s = %{gem "#{spec.name}"}
+
+        source = spec.source
+
+        if !constraint.none? && !source.git?
+          s << ", "
+          s << constraint.to_s.split(",").map { |c| %{"#{c.strip}"} }.uniq.join(", ")
         end
-        declaration
+
+        if source.git?
+          s << %{, git: "#{source.repo}"}
+          s << %{, ref: "#{source.ref}"} if source.ref
+          s << %{, branch: "#{source.branch}"} if source.branch
+          s << %{, tag: "#{source.tag}"} if source.tag
+        elsif !source.default?
+          s << %{, source: "#{source.uri}"}
+        end
+
+        s
       end
 
-      def gem_constraints(spec, source)
-        # NOTE: Gems with Git source do not need constraints.
-        return Gem::Requirement.create if source.git?
-
+      def gem_constraints(spec)
         req = Gem::Requirement.create(*spec.version)
-        req.concat(constraints[spec.name].to_s.split(","))
+
+        # NOTE: Gems with Git source do not need constraints.
+        req.concat(constraints[spec.name].to_s.split(",")) unless spec.source.git?
+
         req
       end
     end

--- a/lib/runners/ruby/gem_installer.rb
+++ b/lib/runners/ruby/gem_installer.rb
@@ -57,7 +57,7 @@ module Runners
 
         # @type var lines: Array[String]
         lines = []
-        lines << %{source "#{Gem::DEFAULT_HOST}"}
+        lines << %{source "#{Source.default.uri}"}
         lines << ""
 
         specs.sort_by(&:name).each do |spec|

--- a/sig/runners/ruby/gem_installer.rbs
+++ b/sig/runners/ruby/gem_installer.rbs
@@ -30,11 +30,9 @@ module Runners
 
       private
 
-      def group_specs: () -> Array[[Source, Array[Spec]]]
-
       def gem: (Spec, Gem::Requirement) -> String
 
-      def gem_constraints: (Spec, Source) -> Gem::Requirement
+      def gem_constraints: (Spec) -> Gem::Requirement
     end
   end
 end

--- a/sig/runners/ruby/gem_installer/source.rbs
+++ b/sig/runners/ruby/gem_installer/source.rbs
@@ -1,32 +1,19 @@
 module Runners
   class Ruby::GemInstaller
     class Source
-      DEFAULT: String
+      def self.default: () -> instance
 
-      def self.default: () -> Source
+      attr_reader uri: String?
+      attr_reader repo: String?
+      attr_reader ref: String?
+      attr_reader branch: String?
+      attr_reader tag: String?
 
-      def self.create: (Ruby::gems_item) -> instance
-
-      def rubygems?: () -> bool
+      def initialize: (?uri: String?, ?git: Ruby::git_source?) -> void
 
       def git?: () -> bool
 
       def default?: () -> bool
-
-      class Rubygems < Source
-        attr_reader source: String
-
-        def initialize: (String) -> void
-      end
-
-      class Git < Source
-        attr_reader repo: String
-        attr_reader ref: String?
-        attr_reader branch: String?
-        attr_reader tag: String?
-
-        def initialize: (Ruby::git_source) -> void
-      end
     end
   end
 end

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -240,20 +240,6 @@
   diagnostics:
   - range:
       start:
-        line: 124
-        character: 46
-      end:
-        line: 124
-        character: 49
-    severity: ERROR
-    message: |-
-      Cannot pass a value of type `(::Hash[untyped, untyped] | ::Hash[::Symbol, (::String | nil)])` as an argument of type `::Runners::Ruby::gems_item`
-        (::Hash[untyped, untyped] | ::Hash[::Symbol, (::String | nil)]) <: ::Runners::Ruby::gems_item
-          (::Hash[untyped, untyped] | ::Hash[::Symbol, (::String | nil)]) <: { :git => (::Runners::Ruby::git_source | nil), :name => ::String, :source => (::String | nil), :version => (::String | nil) }
-            ::Hash[untyped, untyped] <: { :git => (::Runners::Ruby::git_source | nil), :name => ::String, :source => (::String | nil), :version => (::String | nil) }
-    code: Ruby::ArgumentTypeMismatch
-  - range:
-      start:
         line: 130
         character: 22
       end:

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -40,12 +40,12 @@ class RubyTest < Minitest::Test
 
   def test_gemfile_content
     specs = [
-      Spec.new(name: "rubocop", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop.git", branch: "master" } })),
-      Spec.new(name: "runners", version: [], source: Source.create({ git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" } })),
-      Spec.new(name: "rubocop-rails", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" } })),
-      Spec.new(name: "rubocop-rspec", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" } })),
-      Spec.new(name: "rubocop-sider", version: [], source: Source.create({ source: "https://gems.sider.review" })),
-      Spec.new(name: "rubocop-nyan", version: [], source: Source.create({ source: "https://gems.sider.review" })),
+      Spec.new(name: "rubocop", version: [], source: Source.new(git: { repo: "https://github.com/rubocop/rubocop.git", branch: "master" })),
+      Spec.new(name: "runners", version: [], source: Source.new(git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" })),
+      Spec.new(name: "rubocop-rails", version: [], source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" })),
+      Spec.new(name: "rubocop-rspec", version: [], source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" })),
+      Spec.new(name: "rubocop-sider", version: [], source: Source.new(uri: "https://gems.sider.review")),
+      Spec.new(name: "rubocop-nyan", version: ["> 1.0"], source: Source.new(uri: "https://gems.sider.review")),
       Spec.new(name: "meowcop", version: ["1.2.0"]),
       Spec.new(name: "strong_json", version: ["0.4.0", "<= 0.8"]),
     ]
@@ -61,33 +61,20 @@ class RubyTest < Minitest::Test
         use_local: false,
       )
 
-      assert_equal <<~CONTENT, installer.gemfile_content
+      content = installer.gemfile_content
+      assert_equal <<~RUBY, content
         source "https://rubygems.org"
 
         gem "meowcop", "= 1.2.0"
+        gem "rubocop", git: "https://github.com/rubocop/rubocop.git", branch: "master"
+        gem "rubocop-nyan", "> 1.0", source: "https://gems.sider.review"
+        gem "rubocop-rails", git: "https://github.com/rubocop/rubocop-rails.git", branch: "dev"
+        gem "rubocop-rspec", git: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0"
+        gem "rubocop-sider", source: "https://gems.sider.review"
+        gem "runners", git: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d"
         gem "strong_json", "= 0.4.0", "<= 0.8"
-
-        source "https://gems.sider.review" do
-          gem "rubocop-sider"
-          gem "rubocop-nyan"
-        end
-
-        git "https://github.com/rubocop/rubocop.git", branch: "master" do
-          gem "rubocop"
-        end
-
-        git "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" do
-          gem "runners"
-        end
-
-        git "https://github.com/rubocop/rubocop-rails.git", branch: "dev" do
-          gem "rubocop-rails"
-        end
-
-        git "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" do
-          gem "rubocop-rspec"
-        end
-      CONTENT
+      RUBY
+      assert_ruby_syntax_ok content
     end
   end
 
@@ -96,7 +83,7 @@ class RubyTest < Minitest::Test
       installer = GemInstaller.new(
         shell: shell,
         specs: [
-          Spec.new(name: "rubocop-sider", version: [], source: Source.create({ source: "https://gems.sider.review" })),
+          Spec.new(name: "rubocop-sider", version: [], source: Source.new(uri: "https://gems.sider.review")),
         ],
         home: path,
         config_path_name: "sider.yml",
@@ -105,13 +92,13 @@ class RubyTest < Minitest::Test
         use_local: false,
       )
 
-      assert_equal <<~CONTENT, installer.gemfile_content
+      content = installer.gemfile_content
+      assert_equal <<~RUBY, content
         source "https://rubygems.org"
 
-        source "https://gems.sider.review" do
-          gem "rubocop-sider"
-        end
-      CONTENT
+        gem "rubocop-sider", source: "https://gems.sider.review"
+      RUBY
+      assert_ruby_syntax_ok content
     end
   end
 
@@ -140,7 +127,7 @@ class RubyTest < Minitest::Test
     specs = [
       Spec.new(name: "strong_json", version: ["0.5.0"]),
       Spec.new(name: "rubocop-rails", version: ["2.9.0"],
-               source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop-rails.git", tag: "v2.9.0" } })),
+               source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-rails.git", tag: "v2.9.0" })),
     ]
 
     mktmpdir do |path|
@@ -167,13 +154,10 @@ class RubyTest < Minitest::Test
         ### Auto-generated Gemfile ###
         source "https://rubygems.org"
 
+        gem "rubocop-rails", git: "https://github.com/rubocop/rubocop-rails.git", tag: "v2.9.0"
         gem "strong_json", "= 0.5.0", "<= 0.8.0"
-
-        git "https://github.com/rubocop/rubocop-rails.git", tag: "v2.9.0" do
-          gem "rubocop-rails"
-        end
       RUBY
-      assert system("ruby", "-ce", gemfile_content_log)
+      assert_ruby_syntax_ok gemfile_content_log
 
       messages = trace_writer.writer.select { |m| m[:trace] == :message }.map { |m| m[:message] }
       assert_equal(["Generating optimized Gemfile...", gemfile_content_log, "Installing gems..."], messages)
@@ -218,10 +202,10 @@ class RubyTest < Minitest::Test
 
       assert_equal [
         Spec.new(name: "rubocop", version: []),
-        Spec.new(name: "strong_json", version: ["0.7.0"], source: Source.create({ source: "https://my.gems.org" })),
-        Spec.new(name: "runners", version: [], source: Source.create({ git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" } })),
-        Spec.new(name: "rubocop-rails", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" } })),
-        Spec.new(name: "rubocop-performance", version: [], source: Source.create({ git: { repo: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" } })),
+        Spec.new(name: "strong_json", version: ["0.7.0"], source: Source.new(uri: "https://my.gems.org")),
+        Spec.new(name: "runners", version: [], source: Source.new(git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" })),
+        Spec.new(name: "rubocop-rails", version: [], source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" })),
+        Spec.new(name: "rubocop-performance", version: [], source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" })),
       ], processor.send(:config_gems)
 
       assert_empty new_processor(workspace: workspace).send(:config_gems)
@@ -857,5 +841,11 @@ EOF
       assert_match %r{URI is a module providing classes to handle Uniform Resource}, processor.gem_info("uri")
       assert_equal 2, trace_writer.writer.count { |trace| trace.key?(:command_line) }
     end
+  end
+
+  private
+
+  def assert_ruby_syntax_ok(code)
+    assert RubyVM::InstructionSequence.compile(code)
   end
 end

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -40,6 +40,7 @@ class RubyTest < Minitest::Test
 
   def test_gemfile_content
     specs = [
+      Spec.new(name: "rubocop-minitest", version: [], source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-minitest.git" })),
       Spec.new(name: "rubocop", version: [], source: Source.new(git: { repo: "https://github.com/rubocop/rubocop.git", branch: "master" })),
       Spec.new(name: "runners", version: [], source: Source.new(git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" })),
       Spec.new(name: "rubocop-rails", version: [], source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" })),
@@ -67,6 +68,7 @@ class RubyTest < Minitest::Test
 
         gem "meowcop", "= 1.2.0"
         gem "rubocop", git: "https://github.com/rubocop/rubocop.git", branch: "master"
+        gem "rubocop-minitest", git: "https://github.com/rubocop/rubocop-minitest.git"
         gem "rubocop-nyan", "> 1.0", source: "https://gems.sider.review"
         gem "rubocop-rails", git: "https://github.com/rubocop/rubocop-rails.git", branch: "dev"
         gem "rubocop-rspec", git: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0"


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to simplify a generated `Gemfile` for Ruby runners (e.g. RuboCop).

For example:

```ruby
# Before (using blocks)
source "https://gems.sider.review" do
  gem "rubocop-sider"
end
git "https://github.com/rubocop/rubocop.git", branch: "master" do
  gem "rubocop"
end

# After (order by names)
gem "rubocop", git: "https://github.com/rubocop/rubocop.git", branch: "master"
gem "rubocop-sider", source: "https://gems.sider.review"
```

See also <https://bundler.io/man/gemfile.5.html>.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
