### PR TITLE
Add `linter.<id>.dependencies` option for npm tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Misc:
 - Secure `pip install` [#2194](https://github.com/sider/runners/pull/2194)
 - Introduce common option `target` [#2191](https://github.com/sider/runners/pull/2191)
 - **PHPMD** Handle syntax error as issue [#2201](https://github.com/sider/runners/pull/2201)
+- Add `linter.<id>.dependencies` option for npm tools [#2202](https://github.com/sider/runners/pull/2202)
 
 ## 0.45.0
 

--- a/lib/runners/nodejs.rb
+++ b/lib/runners/nodejs.rb
@@ -120,7 +120,7 @@ module Runners
 
     # @see https://docs.npmjs.com/cli/v7/commands/npm-install
     # @see https://docs.npmjs.com/cli/v7/commands/npm-ci
-    def npm_install(*packages, subcommand: "install", flags: [])
+    def npm_install(*deps, subcommand: "install", flags: [])
       flags = %w[
         --ignore-scripts
         --no-engine-strict
@@ -132,7 +132,7 @@ module Runners
 
       begin
         ensure_same_yarn_lock do
-          capture3_with_retry! "npm", subcommand, *flags, *packages
+          capture3_with_retry! "npm", subcommand, *flags, *deps
         end
       rescue Shell::ExecError
         message = <<~MSG.strip

--- a/lib/runners/nodejs.rb
+++ b/lib/runners/nodejs.rb
@@ -46,34 +46,43 @@ module Runners
     end
 
     # Install Node.js dependencies by using given parameters.
-    def install_nodejs_deps(constraints:, install_option: config_linter[:npm_install])
-      return if install_option == INSTALL_OPTION_NONE
+    def install_nodejs_deps(constraints:, dependencies: config_linter[:dependencies], install_option: config_linter[:npm_install])
+      # @type var dependencies: Array[String | Hash[Symbol, String]]
+      dependencies = Array(dependencies)
 
-      unless package_json_path.exist?
+      if !dependencies.empty?
         if install_option
+          trace_writer.message "`#{config_field_path(:npm_install)}` in your `#{config.path_name}` is ignored."
+        end
+
+        deps = dependencies.map { |dep| dep.is_a?(Hash) ? dep.values.join("@") : dep }
+        npm_install(*deps)
+      else
+        flags = []
+        case install_option
+        when INSTALL_OPTION_NONE
+          return # noop
+        when INSTALL_OPTION_PRODUCTION
+          flags << "--only=production"
+        when INSTALL_OPTION_DEVELOPMENT
           add_warning <<~MSG, file: PACKAGE_JSON
-            The `npm_install` option is specified in your `#{config.path_name}`, but a `#{PACKAGE_JSON}` file is not found in your repository.
-            In this case, any npm packages are not installed.
+            `#{INSTALL_OPTION_DEVELOPMENT}` of `#{config_field_path(:npm_install)}` is deprecated. It falls back to `#{INSTALL_OPTION_ALL}` instead.
           MSG
         end
 
-        return # not install
+        if package_json_path.exist?
+          npm_install subcommand: (package_lock_json_path.exist? ? "ci" : "install"), flags: flags
+        elsif install_option
+          add_warning <<~MSG, file: PACKAGE_JSON
+            Although `#{config_field_path(:npm_install)}` is enabled in your `#{config.path_name}`, `#{PACKAGE_JSON}` is missing in your repository.
+          MSG
+          return # noop
+        else
+          return # noop
+        end
       end
 
-      trace_writer.message "Installing npm packages..."
-
-      cli_flags = []
-      case install_option
-      when INSTALL_OPTION_PRODUCTION
-        cli_flags << "--only=production"
-      when INSTALL_OPTION_DEVELOPMENT
-        add_warning <<~MSG, file: PACKAGE_JSON
-          `npm_install: #{INSTALL_OPTION_DEVELOPMENT}` has been deprecated and falls back to `npm_install: #{INSTALL_OPTION_ALL}`.
-        MSG
-      end
-      npm_install subcommand: (package_lock_json_path.exist? ? "ci" : "install"), flags: cli_flags
-
-      installed_deps = list_installed_npm_deps_with(names: constraints.keys)
+      installed_deps = list_installed_npm_deps_with names: constraints.keys
 
       case
       when !all_npm_deps_statisfied_constraint?(installed_deps, constraints)
@@ -111,7 +120,7 @@ module Runners
 
     # @see https://docs.npmjs.com/cli/v7/commands/npm-install
     # @see https://docs.npmjs.com/cli/v7/commands/npm-ci
-    def npm_install(subcommand: "install", flags: [])
+    def npm_install(*packages, subcommand: "install", flags: [])
       flags = %w[
         --ignore-scripts
         --no-engine-strict
@@ -119,14 +128,20 @@ module Runners
         --no-save
       ] + flags
 
+      trace_writer.message "Installing npm dependencies..."
+
       begin
         ensure_same_yarn_lock do
-          capture3_with_retry! "npm", subcommand, *flags
+          capture3_with_retry! "npm", subcommand, *flags, *packages
         end
       rescue Shell::ExecError
         message = <<~MSG.strip
-          `npm #{subcommand}` failed. Please check the log for details.
-          If you want to explicitly disable the installation, please set `npm_install: #{INSTALL_OPTION_NONE}` in your `#{config.path_name}`.
+          `npm #{subcommand}` failed. If you want to avoid this installation, try one of the following in your `#{config.path_name}`:
+
+          - Set `#{INSTALL_OPTION_NONE}` to `#{config_field_path(:npm_install)}`
+          - Set necessary packages to `#{config_field_path(:dependencies)}`
+
+          See also <https://help.sider.review/getting-started/custom-configuration>
         MSG
         trace_writer.error message
         raise NpmInstallFailed, message

--- a/lib/runners/processor/coffeelint.rb
+++ b/lib/runners/processor/coffeelint.rb
@@ -21,6 +21,8 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
+        dependencies:
+          - my-coffeelint-plugin@2
         npm_install: false
         file: config/coffeelint.json
       YAML

--- a/lib/runners/processor/eslint.rb
+++ b/lib/runners/processor/eslint.rb
@@ -38,6 +38,8 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
+        dependencies:
+          - my-eslint-plugin@2
         npm_install: false
         target:
           - src/

--- a/lib/runners/processor/remark_lint.rb
+++ b/lib/runners/processor/remark_lint.rb
@@ -31,6 +31,8 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
+        dependencies:
+          - my-remark-plugin@2
         npm_install: false
         target: [docs/]
         ext: "md,markdown"

--- a/lib/runners/processor/stylelint.rb
+++ b/lib/runners/processor/stylelint.rb
@@ -37,6 +37,8 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
+        dependencies:
+          - my-stylelint-plugin@2
         npm_install: false
         config: config/.stylelintrc.yml
         syntax: scss

--- a/lib/runners/processor/tyscan.rb
+++ b/lib/runners/processor/tyscan.rb
@@ -30,6 +30,8 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
+        dependencies:
+          - my-tyscan-plugin@2
         npm_install: false
         config: config/tyscan.yml
         tsconfig: src/tsconfig.json

--- a/lib/runners/schema/config.rb
+++ b/lib/runners/schema/config.rb
@@ -41,8 +41,14 @@ module Runners
       end
 
       def npm(**fields)
-        npm_install = enum(boolean, literal('development'), literal('production'))
-        base(npm_install: optional(npm_install), **fields)
+        base(
+          npm_install: enum?(boolean, literal('development'), literal('production')),
+          dependencies: array?(enum(
+            string,
+            object(name: string, version: string),
+          )),
+          **fields,
+        )
       end
 
       def java(**fields)

--- a/lib/runners/schema/config.rb
+++ b/lib/runners/schema/config.rb
@@ -42,11 +42,11 @@ module Runners
 
       def npm(**fields)
         base(
-          npm_install: enum?(boolean, literal('development'), literal('production')),
           dependencies: array?(enum(
             string,
             object(name: string, version: string),
           )),
+          npm_install: enum?(boolean, literal('development'), literal('production')),
           **fields,
         )
       end

--- a/sig/runners/nodejs.rbs
+++ b/sig/runners/nodejs.rbs
@@ -33,7 +33,7 @@ module Runners
 
     def node_modules_path: () -> Pathname
 
-    def install_nodejs_deps: (constraints: constraints, ?install_option: bool | String) -> void
+    def install_nodejs_deps: (constraints: constraints, ?dependencies: Array[String], ?install_option: bool | String) -> void
 
     private
 
@@ -45,7 +45,7 @@ module Runners
 
     def nodejs_analyzer_local_version: () -> String
 
-    def npm_install: (?subcommand: String, ?flags: Array[String]) -> void
+    def npm_install: (*String, ?subcommand: String, ?flags: Array[String]) -> void
 
     def list_installed_npm_deps_with: (names: Array[String]) -> Hash[String, { name: String, version: String }]
 

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -160,20 +160,20 @@
   diagnostics:
   - range:
       start:
-        line: 80
+        line: 82
         character: 47
       end:
-        line: 80
+        line: 82
         character: 49
     severity: ERROR
     message: Type `(::Gem::Version | nil)` does not have method `>=`
     code: Ruby::NoMethod
   - range:
       start:
-        line: 197
+        line: 199
         character: 53
       end:
-        line: 197
+        line: 199
         character: 55
     severity: ERROR
     message: Type `(::Gem::Version | nil)` does not have method `>=`

--- a/test/config_generator_test.rb
+++ b/test/config_generator_test.rb
@@ -20,7 +20,7 @@ class ConfigGeneratorTest < Minitest::Test
       end
     end
 
-    end_line = 406
+    end_line = 416
     assert_yaml "test_generate_with_tools.yml",
                 tools: tools,
                 comment_out_lines: [9..end_line, (end_line + 3)..(end_line + 7), (end_line + 10)..(end_line + 14)]

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -44,6 +44,7 @@ class ConfigTest < Minitest::Test
         detekt: nil,
         eslint: {
           root_dir: nil,
+          dependencies: nil,
           npm_install: true,
           target: nil,
           dir: nil,
@@ -185,6 +186,7 @@ class ConfigTest < Minitest::Test
     assert_equal({
       ext: ".js",
       root_dir: nil,
+      dependencies: nil,
       npm_install: nil,
       target: nil,
       dir: nil,

--- a/test/data/test_generate_with_tools.yml
+++ b/test/data/test_generate_with_tools.yml
@@ -48,6 +48,8 @@ linter:
 #   # CoffeeLint example. See https://help.sider.review/tools/javascript/coffeelint
 #   coffeelint:
 #     root_dir: project/
+#     dependencies:
+#       - my-coffeelint-plugin@2
 #     npm_install: false
 #     file: config/coffeelint.json
 
@@ -101,6 +103,8 @@ linter:
 #   # ESLint example. See https://help.sider.review/tools/javascript/eslint
 #   eslint:
 #     root_dir: project/
+#     dependencies:
+#       - my-eslint-plugin@2
 #     npm_install: false
 #     target:
 #       - src/
@@ -337,6 +341,8 @@ linter:
 #   # remark-lint example. See https://help.sider.review/tools/markdown/remark-lint
 #   remark_lint:
 #     root_dir: project/
+#     dependencies:
+#       - my-remark-plugin@2
 #     npm_install: false
 #     target: [docs/]
 #     ext: "md,markdown"
@@ -379,6 +385,8 @@ linter:
 #   # stylelint example. See https://help.sider.review/tools/css/stylelint
 #   stylelint:
 #     root_dir: project/
+#     dependencies:
+#       - my-stylelint-plugin@2
 #     npm_install: false
 #     config: config/.stylelintrc.yml
 #     syntax: scss
@@ -400,6 +408,8 @@ linter:
 #   # TyScan example. See https://help.sider.review/tools/javascript/tyscan
 #   tyscan:
 #     root_dir: project/
+#     dependencies:
+#       - my-tyscan-plugin@2
 #     npm_install: false
 #     config: config/tyscan.yml
 #     tsconfig: src/tsconfig.json

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -548,3 +548,25 @@ s.add_test(
   issues: [],
   analyzer: { name: "ESLint", version: "7.22.0" }
 )
+
+s.add_test(
+  "option_dependencies",
+  type: "success",
+  issues: [],
+  analyzer: { name: "ESLint", version: "6.8.0" }
+)
+
+s.add_test(
+  "option_dependencies_missing",
+  type: "failure",
+  message: /`npm install` failed. If you want to avoid this installation, try one of the following in your `sider.yml`/,
+  analyzer: :_
+)
+
+s.add_test(
+  "option_dependencies_outdated",
+  type: "success",
+  issues: [],
+  analyzer: { name: "ESLint", version: default_version },
+  warnings: [{ message: "Installed `eslint@4.19.1` does not satisfy our constraint `>=5.0.0 <8.0.0`. Please update it as possible.", file: "package.json" }]
+)

--- a/test/smokes/eslint/option_dependencies/.eslintrc.yml
+++ b/test/smokes/eslint/option_dependencies/.eslintrc.yml
@@ -1,0 +1,5 @@
+extends:
+  - babel
+
+plugins:
+  - ban

--- a/test/smokes/eslint/option_dependencies/package.json
+++ b/test/smokes/eslint/option_dependencies/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "eslint": "7.8.0"
+  }
+}

--- a/test/smokes/eslint/option_dependencies/sider.yml
+++ b/test/smokes/eslint/option_dependencies/sider.yml
@@ -1,0 +1,7 @@
+linter:
+  eslint:
+    dependencies:
+      - eslint@6
+      - eslint-config-babel
+      - { name: "eslint-plugin-ban", version: "^1.4.0" }
+    npm_install: true

--- a/test/smokes/eslint/option_dependencies_missing/sider.yml
+++ b/test/smokes/eslint/option_dependencies_missing/sider.yml
@@ -1,0 +1,4 @@
+linter:
+  eslint:
+    dependencies:
+      - eslint-foo-bar-baz

--- a/test/smokes/eslint/option_dependencies_outdated/sider.yml
+++ b/test/smokes/eslint/option_dependencies_outdated/sider.yml
@@ -1,0 +1,4 @@
+linter:
+  eslint:
+    dependencies:
+      - eslint@4


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change adds a new feature that users can specify any npm dependencies via `sider.yml`.
For example:

```yaml
linter:
  eslint:
    dependencies:
      - eslint # latest
      - eslint-config-standard@15.0.1
      - { name: "eslint-config-react-app", version: ">=5.0.0" }
    npm_install: true # ignored
```

- When the `dependencies` option is not empty, the `npm_install` option is ignored.
- If users have a problem with `npm install`, this new option should resolve it.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Close #1689

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
