### PR TITLE
Remove `linter.scss_lint.options`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - Loosen unsatisfied constraints for npm packages [#2171](https://github.com/sider/runners/pull/2171)
 - Improve analysis finish message [#2187](https://github.com/sider/runners/pull/2187)
 - Support npm 7 [#2189](https://github.com/sider/runners/pull/2189)
-- Remove deprecated `linter.{id}.options` [#2190](https://github.com/sider/runners/pull/2190)
+- Remove deprecated `linter.{id}.options` [#2190](https://github.com/sider/runners/pull/2190) [#2193](https://github.com/sider/runners/pull/2193)
 
 ## 0.45.0
 

--- a/lib/runners/processor/scss_lint.rb
+++ b/lib/runners/processor/scss_lint.rb
@@ -8,10 +8,6 @@ module Runners
       let :runner_config, Schema::BaseConfig.base.update_fields { |fields|
         fields.merge!(
           config: string?,
-          # DO NOT ADD OPTIONS ANY MORE in `options`.
-          options: object?(
-            config: string?,
-          )
         )
       }
     end
@@ -57,7 +53,7 @@ module Runners
     private
 
     def scss_lint_config
-      config = config_linter[:config] || config_linter.dig(:options, :config)
+      config = config_linter[:config]
       config ? ["--config=#{config}"] : []
     end
 

--- a/test/smokes/scss_lint/with_config_option/sideci.yml
+++ b/test/smokes/scss_lint/with_config_option/sideci.yml
@@ -1,4 +1,3 @@
 linter:
   scss_lint:
-    options:
-      config: 'my-scss-lint-conf.yml'
+    config: 'my-scss-lint-conf.yml'


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change removes the deprecated `linter.scss_lint.options` option for `sider.yml`.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Follow-up of #2190
See also #2095

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
