### PR TITLE
Do not use tmpdir for working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Misc:
 - **Clang-Tidy** Better `apt-get install` failure [#2210](https://github.com/sider/runners/pull/2210)
 - **CoffeeLint** Set deadline for older versions [#2212](https://github.com/sider/runners/pull/2212)
 - **TSLint** Extend deadline and add helpful link [#2215](https://github.com/sider/runners/pull/2215)
+- Do not use tmpdir for working directory [#2217](https://github.com/sider/runners/pull/2217)
 
 ## 0.45.0
 

--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -2,15 +2,17 @@ require "optparse"
 
 module Runners
   class CLI
-    include Tmpdir
+    DEFAULT_WORKING_DIR = Pathname(Dir.home).join("project").freeze
+    private_constant :DEFAULT_WORKING_DIR
 
     attr_reader :stdout
     attr_reader :stderr
     attr_reader :guid
     attr_reader :analyzer
     attr_reader :options
+    attr_reader :working_dir
 
-    def initialize(argv:, stdout:, stderr:, options_json:)
+    def initialize(argv:, stdout:, stderr:, options_json:, working_dir: DEFAULT_WORKING_DIR)
       @stdout = stdout
       @stderr = stderr
 
@@ -41,45 +43,51 @@ module Runners
       end
 
       @options = Options.new(options_json, stdout, stderr)
+
+      if working_dir.exist?
+        raise ArgumentError, "`#{working_dir}` must not exist"
+      else
+        working_dir.mkdir
+        @working_dir = working_dir
+      end
     end
 
     def run
       io.flush! # Write or upload empty content to let the caller of Runners notice the beginning of the analysis.
-      with_working_dir do |working_dir|
-        writer = JSONSEQ::Writer.new(io: io)
-        trace_writer = TraceWriter.new(writer: writer, filter: SensitiveFilter.new(options: options))
-        started_at = Time.now
-        trace_writer.header "Start analysis", recorded_at: started_at
-        trace_writer.message "Started at #{started_at.utc}"
-        trace_writer.message "Runners version #{VERSION}"
-        trace_writer.message "Build GUID #{guid}"
 
-        harness = Harness.new(guid: guid, processor_class: processor_class, options: options,
-                              working_dir: working_dir, trace_writer: trace_writer)
+      writer = JSONSEQ::Writer.new(io: io)
+      trace_writer = TraceWriter.new(writer: writer, filter: SensitiveFilter.new(options: options))
+      started_at = Time.now
+      trace_writer.header "Start analysis", recorded_at: started_at
+      trace_writer.message "Started at #{started_at.utc}"
+      trace_writer.message "Runners version #{VERSION}"
+      trace_writer.message "Build GUID #{guid}"
 
-        result = harness.run
-        warnings = harness.warnings
-        config = harness.config
-        json = {
-          result: result.as_json,
-          warnings: warnings.as_json,
-          ci_config: config&.content,
-          config_file: config&.path_name,
-          version: VERSION,
-        }
+      harness = Harness.new(guid: guid, processor_class: processor_class, options: options,
+                            working_dir: working_dir, trace_writer: trace_writer)
 
-        trace_writer.message "Writing result..." do
-          writer << Schema::Result.envelope.coerce(json)
-        end
+      result = harness.run
+      warnings = harness.warnings
+      config = harness.config
+      json = {
+        result: result.as_json,
+        warnings: warnings.as_json,
+        ci_config: config&.content,
+        config_file: config&.path_name,
+        version: VERSION,
+      }
 
-        result.tap do
-          finished_at = Time.now
-          trace_writer.header "Finish analysis"
-          trace_writer.message finish_message(result)
-          trace_writer.message "Finished at #{finished_at.utc}"
-          trace_writer.message "Elapsed time: #{format_duration(finished_at - started_at)}"
-          trace_writer.finish started_at: started_at, finished_at: finished_at
-        end
+      trace_writer.message "Writing result..." do
+        writer << Schema::Result.envelope.coerce(json)
+      end
+
+      result.tap do
+        finished_at = Time.now
+        trace_writer.header "Finish analysis"
+        trace_writer.message finish_message(result)
+        trace_writer.message "Finished at #{finished_at.utc}"
+        trace_writer.message "Elapsed time: #{format_duration(finished_at - started_at)}"
+        trace_writer.finish started_at: started_at, finished_at: finished_at
       end
     ensure
       io.flush! if defined?(:@io)
@@ -116,10 +124,6 @@ module Runners
       # @see https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html
       Aws.config[:credentials] = Aws::Credentials.new(id, secret) if id && secret
       Aws.config[:region] = region if region
-    end
-
-    def with_working_dir(&block)
-      mktmpdir(&block)
     end
 
     def processor_class

--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -2,7 +2,7 @@ require "optparse"
 
 module Runners
   class CLI
-    DEFAULT_WORKING_DIR = Pathname(Dir.home).join("project").freeze
+    DEFAULT_WORKING_DIR = (Pathname(Dir.home) / "project").freeze
     private_constant :DEFAULT_WORKING_DIR
 
     attr_reader :stdout

--- a/sig/runners/cli.rbs
+++ b/sig/runners/cli.rbs
@@ -1,14 +1,15 @@
 module Runners
   class CLI
-    include Tmpdir
+    DEFAULT_WORKING_DIR: Pathname
 
     attr_reader stdout: ::IO
     attr_reader stderr: ::IO
     attr_reader guid: String
     attr_reader analyzer: Symbol
     attr_reader options: Options
+    attr_reader working_dir: Pathname
 
-    def initialize: (argv: Array[String], stdout: ::IO, stderr: ::IO, options_json: String) -> void
+    def initialize: (argv: Array[String], stdout: ::IO, stderr: ::IO, options_json: String, ?working_dir: Pathname) -> void
 
     def run: () -> void
 
@@ -17,8 +18,6 @@ module Runners
     def setup_bugsnag!: (Array[String]) -> void
 
     def setup_aws!: () -> void
-
-    def with_working_dir: [X] () { (Pathname) -> X } -> X
 
     def processor_class: () -> singleton(Processor)
 

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -3,10 +3,10 @@
   diagnostics:
   - range:
       start:
-        line: 103
+        line: 111
         character: 28
       end:
-        line: 106
+        line: 114
         character: 11
     severity: ERROR
     message: |-
@@ -15,20 +15,20 @@
     code: Ruby::ArgumentTypeMismatch
   - range:
       start:
-        line: 104
+        line: 112
         character: 17
       end:
-        line: 104
+        line: 112
         character: 24
     severity: ERROR
     message: Type `nil` does not have method `add_tab`
     code: Ruby::NoMethod
   - range:
       start:
-        line: 105
+        line: 113
         character: 17
       end:
-        line: 105
+        line: 113
         character: 24
     severity: ERROR
     message: Type `nil` does not have method `add_tab`

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -27,7 +27,7 @@ class CLITest < Minitest::Test
   end
 
   def teardown
-    FileUtils.remove_entry_secure @tmpdir, true
+    FileUtils.remove_entry_secure @tmpdir
   end
 
   def test_parsing_options

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -4,17 +4,9 @@ require "runners/cli"
 class CLITest < Minitest::Test
   include TestHelper
 
-  CLI = Runners::CLI
-  TraceWriter = Runners::TraceWriter
-
   class TestProcessor < Runners::Processor
-    def analyzer_id
-      :rubocop
-    end
-
-    def analyzer_version
-      "1.2.3"
-    end
+    def analyzer_id; :rubocop; end
+    def analyzer_version; "1.2.3"; end
 
     def setup
       yield
@@ -30,15 +22,23 @@ class CLITest < Minitest::Test
     end
   end
 
+  def setup
+    @tmpdir = mktmpdir.tap { FileUtils.remove_entry_secure(_1) }
+  end
+
+  def teardown
+    FileUtils.remove_entry_secure @tmpdir, true
+  end
+
   def test_parsing_options
-    cli = CLI.new(argv: ["--analyzer=rubocop", "test-guid"], stdout: stdout, stderr: stderr, options_json: options_json)
+    cli = new_cli
     assert_equal "test-guid", cli.guid
     assert_equal :rubocop, cli.analyzer
     assert_instance_of Runners::Options, cli.options
   end
 
   def test_run
-    cli = CLI.new(argv: ["--analyzer=rubocop", "test-guid"], stdout: stdout, stderr: stderr, options_json: options_json)
+    cli = new_cli
     cli.stub(:processor_class, TestProcessor) { cli.run }
 
     assert traces.any? { _1[:trace] == 'command_line' && _1[:command_line] == ["test", "command"] }
@@ -60,7 +60,7 @@ class CLITest < Minitest::Test
         Runners::Results::Success.new(guid: guid, analyzer: analyzer, issues: issues)
       end
     end
-    cli = CLI.new(argv: ["--analyzer=rubocop", "test-guid"], stdout: stdout, stderr: stderr, options_json: options_json)
+    cli = new_cli
     cli.stub(:processor_class, klass) { cli.run }
 
     assert_includes traces.filter_map { _1[:message] if _1[:trace] == 'message' },
@@ -74,7 +74,7 @@ class CLITest < Minitest::Test
         Runners::Results::Success.new(guid: guid, analyzer: analyzer, issues: issues)
       end
     end
-    cli = CLI.new(argv: ["--analyzer=rubocop", "test-guid"], stdout: stdout, stderr: stderr, options_json: options_json)
+    cli = new_cli
     cli.stub(:processor_class, klass) { cli.run }
 
     assert_includes traces.filter_map { _1[:message] if _1[:trace] == 'message' },
@@ -87,7 +87,7 @@ class CLITest < Minitest::Test
         Runners::Results::Failure.new(guid: guid, analyzer: analyzer)
       end
     end
-    cli = CLI.new(argv: ["--analyzer=rubocop", "test-guid"], stdout: stdout, stderr: stderr, options_json: options_json)
+    cli = new_cli
     cli.stub(:processor_class, klass) { cli.run }
 
     assert_includes traces.filter_map { _1[:message] if _1[:trace] == 'message' },
@@ -100,7 +100,7 @@ class CLITest < Minitest::Test
         Runners::Results::Failure.new(guid: guid, analyzer: nil)
       end
     end
-    cli = CLI.new(argv: ["--analyzer=rubocop", "test-guid"], stdout: stdout, stderr: stderr, options_json: options_json)
+    cli = new_cli
     cli.stub(:processor_class, klass) { cli.run }
 
     assert_includes traces.filter_map { _1[:message] if _1[:trace] == 'message' },
@@ -108,8 +108,7 @@ class CLITest < Minitest::Test
   end
 
   def test_run_with_broken_config
-    json = options_json({ source: new_source(head: "07aeaa0b17fb34063cbc3ed24d6d65f986c37884") })
-    cli = CLI.new(argv: ["--analyzer=rubocop", "test-guid"], stdout: stdout, stderr: stderr, options_json: json)
+    cli = new_cli(options_json: options_json({ source: new_source(head: "07aeaa0b17fb34063cbc3ed24d6d65f986c37884") }))
     cli.run
 
     assert traces.any? { _1.dig(:result, :type) == 'failure' }
@@ -118,7 +117,7 @@ class CLITest < Minitest::Test
   end
 
   def test_format_duration
-    cli = CLI.new(argv: ["--analyzer=rubocop", "test-guid"], stdout: stdout, stderr: stderr, options_json: options_json)
+    cli = new_cli
     target = ->(value) { cli.send(:format_duration, value) }
 
     assert_equal "0.0s", target.(0.0)
@@ -137,7 +136,7 @@ class CLITest < Minitest::Test
     ENV["RUNNERS_VERSION"] = "version"
     ENV["BUGSNAG_RELEASE_STAGE"] = nil
 
-    CLI.new(argv: ["--analyzer=rubocop", "test-guid"], stdout: stdout, stderr: stderr, options_json: options_json)
+    new_cli
 
     assert_equal "key", Bugsnag.configuration.api_key
     assert_equal "version", Bugsnag.configuration.app_version
@@ -153,7 +152,7 @@ class CLITest < Minitest::Test
     ENV["AWS_SECRET_ACCESS_KEY"] = "secret"
     ENV["AWS_REGION"] = nil
 
-    CLI.new(argv: ["--analyzer=rubocop", "test-guid"], stdout: stdout, stderr: stderr, options_json: options_json)
+    new_cli
 
     assert_equal "id", Aws.config[:credentials].access_key_id
     assert_equal "secret", Aws.config[:credentials].secret_access_key
@@ -165,6 +164,17 @@ class CLITest < Minitest::Test
   end
 
   private
+
+  def new_cli(**params)
+    Runners::CLI.new(
+      argv: ["--analyzer=rubocop", "test-guid"],
+      stdout: stdout,
+      stderr: stderr,
+      options_json: options_json,
+      working_dir: @tmpdir,
+      **params,
+    )
+  end
 
   def stdout
     @stdout ||= StringIO.new


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

An analyzer's error message sometimes includes the absolute path like `/tmp/d20200908-6-dienfd/.eslintrc.yml`.
I think this message may surprise users.

So, this change uses the `${HOME}/project` directory instead. This directory has never been used.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
