### PR TITLE
Fix unstable test and Ruby warning

### DIFF
--- a/lib/runners/nodejs.rb
+++ b/lib/runners/nodejs.rb
@@ -12,6 +12,9 @@ module Runners
 
     PACKAGE_JSON = "package.json".freeze
 
+    # This is actually private. Do not use it out of this class.
+    attr_accessor :nodejs_force_default_version
+
     # Return the locally installed analyzer command.
     def nodejs_analyzer_local_command
       File.join("node_modules", ".bin", analyzer_bin)
@@ -86,7 +89,7 @@ module Runners
 
       case
       when !all_npm_deps_statisfied_constraint?(installed_deps, constraints)
-        @nodejs_force_default_version = true
+        self.nodejs_force_default_version = true
         trace_writer.message "All constraints are not satisfied. The default version `#{analyzer_version}` will be used instead."
       when nodejs_analyzer_locally_installed?
         trace_writer.message "`#{nodejs_analyzer_local_command}` was successfully installed with the version `#{analyzer_version}`."
@@ -103,7 +106,7 @@ module Runners
     private
 
     def nodejs_use_local_version?
-      !@nodejs_force_default_version && nodejs_analyzer_locally_installed?
+      !nodejs_force_default_version && nodejs_analyzer_locally_installed?
     end
 
     def nodejs_analyzer_locally_installed?

--- a/sig/runners/nodejs.rbs
+++ b/sig/runners/nodejs.rbs
@@ -21,6 +21,8 @@ module Runners
 
     PACKAGE_JSON: String
 
+    attr_accessor nodejs_force_default_version: bool
+
     def nodejs_analyzer_local_command: () -> String
 
     def nodejs_analyzer_bin: () -> String

--- a/test/java_test.rb
+++ b/test/java_test.rb
@@ -98,17 +98,19 @@ class JavaTest < Minitest::Test
 
   private
 
-  TestProcessor = Class.new(Runners::Processor) do
-    include Runners::Java
-    def self.analyzer_id; :checkstyle; end
-    def analyzer_name; "Checkstyle"; end
-    def fetch_deps_via_gradle!
-      # noop
+  def processor_class
+    @processor_class ||= Class.new(Runners::Processor) do
+      include Runners::Java
+      def self.analyzer_id; :checkstyle; end
+      def analyzer_name; "Checkstyle"; end
+      def fetch_deps_via_gradle!
+        # noop
+      end
     end
   end
 
   def new_processor(workspace, config_yaml:)
-    TestProcessor.new(
+    processor_class.new(
       guid: "test-guid",
       working_dir: workspace.working_dir,
       config: config(config_yaml),


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to fix the following error and warning:

- `ConfigGeneratorTest#test_generate_with_tools [/home/runner/work/runners/runners/test/config_generator_test.rb:24]`
- `.../lib/runners/nodejs.rb:106: warning: instance variable @nodejs_force_default_version not initialized`

See <https://github.com/sider/runners/runs/2182668135>

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
