### PR TITLE
[Flake8] Use default formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Misc:
 - **ESLint** Update pre-installed packages [#2155](https://github.com/sider/runners/pull/2155)
 - **Flake8** Enable new recommended configuration [#2157](https://github.com/sider/runners/pull/2157)
 - Simplify generated `Gemfile` [#2168](https://github.com/sider/runners/pull/2168)
+- **Flake8** Use default formatter [#2181](https://github.com/sider/runners/pull/2181)
 
 ## 0.44.1
 

--- a/sig/runners/processor/flake8.rbs
+++ b/sig/runners/processor/flake8.rbs
@@ -7,8 +7,6 @@ module Runners
     end
     Schema: SchemaClass
 
-    OUTPUT_FORMAT: String
-    OUTPUT_PATTERN: Regexp
     DEFAULT_TARGET: String
     DEFAULT_CONFIG_PATH: String
     DEFAULT_IGNORED_CONFIG_PATH: String


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change uses the default formatter instead of the custom one.

E.g.

```
./foo.py:2:1: W191 indentation contains tabs
```

Reason:
- The default formatter should be familiar to users.
- The default formatter output is easier to view on logs.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
