### PR TITLE
Refactor `Runners::GemInstaller::Spec`

### DIFF
--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -70,7 +70,7 @@ module Runners
       default_gems = default_gem_specs(GEM_NAME, *REQUIRED_GEM_NAMES)
       if setup_default_rubocop_config
         # NOTE: See rubocop.rb about no versions.
-        default_gems << GemInstaller::Spec.new(name: "meowcop", version: [])
+        default_gems << GemInstaller::Spec.new("meowcop")
       end
 
       optionals = official_rubocop_plugins + third_party_rubocop_plugins

--- a/lib/runners/processor/querly.rb
+++ b/lib/runners/processor/querly.rb
@@ -22,8 +22,8 @@ module Runners
     register_config_schema(name: :querly, schema: Schema.runner_config)
 
     OPTIONAL_GEMS = [
-      GemInstaller::Spec.new(name: "slim", version: []),
-      GemInstaller::Spec.new(name: "haml", version: []),
+      GemInstaller::Spec.new("slim"),
+      GemInstaller::Spec.new("haml"),
     ].freeze
 
     GEM_NAME = "querly".freeze

--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -31,13 +31,13 @@ module Runners
     register_config_schema(name: :rails_best_practices, schema: Schema.runner_config)
 
     OPTIONAL_GEMS = [
-      GemInstaller::Spec.new(name: "slim", version: []),
-      GemInstaller::Spec.new(name: "haml", version: []),
-      GemInstaller::Spec.new(name: "sass", version: []),
-      GemInstaller::Spec.new(name: "sassc", version: []),
+      GemInstaller::Spec.new("slim"),
+      GemInstaller::Spec.new("haml"),
+      GemInstaller::Spec.new("sass"),
+      GemInstaller::Spec.new("sassc"),
       # HACK: sassc v1.x does not have `rake` dependency, but fail to install if the `rake` missing
       # https://github.com/sass/sassc-ruby/issues/86
-      GemInstaller::Spec.new(name: "rake", version: []),
+      GemInstaller::Spec.new("rake"),
     ].freeze
 
     GEM_NAME = "rails_best_practices".freeze

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -52,7 +52,7 @@ module Runners
         #       (e.g. MeowCop 2.4.0 requires RuboCop 0.75.0+)
         #       So, MeowCop versions must be unspecified because the installation will fail when a user's RuboCop is 0.60.0.
         #       Bundler will select an appropriate version automatically unless versions.
-        default_gems << GemInstaller::Spec.new(name: "meowcop", version: [])
+        default_gems << GemInstaller::Spec.new("meowcop")
       end
 
       optionals = official_rubocop_plugins + third_party_rubocop_plugins

--- a/lib/runners/processor/slim_lint.rb
+++ b/lib/runners/processor/slim_lint.rb
@@ -50,7 +50,7 @@ module Runners
 
       if setup_default_rubocop_config
         # NOTE: See `Processor::RuboCop` about no versions.
-        default_gems << GemInstaller::Spec.new(name: "meowcop", version: [])
+        default_gems << GemInstaller::Spec.new("meowcop")
       end
 
       optionals = official_rubocop_plugins + third_party_rubocop_plugins

--- a/lib/runners/rubocop_utils.rb
+++ b/lib/runners/rubocop_utils.rb
@@ -13,7 +13,7 @@ module Runners
         rubocop-rubycw
         rubocop-sequel
       ].map do |name|
-        Ruby::GemInstaller::Spec.new(name: name, version: [])
+        Ruby::GemInstaller::Spec.new(name)
       end.freeze
     end
 
@@ -59,7 +59,7 @@ module Runners
         unifacop
         ws-style
       ].map do |name|
-        Ruby::GemInstaller::Spec.new(name: name, version: [])
+        Ruby::GemInstaller::Spec.new(name)
       end.freeze
     end
 

--- a/lib/runners/ruby.rb
+++ b/lib/runners/ruby.rb
@@ -36,7 +36,7 @@ module Runners
           else
             locked_version = lockfile.locked_version!(spec)
             add_warning <<~MESSAGE
