### PR TITLE
Secure `pip install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Support npm 7 [#2189](https://github.com/sider/runners/pull/2189)
 - Remove deprecated `linter.{id}.options` [#2190](https://github.com/sider/runners/pull/2190) [#2193](https://github.com/sider/runners/pull/2193)
 - Simplify `sider.yml` schema [#2192](https://github.com/sider/runners/pull/2192)
+- Secure `pip install` [#2194](https://github.com/sider/runners/pull/2194)
 
 ## 0.45.0
 

--- a/lib/runners/python.rb
+++ b/lib/runners/python.rb
@@ -1,15 +1,26 @@
 module Runners
   module Python
+    class PipInstallFailed < UserError; end
+
     def show_runtime_versions
       capture3! "python", "--version"
       capture3! "pip", "--version"
       capture3! "pipenv", "--version"
     end
 
+    # @see https://pip.pypa.io/en/stable/reference/pip_install
+    # @see https://pip.pypa.io/en/stable/reference/pip_list
     def pip_install(*packages)
       unless packages.empty?
         options = %w[--disable-pip-version-check]
-        capture3! "pip", "install", "--quiet", *options, *packages
+
+        begin
+          # NOTE: Use `--only-binary` to prevent malicious dependency's code execution.
+          capture3! "pip", "install", "--quiet", "--only-binary", ":all:", *options, *packages
+        rescue Runners::Shell::ExecError
+          raise PipInstallFailed, "Install failed: #{packages.join(', ')}"
+        end
+
         capture3! "pip", "list", "--verbose", *options
       end
     end

--- a/sig/runners/python.rbs
+++ b/sig/runners/python.rbs
@@ -1,5 +1,8 @@
 module Runners
   module Python : Processor
+    class PipInstallFailed < UserError
+    end
+
     def pip_install: (*String) -> void
   end
 end

--- a/test/smokes/flake8/expectations.rb
+++ b/test/smokes/flake8/expectations.rb
@@ -158,7 +158,7 @@ s.add_test(
       path: "foo.py",
       location: { start_line: 2, start_column: 1 },
       id: "W191",
-      message: 'indentation contains tabs',
+      message: "indentation contains tabs",
       links: [],
       object: nil,
       git_blame_info: {
@@ -197,6 +197,13 @@ s.add_test(
     }
   ],
   analyzer: { name: "Flake8", version: default_version }
+)
+
+s.add_test(
+  "with_plugins_failed",
+  type: "failure",
+  message: "Install failed: mysqlclient==2.0.0, flake8-builtins==1.4.1",
+  analyzer: :_
 )
 
 s.add_test(

--- a/test/smokes/flake8/with_plugins_failed/sider.yml
+++ b/test/smokes/flake8/with_plugins_failed/sider.yml
@@ -1,0 +1,5 @@
+linter:
+  flake8:
+    plugins:
+      - mysqlclient==2.0.0
+      - flake8-builtins==1.4.1


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to make `pip install` more secure via the `--only-binary` option.
(see <https://pip.pypa.io/en/stable/reference/pip_install/#install-only-binary>)

I believe any packages do not need source compilation for us.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
