### PR TITLE
[ESLint] Use `--no-error-on-unmatched-pattern` if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Misc:
 - Loosen unsatisfied constraints for npm packages [#2171](https://github.com/sider/runners/pull/2171)
 - Improve analysis finish message [#2187](https://github.com/sider/runners/pull/2187)
 - **ESLint** Provide new recommended configuration [#2165](https://github.com/sider/runners/pull/2165)
+- **ESLint** Use `--no-error-on-unmatched-pattern` if possible [#2199](https://github.com/sider/runners/pull/2199)
 - Simplify `sider.yml` schema [#2192](https://github.com/sider/runners/pull/2192)
 - Secure `pip install` [#2194](https://github.com/sider/runners/pull/2194)
 - Introduce common option `target` [#2191](https://github.com/sider/runners/pull/2191)

--- a/lib/runners/processor/eslint.rb
+++ b/lib/runners/processor/eslint.rb
@@ -165,11 +165,11 @@ module Runners
       #
       # @see https://github.com/typescript-eslint/typescript-eslint/blob/v2.6.0/packages/typescript-estree/src/parser.ts#L237-L247
 
-      # NOTE: The `--no-error-on-unpatched-pattern` option has been available since v6.8.0
+      # NOTE: The `--no-error-on-unpatched-pattern` option has been available since v6.8.0.
       #
       # @see https://github.com/eslint/eslint/blob/v6.8.0/CHANGELOG.md
       # @see https://eslint.org/blog/2019/12/eslint-v6.8.0-released
-      no_error_unmatched = Gem::Version.new(analyzer_version) >= Gem::Version.create("6.8.0") ? ["--no-error-on-unmatched-pattern"] : []
+      no_error_unmatched = Gem::Version.new(analyzer_version) >= Gem::Version.new("6.8.0") ? ["--no-error-on-unmatched-pattern"] : []
 
       _stdout, stderr, status = capture3(
         nodejs_analyzer_bin,

--- a/lib/runners/processor/eslint.rb
+++ b/lib/runners/processor/eslint.rb
@@ -155,7 +155,7 @@ module Runners
     def run_analyzer(config: nil)
       # NOTE: eslint exit with status code 1 when some issues are found.
       #       We use `capture3` instead of `capture3!`
-      #
+
       # NOTE: ESLint v5 returns 2 as exit status when fatal error is occurred.
       #       However, this runner doesn't depends on this behavior because it also supports ESLint v4
       #
@@ -165,11 +165,18 @@ module Runners
       #
       # @see https://github.com/typescript-eslint/typescript-eslint/blob/v2.6.0/packages/typescript-estree/src/parser.ts#L237-L247
 
+      # NOTE: The `--no-error-on-unpatched-pattern` option has been available since v6.8.0
+      #
+      # @see https://github.com/eslint/eslint/blob/v6.8.0/CHANGELOG.md
+      # @see https://eslint.org/blog/2019/12/eslint-v6.8.0-released
+      no_error_unmatched = Gem::Version.new(analyzer_version) >= Gem::Version.create("6.8.0") ? ["--no-error-on-unmatched-pattern"] : []
+
       _stdout, stderr, status = capture3(
         nodejs_analyzer_bin,
         "--format", CUSTOM_FORMATTER,
         "--output-file", report_file,
         "--no-color",
+        *no_error_unmatched,
         *(config ? ["--config", config] : []),
         *ext,
         *ignore_path,

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -100,6 +100,8 @@ s.add_test(
 
 s.add_test("no_files", type: "success", issues: [], analyzer: { name: "ESLint", version: default_version })
 
+s.add_test("no_files_with_option_target", type: "success", issues: [], analyzer: { name: "ESLint", version: default_version })
+
 s.add_test(
   "pinned_eslint5",
   type: "success",

--- a/test/smokes/eslint/no_files_with_option_target/sider.yml
+++ b/test/smokes/eslint/no_files_with_option_target/sider.yml
@@ -1,0 +1,3 @@
+linter:
+  eslint:
+    target: "**/*.js"


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to reduce the following noise from traces via `eslint --no-error-on-unmatched-pattern`:

```console
$ eslint --no-error-on-unmatched-pattern foo
(no errors)

$ eslint foo
Oops! Something went wrong! :(

ESLint: 7.22.0

No files matching the pattern "foo" were found.
Please check for typing mistakes in the pattern.
```

Note:
This option has been added since v6.8.0, but we support v5.0.0+ still.
So, parsing the error message is needed still.

See also:
- https://github.com/eslint/eslint/blob/v6.8.0/CHANGELOG.md
- https://eslint.org/blog/2019/12/eslint-v6.8.0-released

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
