### PR TITLE
[ktlint] Add issue ID for syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Misc:
 - Introduce common option `target` [#2191](https://github.com/sider/runners/pull/2191)
 - **PHPMD** Handle syntax error as issue [#2201](https://github.com/sider/runners/pull/2201)
 - Add `linter.<id>.dependencies` option for npm tools [#2202](https://github.com/sider/runners/pull/2202)
+- **ktlint** Add issue ID for syntax error [#2206](https://github.com/sider/runners/pull/2206)
 
 ## 0.45.0
 

--- a/test/smokes/ktlint/expectations.rb
+++ b/test/smokes/ktlint/expectations.rb
@@ -8,7 +8,7 @@ s.add_test(
   analyzer: { name: "ktlint", version: default_version },
   issues: [
     {
-      id: "18748d47ed6c20995492c1190b0fb829b794f8c1",
+      id: "SyntaxError",
       path: "src/Foo.kt",
       location: { start_line: 1, start_column: 1 },
       message: "Not a valid Kotlin file (1:1 expecting a top level declaration) (cannot be auto-corrected)",


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change adds an issue ID that is unique to Sider when the issue is due to a Kotlin syntax error.

Note that ktlint provides an empty issue ID for such an error by default.
See <https://github.com/pinterest/ktlint/blob/0.41.0/ktlint/src/main/kotlin/com/pinterest/ktlint/Main.kt#L478-L483>.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
