### PR TITLE
[Clang-Tidy] Better `apt-get install` failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Misc:
 - **PHPMD** Handle syntax error as issue [#2201](https://github.com/sider/runners/pull/2201)
 - Add `linter.<id>.dependencies` option for npm tools [#2202](https://github.com/sider/runners/pull/2202)
 - **ktlint** Add issue ID for syntax error [#2206](https://github.com/sider/runners/pull/2206)
+- **Clang-Tidy** Better `apt-get install` failure [#2210](https://github.com/sider/runners/pull/2210)
 
 ## 0.45.0
 

--- a/sig/runners/cplusplus.rbs
+++ b/sig/runners/cplusplus.rbs
@@ -1,5 +1,8 @@
 module Runners
   module CPlusPlus : Processor
+    class AptInstallFailed < UserError
+    end
+
     CPP_SOURCES_GLOB: String
     CPP_HEADERS_GLOB: String
 

--- a/test/smokes/clang_tidy/expectations.rb
+++ b/test/smokes/clang_tidy/expectations.rb
@@ -272,3 +272,17 @@ s.add_test(
   issues: [],
   analyzer: { name: "Clang-Tidy", version: default_version }
 )
+
+s.add_test(
+  "invalid_apt_package_name",
+  type: "failure",
+  message: "`apt-get install` failed. Please check that the package names or versions are correct in your `sider.yml`.",
+  analyzer: :_
+)
+
+s.add_test(
+  "invalid_apt_package_version",
+  type: "failure",
+  message: "`apt-get install` failed. Please check that the package names or versions are correct in your `sider.yml`.",
+  analyzer: :_
+)

--- a/test/smokes/clang_tidy/invalid_apt_package_name/sider.yml
+++ b/test/smokes/clang_tidy/invalid_apt_package_name/sider.yml
@@ -1,0 +1,4 @@
+linter:
+  clang_tidy:
+    apt:
+      - libfoo-dev

--- a/test/smokes/clang_tidy/invalid_apt_package_version/sider.yml
+++ b/test/smokes/clang_tidy/invalid_apt_package_version/sider.yml
@@ -1,0 +1,4 @@
+linter:
+  clang_tidy:
+    apt:
+      - libfastjson-dev=0.1


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to handle failures of the `apt-get install` command, as not `type: "error"` but `type: "failure"`.
Because I think the failure is due to users' mistakes in `sider.yml`.

<img width="1435" alt="image" src="https://user-images.githubusercontent.com/473530/111970713-e7e96d00-8b3e-11eb-9c88-49e1e1059458.png">

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
