### PR TITLE
Simplify `Runners::Processor.register_config_schema` method

### DIFF
--- a/lib/runners/processor/brakeman.rb
+++ b/lib/runners/processor/brakeman.rb
@@ -13,7 +13,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :brakeman, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     GEM_NAME = "brakeman".freeze
     CONSTRAINTS = {

--- a/lib/runners/processor/checkstyle.rb
+++ b/lib/runners/processor/checkstyle.rb
@@ -23,7 +23,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :checkstyle, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_TARGET = ".".freeze
     DEFAULT_CONFIG_FILE = (Pathname(Dir.home) / "sider_recommended_checkstyle.xml").to_path.freeze

--- a/lib/runners/processor/clang_tidy.rb
+++ b/lib/runners/processor/clang_tidy.rb
@@ -13,7 +13,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :clang_tidy, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     def self.config_example
       <<~'YAML'

--- a/lib/runners/processor/code_sniffer.rb
+++ b/lib/runners/processor/code_sniffer.rb
@@ -24,7 +24,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :code_sniffer, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_CONFIG_FILE = (Pathname(Dir.home) / "sider_recommended_code_sniffer.xml").to_path.freeze
 

--- a/lib/runners/processor/coffeelint.rb
+++ b/lib/runners/processor/coffeelint.rb
@@ -11,7 +11,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :coffeelint, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     CONSTRAINTS = {
       # TODO: Remove the old package after the deadline.

--- a/lib/runners/processor/cppcheck.rb
+++ b/lib/runners/processor/cppcheck.rb
@@ -31,7 +31,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :cppcheck, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_TARGET = ".".freeze
     DEFAULT_IGNORE = [].freeze

--- a/lib/runners/processor/cpplint.rb
+++ b/lib/runners/processor/cpplint.rb
@@ -20,7 +20,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :cpplint, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_TARGET = ".".freeze
     CONFIG_FILE_NAME = "CPPLINT.cfg".freeze

--- a/lib/runners/processor/detekt.rb
+++ b/lib/runners/processor/detekt.rb
@@ -24,7 +24,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :detekt, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     def self.config_example
       <<~'YAML'

--- a/lib/runners/processor/eslint.rb
+++ b/lib/runners/processor/eslint.rb
@@ -25,7 +25,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :eslint, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     CONSTRAINTS = {
       "eslint" => Gem::Requirement.new(">= 5.0.0", "< 8.0.0").freeze,

--- a/lib/runners/processor/flake8.rb
+++ b/lib/runners/processor/flake8.rb
@@ -14,7 +14,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :flake8, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_TARGET = ".".freeze
     DEFAULT_CONFIG_PATH = (Pathname(Dir.home) / '.config' / 'flake8').to_path.freeze

--- a/lib/runners/processor/fxcop.rb
+++ b/lib/runners/processor/fxcop.rb
@@ -13,7 +13,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :fxcop, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     def self.config_example
       <<~'YAML'

--- a/lib/runners/processor/golangci_lint.rb
+++ b/lib/runners/processor/golangci_lint.rb
@@ -37,7 +37,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :golangci_lint, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_CONFIG_FILE = (Pathname(Dir.home) / "sider_golangci.yml").to_path.freeze
 

--- a/lib/runners/processor/goodcheck.rb
+++ b/lib/runners/processor/goodcheck.rb
@@ -18,7 +18,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :goodcheck, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     GEM_NAME = "goodcheck".freeze
     CONSTRAINTS = {

--- a/lib/runners/processor/hadolint.rb
+++ b/lib/runners/processor/hadolint.rb
@@ -16,7 +16,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :hadolint, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_TARGET = "**/Dockerfile{,.*}".freeze
     DEFAULT_TARGET_EXCLUDED = "*.{erb,txt}".freeze # Exclude templates

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -22,7 +22,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :haml_lint, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     GEM_NAME = "haml_lint".freeze
     REQUIRED_GEM_NAMES = ["rubocop"].freeze

--- a/lib/runners/processor/javasee.rb
+++ b/lib/runners/processor/javasee.rb
@@ -19,7 +19,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :javasee, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_CONFIG_FILE = "javasee.yml".freeze
 

--- a/lib/runners/processor/jshint.rb
+++ b/lib/runners/processor/jshint.rb
@@ -13,7 +13,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :jshint, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_TARGET = ".".freeze
     DEFAULT_CONFIG_FILE = (Pathname(Dir.home) / 'sider_jshintrc').to_path.freeze

--- a/lib/runners/processor/ktlint.rb
+++ b/lib/runners/processor/ktlint.rb
@@ -15,7 +15,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :ktlint, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     def self.config_example
       <<~'YAML'

--- a/lib/runners/processor/languagetool.rb
+++ b/lib/runners/processor/languagetool.rb
@@ -27,7 +27,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :languagetool, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_TARGET = ".".freeze
     DEFAULT_EXT = ".txt".freeze

--- a/lib/runners/processor/misspell.rb
+++ b/lib/runners/processor/misspell.rb
@@ -18,7 +18,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :misspell, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_TARGET = ".".freeze
 

--- a/lib/runners/processor/phinder.rb
+++ b/lib/runners/processor/phinder.rb
@@ -19,7 +19,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :phinder, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_RULE_FILE = "phinder.yml".freeze
 

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -17,7 +17,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :phpmd, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_TARGET = ".".freeze
     DEFAULT_CONFIG_FILE = (Pathname(Dir.home) / "sider_config.xml").to_path.freeze

--- a/lib/runners/processor/pmd_cpd.rb
+++ b/lib/runners/processor/pmd_cpd.rb
@@ -69,7 +69,7 @@ module Runners
     DEFAULT_TARGET = ".".freeze
     DEFAULT_LANGUAGE = ["cpp", "cs", "ecmascript", "go", "java", "kotlin", "php", "python", "ruby", "swift"].freeze
 
-    register_config_schema(name: :pmd_cpd, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     def self.config_example
       <<~'YAML'

--- a/lib/runners/processor/pmd_java.rb
+++ b/lib/runners/processor/pmd_java.rb
@@ -20,7 +20,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :pmd_java, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_RULESET = (Pathname(Dir.home) / "default-ruleset.xml").to_path.freeze
     DEFAULT_TARGET = ".".freeze

--- a/lib/runners/processor/pylint.rb
+++ b/lib/runners/processor/pylint.rb
@@ -21,7 +21,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :pylint, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_TARGET = ["**/*.{py}"].freeze
 

--- a/lib/runners/processor/querly.rb
+++ b/lib/runners/processor/querly.rb
@@ -18,7 +18,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :querly, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     OPTIONAL_GEMS = [
       GemInstaller::Spec.new("slim"),

--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -17,7 +17,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :rails_best_practices, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     OPTIONAL_GEMS = [
       GemInstaller::Spec.new("slim"),

--- a/lib/runners/processor/reek.rb
+++ b/lib/runners/processor/reek.rb
@@ -12,7 +12,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :reek, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     GEM_NAME = "reek".freeze
     CONSTRAINTS = {

--- a/lib/runners/processor/remark_lint.rb
+++ b/lib/runners/processor/remark_lint.rb
@@ -19,7 +19,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :remark_lint, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     CONSTRAINTS = {
       "remark-cli" => Gem::Requirement.new(">= 7.0.0", "< 10.0.0").freeze,

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -19,7 +19,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :rubocop, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     GEM_NAME = "rubocop".freeze
     CONSTRAINTS = {

--- a/lib/runners/processor/scss_lint.rb
+++ b/lib/runners/processor/scss_lint.rb
@@ -11,7 +11,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :scss_lint, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     # https://github.com/brigade/scss-lint#exit-status-codes
     EXIT_CODE_FILES_NOT_EXIST = 80

--- a/lib/runners/processor/shellcheck.rb
+++ b/lib/runners/processor/shellcheck.rb
@@ -34,7 +34,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :shellcheck, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     DEFAULT_TARGET = [
       "**/*.{bash,bats,dash,ksh,sh}",

--- a/lib/runners/processor/slim_lint.rb
+++ b/lib/runners/processor/slim_lint.rb
@@ -17,7 +17,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :slim_lint, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     GEM_NAME = "slim_lint".freeze
     REQUIRED_GEM_NAMES = ["rubocop"].freeze

--- a/lib/runners/processor/stylelint.rb
+++ b/lib/runners/processor/stylelint.rb
@@ -22,7 +22,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :stylelint, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     CONSTRAINTS = {
       "stylelint" => Gem::Requirement.new(">= 8.3.0", "< 14.0.0").freeze,

--- a/lib/runners/processor/swiftlint.rb
+++ b/lib/runners/processor/swiftlint.rb
@@ -20,7 +20,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :swiftlint, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     def self.config_example
       <<~'YAML'

--- a/lib/runners/processor/tslint.rb
+++ b/lib/runners/processor/tslint.rb
@@ -16,7 +16,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :tslint, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     CONSTRAINTS = {
       "tslint" => Gem::Requirement.new(">= 5.0.0", "< 7.0.0").freeze,

--- a/lib/runners/processor/tyscan.rb
+++ b/lib/runners/processor/tyscan.rb
@@ -19,7 +19,7 @@ module Runners
       )
     end
 
-    register_config_schema(name: :tyscan, schema: SCHEMA.config)
+    register_config_schema SCHEMA.config
 
     CONSTRAINTS = {
       "tyscan" => Gem::Requirement.new(">= 0.2.1", "< 1.0.0").freeze,

--- a/sig/runners/processor.rbs
+++ b/sig/runners/processor.rbs
@@ -4,14 +4,11 @@ module Runners
 
     include Tmpdir
 
-    class CIConfigBroken < UserError
-    end
-
-    def self.register_config_schema: (name: Symbol, schema: StrongJSON::_Schema[untyped]) -> void
+    def self.analyzer_id: () -> Symbol
 
     def self.children: () -> Hash[Symbol, singleton(Processor)]
 
-    def self.analyzer_id: () -> Symbol
+    def self.register_config_schema: (StrongJSON::_Schema[untyped]) -> void
 
     def self.config_example: () -> String
 

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -104,10 +104,10 @@
   diagnostics:
   - range:
       start:
-        line: 116
+        line: 114
         character: 26
       end:
-        line: 116
+        line: 114
         character: 29
     severity: ERROR
     message: |-
@@ -119,10 +119,10 @@
     code: Ruby::ArgumentTypeMismatch
   - range:
       start:
-        line: 116
+        line: 114
         character: 31
       end:
-        line: 116
+        line: 114
         character: 40
     severity: ERROR
     message: |-
@@ -137,10 +137,10 @@
     code: Ruby::ArgumentTypeMismatch
   - range:
       start:
-        line: 252
+        line: 250
         character: 45
       end:
-        line: 252
+        line: 250
         character: 50
     severity: ERROR
     message: Type `(::String | ::Array[::String] | nil)` does not have method `split`


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring aims to simplify the `Runners::Processor.register_config_schema` method.
Since the class now has the `.analyzer_id` method, the `name` argument of `.register_config_schema` is needless.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
