### PR TITLE
`Runners::Config` check warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Misc:
 - **CoffeeLint** Set deadline for older versions [#2212](https://github.com/sider/runners/pull/2212)
 - **TSLint** Extend deadline and add helpful link [#2215](https://github.com/sider/runners/pull/2215)
 - Do not use tmpdir for working directory [#2217](https://github.com/sider/runners/pull/2217)
+- `Runners::Config` check warnings [#2221](https://github.com/sider/runners/pull/2221)
 
 ## 0.45.0
 

--- a/lib/runners/processor/eslint.rb
+++ b/lib/runners/processor/eslint.rb
@@ -27,6 +27,10 @@ module Runners
 
     register_config_schema SCHEMA.config
 
+    Config.register_warnings do |config|
+      config.add_warning_for_deprecated_option(analyzer: analyzer_id, old: :dir, new: :target)
+    end
+
     CONSTRAINTS = {
       "eslint" => Gem::Requirement.new(">= 5.0.0", "< 8.0.0").freeze,
     }.freeze
@@ -55,8 +59,6 @@ module Runners
     end
 
     def setup
-      warnings.add_warning_for_deprecated_option(config: config, analyzer: analyzer_id, old: :dir, new: :target)
-
       begin
         install_nodejs_deps constraints: CONSTRAINTS
       rescue UserError => exn

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -24,6 +24,10 @@ module Runners
 
     register_config_schema SCHEMA.config
 
+    Config.register_warnings do |config|
+      config.add_warning_for_deprecated_option(analyzer: analyzer_id, old: :file, new: :target)
+    end
+
     GEM_NAME = "haml_lint".freeze
     REQUIRED_GEM_NAMES = ["rubocop"].freeze
     CONSTRAINTS = {
@@ -53,8 +57,6 @@ module Runners
     end
 
     def setup
-      warnings.add_warning_for_deprecated_option(config: config, analyzer: analyzer_id, old: :file, new: :target)
-
       setup_haml_lint_config
 
       default_gems = default_gem_specs(GEM_NAME, *REQUIRED_GEM_NAMES)

--- a/lib/runners/processor/misspell.rb
+++ b/lib/runners/processor/misspell.rb
@@ -20,6 +20,10 @@ module Runners
 
     register_config_schema SCHEMA.config
 
+    Config.register_warnings do |config|
+      config.add_warning_for_deprecated_option(analyzer: analyzer_id, old: :targets, new: :target)
+    end
+
     DEFAULT_TARGET = ".".freeze
 
     def self.config_example
@@ -34,11 +38,6 @@ module Runners
 
     def extract_version_option
       "-v"
-    end
-
-    def setup
-      warnings.add_warning_for_deprecated_option(config: config, analyzer: analyzer_id, old: :targets, new: :target)
-      yield
     end
 
     def analyze(_changes)

--- a/lib/runners/warnings.rb
+++ b/lib/runners/warnings.rb
@@ -19,16 +19,6 @@ module Runners
       end
     end
 
-    def add_warning_for_deprecated_option(config:, analyzer:, old:, new:)
-      linter = config.linter(analyzer)
-      return unless linter[old]
-
-      file = config.path_name
-      old_path = config.linter_field_path(analyzer, old)
-      new_path = config.linter_field_path(analyzer, new)
-      add "The `#{old_path}` option is deprecated. Please use the `#{new_path}` option instead in your `#{file}`.", file: file
-    end
-
     def add_warning_for_deprecated_linter(old:, new:, links: [], deadline: nil)
       message = "The support for #{old} is deprecated and will be removed #{deadline_text(deadline)}. Please migrate to #{new}."
       unless links.empty?
@@ -44,6 +34,10 @@ module Runners
 
     def empty?
       @list.empty?
+    end
+
+    def each(&block)
+      @list.each(&block)
     end
 
     def as_json

--- a/sig/runners/config.rbs
+++ b/sig/runners/config.rbs
@@ -26,6 +26,10 @@ module Runners
 
     def self.load_from_dir: (Pathname) -> instance
 
+    def self.register_warnings: () { (instance) -> void } -> void
+
+    def self.check_warnings: (instance) -> void
+
     attr_reader path: Pathname?
     attr_reader raw_content: String?
 
@@ -35,7 +39,7 @@ module Runners
 
     def content: () -> Hash[Symbol, untyped]
 
-    alias validate content
+    def validate: () -> void
 
     def valid?: () -> bool
 
@@ -62,6 +66,8 @@ module Runners
     def linter_field_path: (*(Symbol | String)) -> String
 
     def warnings: () -> Warnings
+
+    def add_warning_for_deprecated_option: (analyzer: Symbol, old: Symbol, new: Symbol) -> void
 
     private
 

--- a/sig/runners/processor.rbs
+++ b/sig/runners/processor.rbs
@@ -15,6 +15,7 @@ module Runners
     attr_reader config: Config
     attr_reader shell: Shell
     attr_reader trace_writer: TraceWriter
+    attr_reader warnings: Warnings
 
     def initialize: (guid: String, working_dir: Pathname, config: Config, shell: Shell, trace_writer: TraceWriter) -> void
 
@@ -70,8 +71,6 @@ module Runners
     def config_field_path: (*(Symbol | String)) -> String
 
     def delete_unchanged_files: (Changes, ?except: Array[String], ?only: Array[String]) -> void
-
-    def warnings: () -> Warnings
 
     def add_warning: (String, ?file: String?) -> void
 

--- a/sig/runners/warnings.rbs
+++ b/sig/runners/warnings.rbs
@@ -1,5 +1,7 @@
 module Runners
   class Warnings
+    type warning = { message: String, file: String? }
+
     attr_reader trace_writer: TraceWriter?
 
     def initialize: (?trace_writer: TraceWriter?) -> void
@@ -8,15 +10,15 @@ module Runners
 
     def add_warning_if_deprecated_version: (String, current: String, minimum: String, ?deadline: Time?) -> void
 
-    def add_warning_for_deprecated_option: (config: Config, analyzer: Symbol, old: Symbol, new: Symbol) -> void
-
     def add_warning_for_deprecated_linter: (old: String, new: String, ?links: Array[String], ?deadline: Time?) -> void
 
     def size: () -> Integer
 
     def empty?: () -> bool
 
-    def as_json: () -> Array[Hash[Symbol, String?]]
+    def each: () { (warning) -> void } -> void
+
+    def as_json: () -> Array[warning]
 
     alias to_a as_json
 

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -73,10 +73,10 @@
   diagnostics:
   - range:
       start:
-        line: 64
+        line: 63
         character: 51
       end:
-        line: 64
+        line: 63
         character: 55
     severity: ERROR
     message: Type `bot` does not have method `size`
@@ -104,10 +104,10 @@
   diagnostics:
   - range:
       start:
-        line: 113
+        line: 117
         character: 26
       end:
-        line: 113
+        line: 117
         character: 29
     severity: ERROR
     message: |-
@@ -119,10 +119,10 @@
     code: Ruby::ArgumentTypeMismatch
   - range:
       start:
-        line: 113
+        line: 117
         character: 31
       end:
-        line: 113
+        line: 117
         character: 40
     severity: ERROR
     message: |-

--- a/test/warnings_test.rb
+++ b/test/warnings_test.rb
@@ -36,18 +36,6 @@ class WarningsTest < Minitest::Test
                      { message: "Foo 1.0.0 is deprecated and will be dropped on January 9, 2020. Please update to 1.0.1 or higher.", file: nil },]
   end
 
-  def test_add_warning_for_deprecated_option
-    config = Runners::Config.new(path: "foo.yml", raw_content: <<~YAML)
-      ---
-      linter:
-        eslint:
-          dir: "src/"
-    YAML
-    warnings.add_warning_for_deprecated_option(config: config, analyzer: :eslint, old: :dir, new: :target)
-
-    assert_warnings [{ message: "The `linter.eslint.dir` option is deprecated. Please use the `linter.eslint.target` option instead in your `foo.yml`.", file: "foo.yml" }]
-  end
-
   def test_add_warning_for_deprecated_linter
     warnings.add_warning_for_deprecated_linter(old: "Foo", new: "Bar")
     warnings.add_warning_for_deprecated_linter(old: "Foo", new: "Bar", links: ["https://foo", "https://bar"], deadline: Time.new(2020, 12, 31))


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to allow the `Runners::Config` class to report warnings in `sider.yml`.
By doing this, we will be able to get warnings in `sider.yml` without triggering a heavy runner process.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
