### PR TITLE
Do not use deprecated options for config example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Misc:
 - Do not use tmpdir for working directory [#2217](https://github.com/sider/runners/pull/2217)
 - `Runners::Config` check warnings [#2221](https://github.com/sider/runners/pull/2221)
 - **remark-lint** Use `.git` directory and add `remark-validate-links` to default ruleset [#2224](https://github.com/sider/runners/pull/2224)
-- Introduce common option `linter.<id>.dependencies` [#2211](https://github.com/sider/runners/pull/2211)
+- Introduce common option `linter.<id>.dependencies` [#2211](https://github.com/sider/runners/pull/2211) [#2263](https://github.com/sider/runners/pull/2263)
 - **Metrics File Info** Report the number of commits, additions, deletions used to measure code churn [#2184](https://github.com/sider/runners/pull/2184)
 - **ESLint** Allow strings for ext and global options [#2236](https://github.com/sider/runners/pull/2236)
 

--- a/lib/runners/processor/checkstyle.rb
+++ b/lib/runners/processor/checkstyle.rb
@@ -31,8 +31,8 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
-        jvm_deps:
-          - [com.github.sevntu-checkstyle, sevntu-checks, 1.37.1]
+        dependencies:
+          - "my.company.com:checkstyle-rules:1.0.0"
         config: custom-checkstyle.xml
         target: src/
         exclude: vendor/

--- a/lib/runners/processor/clang_tidy.rb
+++ b/lib/runners/processor/clang_tidy.rb
@@ -18,7 +18,7 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
-        apt:
+        dependencies:
           - libgdbm-dev
           - libfastjson-dev=0.99.8-2
         include-path:

--- a/lib/runners/processor/detekt.rb
+++ b/lib/runners/processor/detekt.rb
@@ -29,8 +29,8 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
-        jvm_deps:
-          - [com.example, detekt-rules, 1.0.0]
+        dependencies:
+          - "com.example:detekt-rules:1.0.0"
         baseline: config/detekt-baseline.xml
         config:
           - config/detekt-config.yml

--- a/lib/runners/processor/ktlint.rb
+++ b/lib/runners/processor/ktlint.rb
@@ -20,8 +20,8 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
-        jvm_deps:
-          - [my.company.com, ktlint-rules, 1.0.0]
+        dependencies:
+          - "my.company.com:ktlint-rules:1.0.0"
         target:
           - "src/**/*.kt"
           - "!src/**/*Test.kt"

--- a/lib/runners/processor/pmd_java.rb
+++ b/lib/runners/processor/pmd_java.rb
@@ -28,8 +28,8 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
-        jvm_deps:
-          - [my.company.com, pmd-ruleset, 1.2.3]
+        dependencies:
+          - "my.company.com:pmd-ruleset:1.2.3"
         target: src/
         rulesets:
           - category/java/errorprone.xml

--- a/test/data/test_generate_with_tools.yml
+++ b/test/data/test_generate_with_tools.yml
@@ -15,8 +15,8 @@ linter:
 #   # Checkstyle example. See https://help.sider.review/tools/java/checkstyle
 #   checkstyle:
 #     root_dir: project/
-#     jvm_deps:
-#       - [com.github.sevntu-checkstyle, sevntu-checks, 1.37.1]
+#     dependencies:
+#       - "my.company.com:checkstyle-rules:1.0.0"
 #     config: custom-checkstyle.xml
 #     target: src/
 #     exclude: vendor/
@@ -26,7 +26,7 @@ linter:
 #   # Clang-Tidy example. See https://help.sider.review/tools/cplusplus/clang-tidy
 #   clang_tidy:
 #     root_dir: project/
-#     apt:
+#     dependencies:
 #       - libgdbm-dev
 #       - libfastjson-dev=0.99.8-2
 #     include-path:
@@ -83,8 +83,8 @@ linter:
 #   # detekt example. See https://help.sider.review/tools/kotlin/detekt
 #   detekt:
 #     root_dir: project/
-#     jvm_deps:
-#       - [com.example, detekt-rules, 1.0.0]
+#     dependencies:
+#       - "com.example:detekt-rules:1.0.0"
 #     baseline: config/detekt-baseline.xml
 #     config:
 #       - config/detekt-config.yml
@@ -209,8 +209,8 @@ linter:
 #   # ktlint example. See https://help.sider.review/tools/kotlin/ktlint
 #   ktlint:
 #     root_dir: project/
-#     jvm_deps:
-#       - [my.company.com, ktlint-rules, 1.0.0]
+#     dependencies:
+#       - "my.company.com:ktlint-rules:1.0.0"
 #     target:
 #       - "src/**/*.kt"
 #       - "!src/**/*Test.kt"
@@ -289,8 +289,8 @@ linter:
 #   # PMD Java example. See https://help.sider.review/tools/java/pmd
 #   pmd_java:
 #     root_dir: project/
-#     jvm_deps:
-#       - [my.company.com, pmd-ruleset, 1.2.3]
+#     dependencies:
+#       - "my.company.com:pmd-ruleset:1.2.3"
 #     target: src/
 #     rulesets:
 #       - category/java/errorprone.xml


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to fix bugs that use the deprecated options in the `Processor.config_example` method.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Follow-up of #2211

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
