### PR TITLE
[ESLint] Allow strings for `ext` and `global` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Misc:
 - **remark-lint** Use `.git` directory and add `remark-validate-links` to default ruleset [#2224](https://github.com/sider/runners/pull/2224)
 - Introduce common option `linter.<id>.dependencies` [#2211](https://github.com/sider/runners/pull/2211)
 - **Metrics File Info** Report the number of commits, additions, deletions used to measure code churn [#2184](https://github.com/sider/runners/pull/2184)
+- **ESLint** Allow strings for ext and global options [#2236](https://github.com/sider/runners/pull/2236)
 
 ## 0.45.0
 

--- a/lib/runners/processor/eslint.rb
+++ b/lib/runners/processor/eslint.rb
@@ -9,12 +9,12 @@ module Runners
       let :config, npm(
         target: target,
         dir: target, # deprecated
-        ext: string?,
+        ext: one_or_more_strings?,
         config: string?,
         'ignore-path': string?,
         'ignore-pattern': one_or_more_strings?,
         'no-ignore': boolean?,
-        global: string?,
+        global: one_or_more_strings?,
         quiet: boolean?,
       )
 
@@ -48,12 +48,12 @@ module Runners
         target:
           - src/
           - lib/
-        ext: ".js,.jsx"
+        ext: [.js, .jsx]
         config: config/.eslintrc.js
         ignore-path: config/.eslintignore
         ignore-pattern: "vendor/**"
         no-ignore: true
-        global: "require,exports:true"
+        global: ["require", "exports:true"]
         quiet: true
       YAML
     end
@@ -87,7 +87,7 @@ module Runners
     end
 
     def ext
-      ext = config_linter[:ext]
+      ext = comma_separated_list(config_linter[:ext])
       ext ? ["--ext", ext] : []
     end
 
@@ -107,7 +107,7 @@ module Runners
     end
 
     def global
-      global = config_linter[:global]
+      global = comma_separated_list(config_linter[:global])
       global ? ["--global", global] : []
     end
 

--- a/test/data/test_generate_with_tools.yml
+++ b/test/data/test_generate_with_tools.yml
@@ -109,12 +109,12 @@ linter:
 #     target:
 #       - src/
 #       - lib/
-#     ext: ".js,.jsx"
+#     ext: [.js, .jsx]
 #     config: config/.eslintrc.js
 #     ignore-path: config/.eslintignore
 #     ignore-pattern: "vendor/**"
 #     no-ignore: true
-#     global: "require,exports:true"
+#     global: ["require", "exports:true"]
 #     quiet: true
 
 #   # Flake8 example. See https://help.sider.review/tools/python/flake8

--- a/test/smokes/eslint/expectations.rb
+++ b/test/smokes/eslint/expectations.rb
@@ -571,3 +571,22 @@ s.add_test(
   issues: [],
   analyzer: { name: "ESLint", version: "7.21.0" }
 )
+
+s.add_test(
+  "option_global",
+  type: "success",
+  issues: [
+    {
+      id: "no-undef",
+      message: "'unknown' is not defined.",
+      links: %w[https://eslint.org/docs/rules/no-undef],
+      path: "foo.js",
+      location: { start_line: 3, start_column: 1, end_line: 3, end_column: 8 },
+      object: { severity: "error", category: "Variables", recommended: true },
+      git_blame_info: {
+        commit: :_, line_hash: "ad0c28a04d30c0f5a968852042a892ccc53b4984", original_line: 3, final_line: 3
+      }
+    }
+  ],
+  analyzer: { name: "ESLint", version: default_version }
+)

--- a/test/smokes/eslint/option_global/.eslintrc.json
+++ b/test/smokes/eslint/option_global/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-undef": "error"
+  }
+}

--- a/test/smokes/eslint/option_global/foo.js
+++ b/test/smokes/eslint/option_global/foo.js
@@ -1,0 +1,4 @@
+hi;
+hi = 1;
+unknown;
+exports = "";

--- a/test/smokes/eslint/option_global/sider.yml
+++ b/test/smokes/eslint/option_global/sider.yml
@@ -1,0 +1,5 @@
+linter:
+  eslint:
+    global:
+      - hi
+      - "exports:true"

--- a/test/smokes/eslint/sider_config/sideci.yml
+++ b/test/smokes/eslint/sider_config/sideci.yml
@@ -3,7 +3,7 @@ linter:
     npm_install: true
     dir: src/
     config: .myeslintrc.yml
-    ext: 'js,jsx'
+    ext: [.js, .jsx]
     ignore-pattern: /src/*
     ignore-path: .gitignore
     no-ignore: true


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change allows not only a string but also strings for the `ext` and `global` options.

See also:
- https://eslint.org/docs/user-guide/command-line-interface#-ext
- https://eslint.org/docs/user-guide/command-line-interface#-global

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

See also #2192

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