-              `#{spec.name} #{spec.version.first}` is installed instead of `#{locked_version}` in your `Gemfile.lock`.
+              `#{spec.name} #{spec.requirement}` will be installed instead of `#{locked_version}` in your `Gemfile.lock`.
               Because `#{locked_version}` does not satisfy our constraints `#{constraints.fetch(spec.name)}`.
 
               If you want to use a different version of `#{spec.name}`, please do either:
@@ -58,7 +58,7 @@ module Runners
 
     private def user_specs(specs, lockfile)
       specs.map do |spec|
-        if spec.version.empty?
+        if spec.requirement.none?
           spec.override_by_lockfile(lockfile)
         else
           spec
@@ -88,7 +88,7 @@ module Runners
         # NOTE: A format example: `rubocop (0.75.1, 0.75.0)`
         version = /#{Regexp.escape(name)} \((.+)\)/.match(stdout)&.captures&.first
         if version
-          GemInstaller::Spec.new(name: name, version: version.split(/,\s*/))
+          GemInstaller::Spec.new(name, requirement: version.split(/,\s*/))
         else
           raise "Not found installed gem #{name.inspect}"
         end
@@ -119,8 +119,8 @@ module Runners
               end
 
         GemInstaller::Spec.new(
-          name: gem.fetch(:name),
-          version: Array(gem[:version]),
+          gem.fetch(:name),
+          requirement: Array(gem[:version]),
           source: GemInstaller::Source.new(uri: gem[:source], git: gem[:git]),
         )
       end
@@ -135,11 +135,7 @@ module Runners
       specs += defaults_hash.map do |name, spec|
         user_spec = users_hash[name]
         if user_spec
-          GemInstaller::Spec.new(
-            name: name,
-            version: user_spec.version,
-            source: user_spec.source
-          )
+          GemInstaller::Spec.new(name, requirement: user_spec.requirement, source: user_spec.source)
         else
           spec
         end

--- a/lib/runners/ruby/gem_installer.rb
+++ b/lib/runners/ruby/gem_installer.rb
@@ -97,7 +97,7 @@ module Runners
       end
 
       def gem_constraints(spec)
-        req = Gem::Requirement.create(*spec.version)
+        req = spec.requirement.dup
 
         # NOTE: Gems with Git source do not need constraints.
         req.concat(constraints[spec.name].to_s.split(",")) unless spec.source.git?

--- a/lib/runners/ruby/gem_installer/spec.rb
+++ b/lib/runners/ruby/gem_installer/spec.rb
@@ -2,29 +2,27 @@ module Runners
   module Ruby
     class GemInstaller
       class Spec
-        attr_reader :name, :version, :source
+        attr_reader :name, :requirement, :source
 
-        alias versions version
-
-        def initialize(name:, version:, source: Source.default)
+        def initialize(name, requirement: [], source: Source.default)
           @name = name
-          @version = version
+          @requirement = requirement.is_a?(Gem::Requirement) ? requirement : Gem::Requirement.create(*requirement)
           @source = source
         end
 
         def ==(other)
-          self.class == other.class && name == other.name && version == other.version && source == other.source
+          self.class == other.class && name == other.name && requirement == other.requirement && source == other.source
         end
         alias eql? ==
 
         def hash
-          name.hash ^ version.hash ^ source.hash
+          name.hash ^ requirement.hash ^ source.hash
         end
 
         def override_by_lockfile(lockfile)
           locked_version = lockfile.locked_version(self)
-          new_version = locked_version ? [locked_version] : version
-          Spec.new(name: name, version: new_version, source: source)
+          new_version = locked_version ? [locked_version] : requirement
+          self.class.new(name, requirement: new_version, source: source)
         end
       end
     end

--- a/sig/runners/ruby/gem_installer/spec.rbs
+++ b/sig/runners/ruby/gem_installer/spec.rbs
@@ -3,12 +3,12 @@ module Runners
     class GemInstaller
       class Spec
         attr_reader name: String
-        attr_reader version: Array[String]
+        attr_reader requirement: Gem::Requirement
         attr_reader source: Source
 
