### PR TITLE
[PHPMD] Handle syntax error as issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Misc:
 - Simplify `sider.yml` schema [#2192](https://github.com/sider/runners/pull/2192)
 - Secure `pip install` [#2194](https://github.com/sider/runners/pull/2194)
 - Introduce common option `target` [#2191](https://github.com/sider/runners/pull/2191)
+- **PHPMD** Handle syntax error as issue [#2201](https://github.com/sider/runners/pull/2201)
 
 ## 0.45.0
 

--- a/test/smokes/phpmd/expectations.rb
+++ b/test/smokes/phpmd/expectations.rb
@@ -72,7 +72,19 @@ s.add_test(
 
 s.add_test(
   "syntax_error",
-  type: "failure", message: /Unexpected end of token stream in file:/, analyzer: { name: "PHPMD", version: default_version }
+  type: "success",
+  issues: [
+    {
+      path: "app.php",
+      location: nil,
+      id: "UnknownError",
+      message: "Unexpected end of token stream in file: app.php.",
+      links: [],
+      object: nil,
+      git_blame_info: nil
+    }
+  ],
+  analyzer: { name: "PHPMD", version: default_version }
 )
 
 s.add_test(


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to reduce analysis errors due to PHP syntax errors.
A syntax error will be handled as an issue, instead of raising failures.

I think this behavior is reasonable because just a syntax error in a file will not fail an analysis.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
