### PR TITLE
Refactor use of `Runners::Tmpdir` module

### DIFF
--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -1,11 +1,10 @@
 module Runners
   class Processor
     extend Forwardable
-    include Tmpdir
 
     def self.analyzer_id
       # Naming convention
-      source_file, _ = Module.const_source_location(self.name.to_s)
+      source_file, _ = Module.const_source_location(name.to_s)
       File.basename(source_file, ".rb").to_sym
     end
 
@@ -17,7 +16,7 @@ module Runners
     end
 
     def self.register_config_schema(schema)
-      Schema::Config.register(name: self.analyzer_id, schema: schema)
+      Schema::Config.register(name: analyzer_id, schema: schema)
     end
 
     def self.config_example

--- a/lib/runners/ruby.rb
+++ b/lib/runners/ruby.rb
@@ -16,7 +16,7 @@ module Runners
 
       specs = merge_specs(default_specs, user_specs.empty? ? optionals : user_specs)
 
-      mktmpdir do |path|
+      Tmpdir.mktmpdir do |path|
         installer = GemInstaller.new(shell: shell,
                                      home: path,
                                      config_path_name: config.path_name,

--- a/lib/runners/tmpdir.rb
+++ b/lib/runners/tmpdir.rb
@@ -1,5 +1,7 @@
 module Runners
   module Tmpdir
+    module_function
+
     def mktmpdir
       if block_given?
         Dir.mktmpdir do |dir|

--- a/sig/runners/processor.rbs
+++ b/sig/runners/processor.rbs
@@ -2,8 +2,6 @@ module Runners
   class Processor
     extend Forwardable
 
-    include Tmpdir
-
     def self.analyzer_id: () -> Symbol
 
     def self.children: () -> Hash[Symbol, singleton(Processor)]

--- a/sig/runners/tmpdir.rbs
+++ b/sig/runners/tmpdir.rbs
@@ -1,6 +1,6 @@
 module Runners
   module Tmpdir
-    def mktmpdir: [X] () { (Pathname) -> X } -> X
-                | () -> Pathname
+    def self?.mktmpdir: [X] () { (Pathname) -> X } -> X
+                      | () -> Pathname
   end
 end

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -104,10 +104,10 @@
   diagnostics:
   - range:
       start:
-        line: 114
+        line: 113
         character: 26
       end:
-        line: 114
+        line: 113
         character: 29
     severity: ERROR
     message: |-
@@ -119,10 +119,10 @@
     code: Ruby::ArgumentTypeMismatch
   - range:
       start:
-        line: 114
+        line: 113
         character: 31
       end:
-        line: 114
+        line: 113
         character: 40
     severity: ERROR
     message: |-
@@ -137,10 +137,10 @@
     code: Ruby::ArgumentTypeMismatch
   - range:
       start:
-        line: 250
+        line: 249
         character: 45
       end:
-        line: 250
+        line: 249
         character: 50
     severity: ERROR
     message: Type `(::String | ::Array[::String] | nil)` does not have method `split`


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring aims to make the use of the `Runners::Tmpdir` module more readable.

- Set `module_function` to the `Tmpdir.mktmpdir` method.
- Remove needless the use of `Tmpdir`.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
