### PR TITLE
Use `Gem::Version.new` to fix Steep errors

### DIFF
--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -180,7 +180,7 @@ module Runners
     end
 
     def add_warning_if_deprecated_version(minimum:, file: nil, deadline: nil)
-      unless Gem::Version.create(minimum) <= Gem::Version.create(analyzer_version)
+      unless Gem::Version.new(minimum) <= Gem::Version.new(analyzer_version)
         deadline_str = deadline ? deadline.strftime('on %B %-d, %Y') : 'in the near future'
         add_warning <<~MSG, file: file
           DEPRECATION WARNING!!!

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -131,7 +131,7 @@ module Runners
 
     def config_parallel
       minimum_version = "0.36.0"
-      if Gem::Version.create(analyzer_version) >= Gem::Version.create(minimum_version)
+      if Gem::Version.new(analyzer_version) >= Gem::Version.new(minimum_version)
         parallel = config_linter[:parallel]
         if parallel == true || parallel.nil?
           return ["--parallel"]

--- a/lib/runners/processor/reek.rb
+++ b/lib/runners/processor/reek.rb
@@ -97,8 +97,8 @@ module Runners
     def v4?
       return @v4 if defined? @v4
 
-      @v4 ||= Gem::Version.create(analyzer.version).then do |v|
-        v >= Gem::Version.create("4.0.0") && v < Gem::Version.create("5.0.0")
+      @v4 ||= Gem::Version.new(analyzer.version).then do |v|
+        v >= Gem::Version.new("4.0.0") && v < Gem::Version.new("5.0.0")
       end
     end
 

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -197,12 +197,12 @@ module Runners
 
     # @see https://github.com/rubocop/rubocop/blob/v0.72.0/CHANGELOG.md
     def rails_cops_removed?
-      Gem::Version.create(analyzer_version) >= Gem::Version.create("0.72.0")
+      Gem::Version.new(analyzer_version) >= Gem::Version.new("0.72.0")
     end
 
     def cache_root
       # @see https://github.com/rubocop/rubocop/blob/v0.91.0/CHANGELOG.md
-      if Gem::Version.create(analyzer_version) >= Gem::Version.create("0.91.0")
+      if Gem::Version.new(analyzer_version) >= Gem::Version.new("0.91.0")
         ["--cache-root=#{File.join(Dir.tmpdir, 'rubocop-cache')}"]
       else
         []

--- a/lib/runners/processor/stylelint.rb
+++ b/lib/runners/processor/stylelint.rb
@@ -79,7 +79,7 @@ module Runners
       # The `--allow-empty-input` option breaks with v10.0.0. Fixed with v10.0.1.
       # @see https://github.com/stylelint/stylelint/releases/tag/10.0.1
       # @see https://github.com/stylelint/stylelint/pull/4029
-      if Gem::Version.create(analyzer_version) >= Gem::Version.create("10.0.1")
+      if Gem::Version.new(analyzer_version) >= Gem::Version.new("10.0.1")
         default_options << '--allow-empty-input'
       end
 
@@ -196,7 +196,7 @@ module Runners
       return if config_file_path
 
       # NOTE: `stylelint-config-recommended@2` does not work with `stylelint@11`.
-      src = if Gem::Version.create(analyzer_version) >= Gem::Version.create("11.0.0")
+      src = if Gem::Version.new(analyzer_version) >= Gem::Version.new("11.0.0")
               DEFAULT_CONFIG_FILE
             else
               DEFAULT_CONFIG_FILE_OLD

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -57,18 +57,6 @@
     severity: ERROR
     message: The branch is unreachable because the condition is exhaustive
     code: Ruby::ElseOnExhaustiveCase
-- file: lib/runners/processor/haml_lint.rb
-  diagnostics:
-  - range:
-      start:
-        line: 134
-        character: 47
-      end:
-        line: 134
-        character: 49
-    severity: ERROR
-    message: Type `(::Gem::Version | nil)` does not have method `>=`
-    code: Ruby::NoMethod
 - file: lib/runners/processor/languagetool.rb
   diagnostics:
   - range:
@@ -93,50 +81,6 @@
     severity: ERROR
     message: Type `bot` does not have method `size`
     code: Ruby::NoMethod
-- file: lib/runners/processor/reek.rb
-  diagnostics:
-  - range:
-      start:
-        line: 101
-        character: 10
-      end:
-        line: 101
-        character: 12
-    severity: ERROR
-    message: Type `(::Gem::Version | nil)` does not have method `>=`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 101
-        character: 47
-      end:
-        line: 101
-        character: 48
-    severity: ERROR
-    message: Type `(::Gem::Version | nil)` does not have method `<`
-    code: Ruby::NoMethod
-- file: lib/runners/processor/rubocop.rb
-  diagnostics:
-  - range:
-      start:
-        line: 200
-        character: 44
-      end:
-        line: 200
-        character: 46
-    severity: ERROR
-    message: Type `(::Gem::Version | nil)` does not have method `>=`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 205
-        character: 47
-      end:
-        line: 205
-        character: 49
-    severity: ERROR
-    message: Type `(::Gem::Version | nil)` does not have method `>=`
-    code: Ruby::NoMethod
 - file: lib/runners/processor/shellcheck.rb
   diagnostics:
   - range:
@@ -156,28 +100,6 @@
                 ::Object <: ::String
                   ::BasicObject <: ::String
     code: Ruby::IncompatibleAssignment
-- file: lib/runners/processor/stylelint.rb
-  diagnostics:
-  - range:
-      start:
-        line: 82
-        character: 47
-      end:
-        line: 82
-        character: 49
-    severity: ERROR
-    message: Type `(::Gem::Version | nil)` does not have method `>=`
-    code: Ruby::NoMethod
-  - range:
-      start:
-        line: 199
-        character: 53
-      end:
-        line: 199
-        character: 55
-    severity: ERROR
-    message: Type `(::Gem::Version | nil)` does not have method `>=`
-    code: Ruby::NoMethod
 - file: lib/runners/processor.rb
   diagnostics:
   - range:
@@ -213,16 +135,6 @@
                   ::Object <: ::String
                     ::BasicObject <: ::String
     code: Ruby::ArgumentTypeMismatch
-  - range:
-      start:
-        line: 183
-        character: 42
-      end:
-        line: 183
-        character: 44
-    severity: ERROR
-    message: Type `(::Gem::Version | nil)` does not have method `<=`
-    code: Ruby::NoMethod
   - range:
       start:
         line: 282


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

`Gem::Version.create` can return `nil`, so this changes it to `Gem::Version.new` instead.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
