### PR TITLE
Pass `--force` flag to `npm install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 Breaking:
 
-- Support npm 7 [#2189](https://github.com/sider/runners/pull/2189)
+- Support npm 7 [#2189](https://github.com/sider/runners/pull/2189) [#2218](https://github.com/sider/runners/pull/2218)
 - Remove deprecated `linter.{id}.options` [#2190](https://github.com/sider/runners/pull/2190) [#2193](https://github.com/sider/runners/pull/2193)
 
 Updated environments:

--- a/lib/runners/nodejs.rb
+++ b/lib/runners/nodejs.rb
@@ -121,7 +121,7 @@ module Runners
     # @see https://docs.npmjs.com/cli/v7/commands/npm-install
     # @see https://docs.npmjs.com/cli/v7/commands/npm-ci
     def npm_install(*deps, subcommand: "install", flags: [])
-      # NOTE: `--force` is to install *unmet* dependencies like Yarn.
+      # NOTE: `--force` is to install *unmet* dependencies like npm 6 or Yarn.
       flags = %w[
         --force
         --ignore-scripts

--- a/lib/runners/nodejs.rb
+++ b/lib/runners/nodejs.rb
@@ -121,7 +121,9 @@ module Runners
     # @see https://docs.npmjs.com/cli/v7/commands/npm-install
     # @see https://docs.npmjs.com/cli/v7/commands/npm-ci
     def npm_install(*deps, subcommand: "install", flags: [])
+      # NOTE: `--force` is to install *unmet* dependencies like Yarn.
       flags = %w[
+        --force
         --ignore-scripts
         --no-engine-strict
         --no-progress

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -564,3 +564,10 @@ s.add_test(
   analyzer: { name: "ESLint", version: default_version },
   warnings: [{ message: "Installed `eslint@4.19.1` does not satisfy our constraint `>=5.0.0 <8.0.0`. Please update it as possible.", file: "package.json" }]
 )
+
+s.add_test(
+  "unmet_peer_deps",
+  type: "success",
+  issues: [],
+  analyzer: { name: "ESLint", version: "7.21.0" }
+)

--- a/test/smokes/eslint/unmet_peer_deps/package.json
+++ b/test/smokes/eslint/unmet_peer_deps/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "eslint": "7.21.0",
+    "eslint-config-airbnb": "18.1.0"
+  }
+}


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

`npm install` without `--force` can fail due to *unmet* dependencies as below.
By adding the `--force` flag, `npm install` behaves like npm 6 or Yarn.

```console
$ npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: undefined@undefined
npm ERR! Found: eslint@7.21.0
npm ERR! node_modules/eslint
npm ERR!   eslint@"7.21.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer eslint@"^5.16.0 || ^6.8.0" from eslint-config-airbnb@18.1.0
npm ERR! node_modules/eslint-config-airbnb
npm ERR!   eslint-config-airbnb@"18.1.0" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
(...truncated...)

$ npm install --force
npm WARN using --force Recommended protections disabled.
npm WARN ERESOLVE overriding peer dependency
npm WARN Found: eslint@7.21.0
npm WARN node_modules/eslint
npm WARN   eslint@"7.21.0" from the root project
npm WARN
npm WARN Could not resolve dependency:
npm WARN peer eslint@"^5.16.0 || ^6.8.0" from eslint-config-airbnb@18.1.0
npm WARN node_modules/eslint-config-airbnb
npm WARN   eslint-config-airbnb@"18.1.0" from the root project
npm WARN ERESOLVE overriding peer dependency
npm WARN Found: eslint@7.21.0
npm WARN node_modules/eslint
npm WARN   eslint@"7.21.0" from the root project
npm WARN
npm WARN Could not resolve dependency:
npm WARN peer eslint@"^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0" from eslint-plugin-react-hooks@2.5.1
npm WARN node_modules/eslint-plugin-react-hooks
npm WARN   peer eslint-plugin-react-hooks@"^2.5.0 || ^1.7.0" from eslint-config-airbnb@18.1.0
npm WARN   node_modules/eslint-config-airbnb

added 214 packages, and audited 215 packages in 6s

45 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Follow-up of #2189

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
