### PR TITLE
Remove needless Goodcheck rule for TypeScript ESLint

### DIFF
--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -57,14 +57,6 @@ rules:
       A package's version with `^x.y.z` is changeable at runtime (e.g. `npm install`).
       Such an inaccurate version may makes our debugging hard.
 
-  - id: sider.runners.use_same_version_for_typescript_eslint
-    pattern: "@typescript-eslint/"
-    glob: images/eslint/package.json
-    message: |
-      Use the same version for the `@typescript-eslint/*` packages.
-    justification:
-      - When the same version has been used already.
-
   - id: sider.runners.time_iso8601
     pattern: iso8601
     glob: lib/**/*.rb


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Via PR #2150, peer dependencies are automatically installed.
So, the rule to check `@typescript-eslint/*` packages is no longer necessary.

https://github.com/sider/runners/blob/b4ce8ed4b7965e32c210d65d7231506a03cd6568/images/eslint/package.json#L4

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Related to #2150

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
