### PR TITLE
[CoffeeLint] Set deadline for older versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Misc:
 - Add `linter.<id>.dependencies` option for npm tools [#2202](https://github.com/sider/runners/pull/2202)
 - **ktlint** Add issue ID for syntax error [#2206](https://github.com/sider/runners/pull/2206)
 - **Clang-Tidy** Better `apt-get install` failure [#2210](https://github.com/sider/runners/pull/2210)
+- **CoffeeLint** Set deadline for older versions [#2212](https://github.com/sider/runners/pull/2212)
 
 ## 0.45.0
 

--- a/lib/runners/processor/coffeelint.rb
+++ b/lib/runners/processor/coffeelint.rb
@@ -14,6 +14,7 @@ module Runners
     register_config_schema(name: :coffeelint, schema: SCHEMA.config)
 
     CONSTRAINTS = {
+      # TODO: Remove the old package after the deadline.
       "coffeelint" => Gem::Requirement.new(">= 1.16.0", "< 3.0.0").freeze,
       "@coffeelint/cli" => Gem::Requirement.new(">= 4.0.0", "< 5.0.0").freeze,
     }.freeze
@@ -35,7 +36,7 @@ module Runners
         return Results::Failure.new(guid: guid, message: exn.message, analyzer: nil)
       end
 
-      add_warning_if_deprecated_version minimum: "4.0.0"
+      add_warning_if_deprecated_version minimum: "4.0.0", deadline: Time.new(2021, 5, 10)
 
       yield
     end

--- a/test/smokes/coffeelint/expectations.rb
+++ b/test/smokes/coffeelint/expectations.rb
@@ -154,7 +154,7 @@ s.add_test(
   analyzer: { name: "CoffeeLint", version: "2.0.6" },
   warnings: [{ message: <<~MSG.strip, file: nil }]
     DEPRECATION WARNING!!!
-    The `2.0.6` and older versions are deprecated, and these versions will be dropped in the near future.
+    The `2.0.6` and older versions are deprecated, and these versions will be dropped on May 10, 2021.
     Please consider upgrading to `4.0.0` or a newer version.
   MSG
 )


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change sets a deadline for the message that warns the use of CoffeeLint older versions.
The deadline is almost 1 month later.

I have confirmed already that the older versions are rarely used.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Related to #2213

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
