### PR TITLE
[Actions] Replace `softprops/action-gh-release` with `gh release`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,6 @@ jobs:
       - uses: actions/checkout@v2
       - run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
         id: get_tag
-      - uses: softprops/action-gh-release@v1
-        with:
-          body: |
-            See the [changelog](https://github.com/${{ github.repository }}/blob/${{ steps.get_tag.outputs.tag }}/CHANGELOG.md) for more details.
+      - run: gh release create '${{ steps.get_tag.outputs.tag }}' --notes 'See the [changelog](https://github.com/${{ github.repository }}/blob/${{ steps.get_tag.outputs.tag }}/CHANGELOG.md) for more details.'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change replaces the third-party action with the built-in `gh` command.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

See sider/devon_rex#485

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
