### PR TITLE
Refactor `GemInstaller#install!` method

### DIFF
--- a/lib/runners/ruby/gem_installer.rb
+++ b/lib/runners/ruby/gem_installer.rb
@@ -23,7 +23,7 @@ module Runners
         gemfile_path.sub_ext(".lock")
       end
 
-      def install!
+      def install!(&block)
         gemfile_path.write(gemfile_content)
 
         trace_writer.message "Installing gems..."
@@ -41,13 +41,7 @@ module Runners
             MESSAGE
           end
 
-          versions = LockfileParser.parse(lockfile_path.read).specs.map do |spec|
-            [spec.name, spec.version.version]
-          end.to_h
-
-          shell.push_env_hash({ "BUNDLE_GEMFILE" => gemfile_path.to_s }) do
-            yield versions
-          end
+          shell.push_env_hash({ "BUNDLE_GEMFILE" => gemfile_path.to_s }, &block)
         end
       end
 

--- a/sig/runners/ruby.rbs
+++ b/sig/runners/ruby.rbs
@@ -19,7 +19,7 @@ module Runners
     class InstallGemsFailure < UserError
     end
 
-    def install_gems: [X] (Array[GemInstaller::Spec], constraints: constraints, ?optionals: Array[GemInstaller::Spec]) { (Hash[String, String]) -> X } -> X
+    def install_gems: [X] (Array[GemInstaller::Spec], constraints: constraints, ?optionals: Array[GemInstaller::Spec]) { () -> X } -> X
 
     def ruby_analyzer_command: (*String) -> Command
 

--- a/sig/runners/ruby/gem_installer.rbs
+++ b/sig/runners/ruby/gem_installer.rbs
@@ -24,7 +24,7 @@ module Runners
 
       def lockfile_path: () -> Pathname
 
-      def install!: [X] () { (Hash[String, String]) -> X } -> X
+      def install!: [X] () { () -> X } -> X
 
       def gemfile_content: () -> String
 

--- a/test/ruby_test.rb
+++ b/test/ruby_test.rb
@@ -144,12 +144,9 @@ class RubyTest < Minitest::Test
       )
 
       installer.install! do |hash|
-        stdout, _ = shell.capture3("bundle", "exec", "gem", "list")
-        lines = stdout.lines(chomp: true)
-        assert_includes lines, "strong_json (0.5.0)"
-        assert_includes lines, "rubocop-rails (2.9.0)"
-        assert_equal "0.5.0", hash["strong_json"]
-        assert_equal "2.9.0", hash["rubocop-rails"]
+        stdout, _ = shell.capture3!("bundle", "list")
+        assert_match "strong_json (0.5.0)", stdout
+        assert_match "rubocop-rails (2.9.0 e91a433)", stdout
       end
 
       gemfile_content_log = <<~RUBY.strip


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to simplify the `Runners::Ruby::GemInstaller#install!` method.
(removing the extra call of `LockfileParser.parse`)

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
