### PR TITLE
Revert skipped test case in rubocop_utils_test.rb

### DIFF
--- a/test/rubocop_utils_test.rb
+++ b/test/rubocop_utils_test.rb
@@ -53,7 +53,7 @@ class RuboCopUtilsTest < Minitest::Test
       assert_links.call %w[
         https://www.rubydoc.info/gems/chefstyle/RuboCop/Cop/Chef/Ruby/GemspecRequireRubygems
         https://github.com/chef/chefstyle
-      ], "Chef/Ruby/GemspecRequireRubygems", skip: true # TODO: rubydoc.info returns 404
+      ], "Chef/Ruby/GemspecRequireRubygems"
       assert_links.call %w[
         https://www.rubydoc.info/gems/rubocop-discourse/RuboCop/Cop/Discourse/NoChdir
         https://github.com/discourse/rubocop-discourse


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

<https://www.rubydoc.info/gems/chefstyle> is restored.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
