### PR TITLE
[TSLint] Extend deadline and add helpful link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Misc:
 - **ktlint** Add issue ID for syntax error [#2206](https://github.com/sider/runners/pull/2206)
 - **Clang-Tidy** Better `apt-get install` failure [#2210](https://github.com/sider/runners/pull/2210)
 - **CoffeeLint** Set deadline for older versions [#2212](https://github.com/sider/runners/pull/2212)
+- **TSLint** Extend deadline and add helpful link [#2215](https://github.com/sider/runners/pull/2215)
 
 ## 0.45.0
 

--- a/lib/runners/processor/tslint.rb
+++ b/lib/runners/processor/tslint.rb
@@ -26,8 +26,8 @@ module Runners
 
     def setup
       add_warning_for_deprecated_linter(alternative: "ESLint",
-                                        ref: "#{analyzer_github}/issues/4534",
-                                        deadline: Time.new(2020, 12, 1))
+                                        ref: "#{analyzer_github}/issues/4534 and https://www.npmjs.com/package/tslint-to-eslint-config",
+                                        deadline: Time.new(2021, 5, 10))
 
       begin
         install_nodejs_deps constraints: CONSTRAINTS

--- a/lib/runners/processor/tslint.rb
+++ b/lib/runners/processor/tslint.rb
@@ -27,7 +27,7 @@ module Runners
     def setup
       add_warning_for_deprecated_linter(alternative: "ESLint",
                                         ref: "#{analyzer_github}/issues/4534 and https://www.npmjs.com/package/tslint-to-eslint-config",
-                                        deadline: Time.new(2021, 5, 10))
+                                        deadline: Time.new(2021, 7, 5))
 
       begin
         install_nodejs_deps constraints: CONSTRAINTS

--- a/test/smokes/tslint/expectations.rb
+++ b/test/smokes/tslint/expectations.rb
@@ -155,8 +155,8 @@ s.add_test(
     {
       message: <<~MSG.strip,
         DEPRECATION WARNING!!!
-        The support for TSLint is deprecated and will be removed on December 1, 2020.
-        Please migrate to ESLint as an alternative. See https://github.com/palantir/tslint/issues/4534
+        The support for TSLint is deprecated and will be removed on May 10, 2021.
+        Please migrate to ESLint as an alternative. See https://github.com/palantir/tslint/issues/4534 and https://www.npmjs.com/package/tslint-to-eslint-config
       MSG
       file: "sideci.yml"
     }

--- a/test/smokes/tslint/expectations.rb
+++ b/test/smokes/tslint/expectations.rb
@@ -155,7 +155,7 @@ s.add_test(
     {
       message: <<~MSG.strip,
         DEPRECATION WARNING!!!
-        The support for TSLint is deprecated and will be removed on May 10, 2021.
+        The support for TSLint is deprecated and will be removed on July 5, 2021.
         Please migrate to ESLint as an alternative. See https://github.com/palantir/tslint/issues/4534 and https://www.npmjs.com/package/tslint-to-eslint-config
       MSG
       file: "sideci.yml"


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- The current deadline `2020-12-01` is past.
- [`tslint-to-eslint-config`](https://www.npmjs.com/package/tslint-to-eslint-config) is a popular migration tool from TSLint to ESLint.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Related to #2214

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
