### PR TITLE
Add number of warnings to finish message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Updated tools:
 Misc:
 
 - Loosen unsatisfied constraints for npm packages [#2171](https://github.com/sider/runners/pull/2171)
-- Improve analysis finish message [#2187](https://github.com/sider/runners/pull/2187)
+- Improve analysis finish message [#2187](https://github.com/sider/runners/pull/2187) [#2232](https://github.com/sider/runners/pull/2232)
 - **ESLint** Provide new recommended configuration [#2165](https://github.com/sider/runners/pull/2165)
 - **ESLint** Use `--no-error-on-unmatched-pattern` if possible [#2199](https://github.com/sider/runners/pull/2199)
 - Simplify `sider.yml` schema [#2192](https://github.com/sider/runners/pull/2192)

--- a/lib/runners/cli.rb
+++ b/lib/runners/cli.rb
@@ -84,7 +84,7 @@ module Runners
       result.tap do
         finished_at = Time.now
         trace_writer.header "Finish analysis"
-        trace_writer.message finish_message(result)
+        trace_writer.message finish_message(result, warnings)
         trace_writer.message "Finished at #{finished_at.utc}"
         trace_writer.message "Elapsed time: #{format_duration(finished_at - started_at)}"
         trace_writer.finish started_at: started_at, finished_at: finished_at
@@ -134,19 +134,12 @@ module Runners
       @io ||= options.io
     end
 
-    def finish_message(result)
+    def finish_message(result, warnings)
       analyzer_name = result.analyzer&.name
 
       case result
       when Results::Success
-        issues_message = if result.issues.empty?
-                           "No issues found."
-                         else
-                           issue_count = result.issues.size
-                           issues_text = issue_count == 1 ? "issue" : "issues"
-                           "#{issue_count} #{issues_text} found."
-                         end
-        "#{analyzer_name} analysis succeeded. #{issues_message}"
+        "#{analyzer_name} analysis succeeded: #{result.issues.size} issues, #{warnings.size} warnings"
       else
         analyzer_name ? "#{analyzer_name} analysis failed." : "Analysis failed."
       end

--- a/sig/runners/cli.rbs
+++ b/sig/runners/cli.rbs
@@ -23,7 +23,7 @@ module Runners
 
     def io: () -> Runners::IO
 
-    def finish_message: (result) -> String
+    def finish_message: (result, Warnings) -> String
 
     def format_duration: (Float) -> String
   end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -50,7 +50,7 @@ class CLITest < Minitest::Test
     assert_equal ["Start analysis", "Set up source code", "Set up RuboCop", "Run RuboCop", "Finish analysis"],
                  traces.filter_map { _1[:message] if _1[:trace] == "header" }
     assert_includes traces.filter_map { _1[:message] if _1[:trace] == 'message' },
-                    "RuboCop analysis succeeded. No issues found."
+                    "RuboCop analysis succeeded: 0 issues, 1 warnings"
   end
 
   def test_run_with_one_issue
@@ -64,7 +64,7 @@ class CLITest < Minitest::Test
     cli.stub(:processor_class, klass) { cli.run }
 
     assert_includes traces.filter_map { _1[:message] if _1[:trace] == 'message' },
-                    "RuboCop analysis succeeded. 1 issue found."
+                    "RuboCop analysis succeeded: 1 issues, 0 warnings"
   end
 
   def test_run_with_multiple_issues
@@ -78,7 +78,7 @@ class CLITest < Minitest::Test
     cli.stub(:processor_class, klass) { cli.run }
 
     assert_includes traces.filter_map { _1[:message] if _1[:trace] == 'message' },
-                    "RuboCop analysis succeeded. 2 issues found."
+                    "RuboCop analysis succeeded: 2 issues, 0 warnings"
   end
 
   def test_run_with_error


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change adds the number of warnings to the finish message.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Follow-up of #2187

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
