### PR TITLE
[Metrics_CodeClone] Fix NoMethodError in `Runners::Processor::MetricsCodeClone#initialize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.46.0...HEAD)
 
+- **Metrics Code Clone** Fix NoMethodError in `Runners::Processor::MetricsCodeClone#initialize` [#2277](https://github.com/sider/runners/pull/2277)
+
 ## 0.46.0
 
 [Full diff](https://github.com/sider/runners/compare/0.45.0...0.46.0)

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -51,6 +51,7 @@ module Runners
             processor.in_root_dir do
               trace_writer.header "Set up #{processor.analyzer_name}"
 
+              processor.validate_config
               processor.check_unsupported_linters
               processor.show_runtime_versions
 

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -37,7 +37,9 @@ module Runners
       @shell = shell
       @trace_writer = trace_writer
       @warnings = Warnings.new(trace_writer: trace_writer)
+    end
 
+    def validate_config
       if config.path_exist?
         trace_writer.ci_config(config.content, raw_content: config.raw_content!, file: config.path_name)
 

--- a/lib/runners/processor/metrics_codeclone.rb
+++ b/lib/runners/processor/metrics_codeclone.rb
@@ -13,6 +13,7 @@ module Runners
     end
 
     def_delegators :@pmd_cpd,
+      :add_warning,
       :warnings,
       :config_linter,
       :analyzer_bin,

--- a/sig/runners/processor.rbs
+++ b/sig/runners/processor.rbs
@@ -28,6 +28,8 @@ module Runners
     def capture3_with_retry!: (String, *Shell::command_argument, ?tries: Integer, ?sleep: ^(Numeric) -> Numeric) -> [String, String]
     def capture3_trace: (String, *Shell::command_argument, **untyped) -> [String, String, Process::Status]
 
+    def validate_config: () -> void
+
     def relative_path: (String | Pathname, ?from: Pathname) -> Pathname
 
     def check_unsupported_linters: () -> void

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -150,10 +150,10 @@
   diagnostics:
   - range:
       start:
-        line: 117
+        line: 119
         character: 26
       end:
-        line: 117
+        line: 119
         character: 29
     severity: ERROR
     message: |-
@@ -165,10 +165,10 @@
     code: Ruby::ArgumentTypeMismatch
   - range:
       start:
-        line: 117
+        line: 119
         character: 31
       end:
-        line: 117
+        line: 119
         character: 40
     severity: ERROR
     message: |-
@@ -183,10 +183,10 @@
     code: Ruby::ArgumentTypeMismatch
   - range:
       start:
-        line: 249
+        line: 251
         character: 45
       end:
-        line: 249
+        line: 251
         character: 50
     severity: ERROR
     message: Type `(::String | ::Array[::String] | nil)` does not have method `split`

--- a/test/java_test.rb
+++ b/test/java_test.rb
@@ -85,7 +85,7 @@ class JavaTest < Minitest::Test
   def test_invalid_config
     with_workspace do |workspace|
       error = assert_raises Runners::Config::InvalidConfiguration do
-        new_processor workspace, config_yaml: <<~YAML
+        new_processor(workspace, config_yaml: <<~YAML).validate_config
           linter:
             checkstyle:
               jvm_deps:

--- a/test/smokes/metrics_codeclone/config_warnings/sider.yml
+++ b/test/smokes/metrics_codeclone/config_warnings/sider.yml
@@ -1,0 +1,3 @@
+linter:
+  eslint:
+    dir: "src/"

--- a/test/smokes/metrics_codeclone/expectations.rb
+++ b/test/smokes/metrics_codeclone/expectations.rb
@@ -678,3 +678,11 @@ s.add_test(
   message: "`src` directory is not found! Please check `linter.pmd_cpd.root_dir` in your `sider.yml`",
   analyzer: :_
 )
+
+s.add_test(
+  "config_warnings",
+  type: "success",
+  issues: [],
+  warnings: [{ message: /`linter.eslint.dir`/, file: "sider.yml" }],
+  analyzer: { name: "Metrics Code Clone", version: default_version }
+)


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to fix the error below:

```
gems/forwardable-1.3.2/lib/forwardable.rb:236:in `warnings': undefined method `warnings' for nil:NilClass (NoMethodError)
    from /home/analyzer_runner/runners/lib/runners/processor.rb:177:in `add_warning'
    from /home/analyzer_runner/runners/lib/runners/processor.rb:45:in `block in initialize'
    from /home/analyzer_runner/runners/lib/runners/warnings.rb:41:in `each'
    from /home/analyzer_runner/runners/lib/runners/warnings.rb:41:in `each'
    from /home/analyzer_runner/runners/lib/runners/processor.rb:45:in `initialize'
    from /home/analyzer_runner/runners/lib/runners/processor/metrics_codeclone.rb:26:in `initialize'
    from /home/analyzer_runner/runners/lib/runners/harness.rb:45:in `new'
    from /home/analyzer_runner/runners/lib/runners/harness.rb:45:in `block (2 levels) in run'
    from /home/analyzer_runner/runners/lib/runners/workspace.rb:34:in `block in open'
    from /home/analyzer_runner/runners/lib/runners/workspace.rb:81:in `prepare_ssh'
    from /home/analyzer_runner/runners/lib/runners/workspace.rb:19:in `open'
    from /home/analyzer_runner/runners/lib/runners/harness.rb:34:in `block in run'
    from /home/analyzer_runner/runners/lib/runners/harness.rb:96:in `ensure_result'
    from /home/analyzer_runner/runners/lib/runners/harness.rb:32:in `run'
    from /home/analyzer_runner/runners/lib/runners/cli.rb:69:in `run'
    from /home/analyzer_runner/runners/exe/runners:25:in `<main>'
```

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
