### PR TITLE
Add `npm install` flags to suppress extra output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 Breaking:
 
-- Support npm 7 [#2189](https://github.com/sider/runners/pull/2189) [#2218](https://github.com/sider/runners/pull/2218)
+- Support npm 7 [#2189](https://github.com/sider/runners/pull/2189) [#2218](https://github.com/sider/runners/pull/2218) [#2222](https://github.com/sider/runners/pull/2222)
 - Remove deprecated `linter.{id}.options` [#2190](https://github.com/sider/runners/pull/2190) [#2193](https://github.com/sider/runners/pull/2193)
 
 Updated environments:

--- a/lib/runners/nodejs.rb
+++ b/lib/runners/nodejs.rb
@@ -125,9 +125,12 @@ module Runners
       flags = %w[
         --force
         --ignore-scripts
+        --no-audit
         --no-engine-strict
+        --no-fund
         --no-progress
         --no-save
+        --no-update-notifier
       ] + flags
 
       trace_writer.message "Installing npm dependencies..."


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

These flags can suppress extra output for `npm install`:

- https://docs.npmjs.com/cli/v7/using-npm/config#audit
- https://docs.npmjs.com/cli/v7/using-npm/config#fund
- https://docs.npmjs.com/cli/v7/using-npm/config#update-notifier

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Related to #2189

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