-        def initialize: (name: String, version: Array[String], ?source: Source) -> void
+        def initialize: (String, ?requirement: (Array[String | Gem::Version] | Gem::Requirement), ?source: Source) -> void
 
-        def override_by_lockfile: (LockfileLoader::Lockfile) -> Spec
+        def override_by_lockfile: (LockfileLoader::Lockfile) -> instance
       end
     end
   end

--- a/sig/runners/ruby/lockfile_loader/lockfile.rbs
+++ b/sig/runners/ruby/lockfile_loader/lockfile.rbs
@@ -4,21 +4,23 @@ module Runners
       class Lockfile
         type spec = GemInstaller::Spec | String
 
-        attr_reader specs: Array[GemInstaller::Spec]
-
         def initialize: (String?) -> void
+
+        def empty?: () -> bool
 
         def spec_exists?: (spec) -> bool
 
-        def locked_version: (spec) -> String?
+        def locked_version: (spec) -> Gem::Version?
 
-        def locked_version!: (spec) -> String
+        def locked_version!: (spec) -> Gem::Version
 
         def satisfied_by?: (spec, constraints) -> bool
 
         private
 
-        def find_spec: (spec) -> GemInstaller::Spec?
+        attr_reader specs: Array[Bundler::LazySpecification]
+
+        def find_spec: (spec) -> Bundler::LazySpecification?
       end
     end
   end

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -221,21 +221,6 @@
     severity: ERROR
     message: Type `(::String | ::Array[::String] | nil)` does not have method `split`
     code: Ruby::NoMethod
