### PR TITLE
Exclude duplicate warnings in `Runners::Warnings`

### DIFF
--- a/lib/runners/warnings.rb
+++ b/lib/runners/warnings.rb
@@ -10,7 +10,8 @@ module Runners
     def add(message, file: nil)
       message = message.strip
       trace_writer&.warning(message, file: file)
-      @list << { message: message, file: file }
+      new_warning = { message: message, file: file }
+      @list << new_warning unless @list.include? new_warning
     end
 
     def add_warning_if_deprecated_version(analyzer_name, current:, minimum:, deadline: nil)
@@ -40,11 +41,10 @@ module Runners
       @list.each(&block)
     end
 
-    def as_json
-      @list
+    def to_a
+      @list.to_a
     end
-
-    alias to_a as_json
+    alias as_json to_a
 
     private
 

--- a/sig/runners/warnings.rbs
+++ b/sig/runners/warnings.rbs
@@ -18,9 +18,8 @@ module Runners
 
     def each: () { (warning) -> void } -> void
 
-    def as_json: () -> Array[warning]
-
-    alias to_a as_json
+    def to_a: () -> Array[warning]
+    alias as_json to_a
 
     private
 

--- a/test/warnings_test.rb
+++ b/test/warnings_test.rb
@@ -5,7 +5,10 @@ class WarningsTest < Minitest::Test
 
   def test_add
     warnings.add "foo"
+    warnings.add "foo"
     warnings.add " bar "
+    warnings.add " bar "
+    warnings.add "\n baz \n", file: "a.yml"
     warnings.add "\n baz \n", file: "a.yml"
 
     assert_warnings [{ message: "foo", file: nil },


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to exclude duplicate warnings added in the `Runners::Warnings` class.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
