### PR TITLE
Prefer `dependencies` option over `gems` for config example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Misc:
 - Do not use tmpdir for working directory [#2217](https://github.com/sider/runners/pull/2217)
 - `Runners::Config` check warnings [#2221](https://github.com/sider/runners/pull/2221)
 - **remark-lint** Use `.git` directory and add `remark-validate-links` to default ruleset [#2224](https://github.com/sider/runners/pull/2224)
-- Introduce common option `linter.<id>.dependencies` [#2211](https://github.com/sider/runners/pull/2211) [#2263](https://github.com/sider/runners/pull/2263)
+- Introduce common option `linter.<id>.dependencies` [#2211](https://github.com/sider/runners/pull/2211) [#2263](https://github.com/sider/runners/pull/2263) [#2264](https://github.com/sider/runners/pull/2264)
 - **Metrics File Info** Report the number of commits, additions, deletions used to measure code churn [#2184](https://github.com/sider/runners/pull/2184)
 - **ESLint** Allow strings for ext and global options [#2236](https://github.com/sider/runners/pull/2236)
 

--- a/lib/runners/processor/brakeman.rb
+++ b/lib/runners/processor/brakeman.rb
@@ -23,8 +23,8 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
-        gems:
-          - { name: "brakeman", version: "< 6" }
+        dependencies:
+          - { name: "brakeman", version: "5.0.0" }
       YAML
     end
 

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -39,8 +39,8 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
-        gems:
-          - { name: rubocop, version: 1.0.0 }
+        dependencies:
+          - { name: "rubocop", version: "1.0.0" }
         target: [app/, lib/]
         include_linter:
           - EmptyScript

--- a/lib/runners/processor/querly.rb
+++ b/lib/runners/processor/querly.rb
@@ -36,8 +36,8 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
-        gems:
-          - { name: "querly", version: "< 2" }
+        dependencies:
+          - { name: "querly", version: "1.2.0" }
         config: config/querly.yml
       YAML
     end

--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -37,8 +37,8 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
-        gems:
-          - { name: "rails_best_practices", version: "< 2" }
+        dependencies:
+          - { name: "rails_best_practices", version: "1.20.0" }
         vendor: false
         spec: true
         test: true

--- a/lib/runners/processor/reek.rb
+++ b/lib/runners/processor/reek.rb
@@ -24,8 +24,8 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
-        gems:
-          - { name: "reek", version: "< 6" }
+        dependencies:
+          - { name: "reek", version: "6.0.0" }
         target: [lib/, test/]
         config: config/reek.yml
       YAML

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -29,9 +29,9 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
-        gems:
+        dependencies:
           - rubocop-rails
-          - { name: rubocop-rspec, version: 2.1.0 }
+          - { name: "rubocop-rspec", version: "2.1.0" }
         config: config/.rubocop.yml
         safe: true
       YAML

--- a/lib/runners/processor/slim_lint.rb
+++ b/lib/runners/processor/slim_lint.rb
@@ -31,8 +31,8 @@ module Runners
     def self.config_example
       <<~'YAML'
         root_dir: project/
-        gems:
-          - { name: rubocop, version: 1.0.0 }
+        dependencies:
+          - { name: "rubocop", version: "1.0.0" }
         target: [app/views/]
         config: config/.slim-lint.yml
       YAML

--- a/test/data/test_generate_with_tools.yml
+++ b/test/data/test_generate_with_tools.yml
@@ -9,8 +9,8 @@ linter:
 #   # Brakeman example. See https://help.sider.review/tools/ruby/brakeman
 #   brakeman:
 #     root_dir: project/
-#     gems:
-#       - { name: "brakeman", version: "< 6" }
+#     dependencies:
+#       - { name: "brakeman", version: "5.0.0" }
 
 #   # Checkstyle example. See https://help.sider.review/tools/java/checkstyle
 #   checkstyle:
@@ -181,8 +181,8 @@ linter:
 #   # HAML-Lint example. See https://help.sider.review/tools/ruby/haml-lint
 #   haml_lint:
 #     root_dir: project/
-#     gems:
-#       - { name: rubocop, version: 1.0.0 }
+#     dependencies:
+#       - { name: "rubocop", version: "1.0.0" }
 #     target: [app/, lib/]
 #     include_linter:
 #       - EmptyScript
@@ -313,15 +313,15 @@ linter:
 #   # Querly example. See https://help.sider.review/tools/ruby/querly
 #   querly:
 #     root_dir: project/
-#     gems:
-#       - { name: "querly", version: "< 2" }
+#     dependencies:
+#       - { name: "querly", version: "1.2.0" }
 #     config: config/querly.yml
 
 #   # Rails Best Practices example. See https://help.sider.review/tools/ruby/rails-best-practices
 #   rails_best_practices:
 #     root_dir: project/
-#     gems:
-#       - { name: "rails_best_practices", version: "< 2" }
+#     dependencies:
+#       - { name: "rails_best_practices", version: "1.20.0" }
 #     vendor: false
 #     spec: true
 #     test: true
@@ -333,8 +333,8 @@ linter:
 #   # Reek example. See https://help.sider.review/tools/ruby/reek
 #   reek:
 #     root_dir: project/
-#     gems:
-#       - { name: "reek", version: "< 6" }
+#     dependencies:
+#       - { name: "reek", version: "6.0.0" }
 #     target: [lib/, test/]
 #     config: config/reek.yml
 
@@ -355,9 +355,9 @@ linter:
 #   # RuboCop example. See https://help.sider.review/tools/ruby/rubocop
 #   rubocop:
 #     root_dir: project/
-#     gems:
+#     dependencies:
 #       - rubocop-rails
-#       - { name: rubocop-rspec, version: 2.1.0 }
+#       - { name: "rubocop-rspec", version: "2.1.0" }
 #     config: config/.rubocop.yml
 #     safe: true
 
@@ -377,8 +377,8 @@ linter:
 #   # Slim-Lint example. See https://help.sider.review/tools/ruby/slim-lint
 #   slim_lint:
 #     root_dir: project/
-#     gems:
-#       - { name: rubocop, version: 1.0.0 }
+#     dependencies:
+#       - { name: "rubocop", version: "1.0.0" }
 #     target: [app/views/]
 #     config: config/.slim-lint.yml
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

`linter.<id>.dependencies` option is preferable because `gems` is an alias. See below:

https://github.com/sider/runners/blob/43e3508eac04c1d7a2de914a59e0950c316e749a/lib/runners/schema/config.rb#L35-L36

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Follow-up of #2211

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