-- file: lib/runners/ruby/lockfile_loader/lockfile.rb
-  diagnostics:
-  - range:
-      start:
-        line: 35
-        character: 75
-      end:
-        line: 35
-        character: 103
-    severity: ERROR
-    message: |-
-      Cannot pass a value of type `(::Gem::Version | nil)` as an argument of type `::Gem::Version`
-        (::Gem::Version | nil) <: ::Gem::Version
-          nil <: ::Gem::Version
-    code: Ruby::ArgumentTypeMismatch
 - file: lib/runners/ruby.rb
   diagnostics:
   - range:

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -40,15 +40,15 @@ class RubyTest < Minitest::Test
 
   def test_gemfile_content
     specs = [
-      Spec.new(name: "rubocop-minitest", version: [], source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-minitest.git" })),
-      Spec.new(name: "rubocop", version: [], source: Source.new(git: { repo: "https://github.com/rubocop/rubocop.git", branch: "master" })),
-      Spec.new(name: "runners", version: [], source: Source.new(git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" })),
-      Spec.new(name: "rubocop-rails", version: [], source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" })),
-      Spec.new(name: "rubocop-rspec", version: [], source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" })),
-      Spec.new(name: "rubocop-sider", version: [], source: Source.new(uri: "https://gems.sider.review")),
-      Spec.new(name: "rubocop-nyan", version: ["> 1.0"], source: Source.new(uri: "https://gems.sider.review")),
-      Spec.new(name: "meowcop", version: ["1.2.0"]),
-      Spec.new(name: "strong_json", version: ["0.4.0", "<= 0.8"]),
+      Spec.new("rubocop-minitest", source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-minitest.git" })),
+      Spec.new("rubocop", source: Source.new(git: { repo: "https://github.com/rubocop/rubocop.git", branch: "master" })),
+      Spec.new("runners", source: Source.new(git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" })),
+      Spec.new("rubocop-rails", source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" })),
+      Spec.new("rubocop-rspec", source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" })),
+      Spec.new("rubocop-sider", source: Source.new(uri: "https://gems.sider.review")),
+      Spec.new("rubocop-nyan", requirement: ["> 1.0"], source: Source.new(uri: "https://gems.sider.review")),
+      Spec.new("meowcop", requirement: ["1.2.0"]),
+      Spec.new("strong_json", requirement: ["0.4.0", "<= 0.8"]),
     ]
 
     mktmpdir do |path|
@@ -85,7 +85,7 @@ class RubyTest < Minitest::Test
       installer = GemInstaller.new(
         shell: shell,
         specs: [
-          Spec.new(name: "rubocop-sider", version: [], source: Source.new(uri: "https://gems.sider.review")),
+          Spec.new("rubocop-sider", source: Source.new(uri: "https://gems.sider.review")),
         ],
         home: path,
         config_path_name: "sider.yml",
@@ -127,8 +127,8 @@ class RubyTest < Minitest::Test
 
   def test_install_success
     specs = [
-      Spec.new(name: "strong_json", version: ["0.5.0"]),
-      Spec.new(name: "rubocop-rails", version: ["2.9.0"],
+      Spec.new("strong_json", requirement: ["0.5.0"]),
+      Spec.new("rubocop-rails", requirement: ["2.9.0"],
                source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-rails.git", tag: "v2.9.0" })),
     ]
 
@@ -168,7 +168,7 @@ class RubyTest < Minitest::Test
 
   def test_install_failure
     specs = [
-      Spec.new(name: "strong_json", version: ["0.5.0"])
+      Spec.new("strong_json", requirement: ["0.5.0"])
     ]
 
     mktmpdir do |path|
@@ -203,11 +203,11 @@ class RubyTest < Minitest::Test
       YAML
 
       assert_equal [
-        Spec.new(name: "rubocop", version: []),
-        Spec.new(name: "strong_json", version: ["0.7.0"], source: Source.new(uri: "https://my.gems.org")),
-        Spec.new(name: "runners", version: [], source: Source.new(git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" })),
-        Spec.new(name: "rubocop-rails", version: [], source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" })),
-        Spec.new(name: "rubocop-performance", version: [], source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" })),
+        Spec.new("rubocop"),
+        Spec.new("strong_json", requirement: ["0.7.0"], source: Source.new(uri: "https://my.gems.org")),
+        Spec.new("runners", source: Source.new(git: { repo: "git@github.com:sider/runners.git", ref: "e66806c02849a0d0bdea66be88b5967d5eb3305d" })),
+        Spec.new("rubocop-rails", source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-rails.git", branch: "dev" })),
+        Spec.new("rubocop-performance", source: Source.new(git: { repo: "https://github.com/rubocop/rubocop-performance.git", tag: "v1.9.0" })),
       ], processor.send(:config_gems)
 
       assert_empty new_processor(workspace: workspace).send(:config_gems)
@@ -371,7 +371,7 @@ gem 'rubocop', "> 0.60.0"
 EOF
 
       LockfileLoader.new(root_dir: path, shell: shell).ensure_lockfile do |lockfile|
-        assert_empty lockfile.specs
+        assert_empty lockfile
       end
     end
   end
@@ -476,19 +476,19 @@ EOF
       processor = new_processor(workspace: workspace)
 
       defaults = [
-        Spec.new(name: "rubocop", version: ["0.4.0"]),
-        Spec.new(name: "strong_json", version: ["0.4.0"]),
+        Spec.new("rubocop", requirement: ["0.4.0"]),
+        Spec.new("strong_json", requirement: ["0.4.0"]),
       ]
 
       users = [
-        Spec.new(name: "rubocop", version: ["0.5.0"], source: "https://some.source.org"),
-        Spec.new(name: "rubocop-rspec", version: ["1.2.3"]),
+        Spec.new("rubocop", requirement: ["0.5.0"], source: "https://some.source.org"),
+        Spec.new("rubocop-rspec", requirement: ["1.2.3"]),
       ]
 
       assert_equal [
-        Spec.new(name: "rubocop", version: ["0.5.0"], source: "https://some.source.org"),
-        Spec.new(name: "strong_json", version: ["0.4.0"]),
-        Spec.new(name: "rubocop-rspec", version: ["1.2.3"]),
+        Spec.new("rubocop", requirement: ["0.5.0"], source: "https://some.source.org"),
+        Spec.new("strong_json", requirement: ["0.4.0"]),
+        Spec.new("rubocop-rspec", requirement: ["1.2.3"]),
       ], processor.send(:merge_specs, defaults, users)
     end
   end
@@ -523,8 +523,8 @@ EOF
           rubocop:
             gems: ["strong_json"]
       YAML
-      processor.install_gems([Spec.new(name: "public_suffix", version: ["4.0.0"])],
-                             optionals: [Spec.new(name: "meowcop", version: ["1.17.1"])],
+      processor.install_gems([Spec.new("public_suffix", requirement: ["4.0.0"])],
+                             optionals: [Spec.new("meowcop", requirement: ["1.17.1"])],
                              constraints: {}) do
         stdout, _ = processor.shell.capture3!("bundle", "list")
         assert_match(/\* public_suffix \(4.0.0\)/, stdout)
@@ -544,8 +544,8 @@ EOF
       YAML
 
       assert_raises GemInstaller::InstallationFailure do
-        processor.install_gems([Spec.new(name: "rubocop", version: ["0.63.0"])],
-                               optionals: [Spec.new(name: "meowcop", version: ["1.17.1"])],
+        processor.install_gems([Spec.new("rubocop", requirement: ["0.63.0"])],
+                               optionals: [Spec.new("meowcop", requirement: ["1.17.1"])],
                                constraints: {}) do
           # nop
         end
@@ -569,8 +569,8 @@ EOF
       end
 
       processor = new_processor(workspace: workspace)
-      processor.install_gems([Spec.new(name: "multi_json", version: ["1.13.0"])],
-                             optionals: [Spec.new(name: "strong_json", version: ["2.0.0"])],
+      processor.install_gems([Spec.new("multi_json", requirement: ["1.13.0"])],
+                             optionals: [Spec.new("strong_json", requirement: ["2.0.0"])],
                              constraints: {}) do
         stdout, _ = processor.shell.capture3!("bundle", "list")
         assert_match(/\* multi_json \(1.13.0\)/, stdout)
@@ -607,8 +607,8 @@ EOF
                 version: "1.14.1"
       YAML
 
-      processor.install_gems([Spec.new(name: "public_suffix", version: ["4.0.3"])],
-                             optionals: [Spec.new(name: "meowcop", version: ["1.17.1"])],
+      processor.install_gems([Spec.new("public_suffix", requirement: ["4.0.3"])],
+                             optionals: [Spec.new("meowcop", requirement: ["1.17.1"])],
                              constraints: { "rubocop" => Gem::Requirement.new(">= 4.0.0") }) do
         stdout, _ = processor.shell.capture3!("bundle", "list")
         assert_match(/\* public_suffix \(4.0.0\)/, stdout)
@@ -643,12 +643,12 @@ EOF
               - rack
       YAML
 
-      processor.install_gems([Spec.new(name: "multi_json", version: ["1.14.0"])],
+      processor.install_gems([Spec.new("multi_json", requirement: ["1.14.0"])],
                              constraints: { "multi_json" => Gem::Requirement.new("> 1.13.0", "< 2.0.0") }) do
         assert_equal 1, processor.warnings.count
         assert trace_writer.writer.find { |m| m[:trace] == :command_line && m[:command_line] == %w[bundle install] }
         assert_equal <<~MESSAGE.strip, processor.warnings.first[:message]
-          `multi_json 1.14.0` is installed instead of `1.12.0` in your `Gemfile.lock`.
+          `multi_json = 1.14.0` will be installed instead of `1.12.0` in your `Gemfile.lock`.
           Because `1.12.0` does not satisfy our constraints `> 1.13.0, < 2.0.0`.
 
           If you want to use a different version of `multi_json`, please do either:
@@ -673,7 +673,7 @@ EOF
       YAML
 
       assert_raises GemInstaller::InstallationFailure do
-        processor.install_gems([Spec.new(name: "rubocop", version: ["0.66.0"])],
+        processor.install_gems([Spec.new("rubocop", requirement: ["0.66.0"])],
                                constraints: { "rubocop" => Gem::Requirement.new("> 0.65.0") }) do
           # noop
         end
@@ -693,7 +693,7 @@ EOF
                 source: "https://rubygems.cae.me.uk"
       YAML
 
-      processor.install_gems([Spec.new(name: "rubocop", version: ["0.63.0"])],
+      processor.install_gems([Spec.new("rubocop", requirement: ["0.63.0"])],
                              optionals: [],
                              constraints: {}) do
         stdout, _ = processor.shell.capture3!("bundle", "list")
@@ -727,7 +727,7 @@ EOF
                     repo: git@github.com:sider/ruby_private_gem.git
                     branch: gem
         YAML
-        processor.install_gems([Spec.new(name: "rubocop", version: ["0.63.0"])],
+        processor.install_gems([Spec.new("rubocop", requirement: ["0.63.0"])],
                                optionals: [],
                                constraints: {}) do
           stdout, _ = processor.shell.capture3!("bundle", "list")
@@ -803,7 +803,7 @@ EOF
 
       processor = new_processor(workspace: workspace)
 
-      processor.install_gems([Spec.new(name: "rack", version: ["2.2.2"])],
+      processor.install_gems([Spec.new("rack", requirement: ["2.2.2"])],
                              constraints: {}) do
         stdout, _ = processor.shell.capture3!("bundle", "list")
         assert_match %r{\* rack \(2.2.0\)}, stdout
@@ -817,12 +817,12 @@ EOF
       processor = new_processor(workspace: workspace)
 
       processor.stub :capture3!, "rubocop (0.75.1, 0.75.0)\n" do
-        assert_equal [Spec.new(name: "rubocop", version: ["0.75.1", "0.75.0"])],
+        assert_equal [Spec.new("rubocop", requirement: ["0.75.1", "0.75.0"])],
                      processor.default_gem_specs("rubocop")
       end
 
       processor.stub :capture3!, "foo (1.2.3)\nbar (4.5.6)\n" do
-        assert_equal [Spec.new(name: "foo", version: ["1.2.3"]), Spec.new(name: "bar", version: ["4.5.6"])],
+        assert_equal [Spec.new("foo", requirement: ["1.2.3"]), Spec.new("bar", requirement: ["4.5.6"])],
                      processor.default_gem_specs("foo", "bar")
       end
 

--- a/test/smokes/rails_best_practices/expectations.rb
+++ b/test/smokes/rails_best_practices/expectations.rb
@@ -215,7 +215,7 @@ s.add_test(
   warnings: [
     {
       message: <<~MESSAGE.strip,
-        `rails_best_practices #{default_version}` is installed instead of `1.16.0` in your `Gemfile.lock`.
+        `rails_best_practices = #{default_version}` will be installed instead of `1.16.0` in your `Gemfile.lock`.
         Because `1.16.0` does not satisfy our constraints `>= 1.19.1, < 2.0`.
 
         If you want to use a different version of `rails_best_practices`, please do either:

--- a/test/smokes/reek/expectations.rb
+++ b/test/smokes/reek/expectations.rb
@@ -188,7 +188,7 @@ s.add_test(
   warnings: [
     {
       message: <<~MESSAGE.strip,
-        `reek #{default_version}` is installed instead of `4.0.0` in your `Gemfile.lock`.
+        `reek = #{default_version}` will be installed instead of `4.0.0` in your `Gemfile.lock`.
         Because `4.0.0` does not satisfy our constraints `>= 4.4.0, < 7.0.0`.
 
         If you want to use a different version of `reek`, please do either:

--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -443,7 +443,7 @@ s.add_test(
   warnings: [
     {
       message: <<~MSG.strip,
-        `rubocop #{default_version}` is installed instead of `0.60.0` in your `Gemfile.lock`.
+        `rubocop = #{default_version}` will be installed instead of `0.60.0` in your `Gemfile.lock`.
         Because `0.60.0` does not satisfy our constraints `>= 0.61.0, < 2.0.0`.
 
         If you want to use a different version of `rubocop`, please do either:


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring aims to simplify the use of the `Runners::GemInstaller::Spec` class.
Using `Gem::Requirement` instead of `Array[String]` for versions makes the code more type-safe.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
