### PR TITLE
Refactor `Runners::Java` class

### DIFF
--- a/lib/runners/java.rb
+++ b/lib/runners/java.rb
@@ -7,10 +7,10 @@ module Runners
       capture3! "gradle", "--version"
     end
 
-    def install_jvm_deps
+    def install_jvm_deps(to: Pathname(Dir.home).join("dependencies"))
       return if config_jvm_deps.empty?
 
-      chdir jvm_deps_dir do
+      chdir to do
         generate_jvm_deps_file
 
         trace_writer.message "Install dependencies..." do
@@ -25,10 +25,6 @@ module Runners
     end
 
     private
-
-    def jvm_deps_dir
-      Pathname(Dir.home) / "dependencies"
-    end
 
     def fetch_deps_via_gradle!
       capture3! "gradle", "--no-build-cache", "--parallel", "--quiet", "deps"

--- a/sig/runners/java.rbs
+++ b/sig/runners/java.rbs
@@ -3,11 +3,9 @@ module Runners
     class InvalidDependency < UserError
     end
 
-    def install_jvm_deps: () -> void
+    def install_jvm_deps: (?to: Pathname) -> void
 
     private
-
-    def jvm_deps_dir: () -> Pathname
 
     def fetch_deps_via_gradle!: () -> void
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring aims to make the `Runners::Java` class and its test class a bit readable.

- Remove `Runners::Java#jvm_deps_dir`.
- Refactor the unit test.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
