### PR TITLE
Refactor `Runners::Schema::Config` class

### DIFF
--- a/lib/runners/schema/config.rb
+++ b/lib/runners/schema/config.rb
@@ -15,6 +15,10 @@ module Runners
         object(name: string, version: string, **fields)
       end
 
+      def dependencies
+        array?(enum(string, dependency))
+      end
+
       def base(**fields)
         object(root_dir: string?, **fields)
       end
@@ -25,22 +29,22 @@ module Runners
           object(repo: string, tag: string),
           object(repo: string, ref: string),
         )
-        dependencies = array?(enum(
+        ruby_deps = array?(enum(
           string,
           dependency(source: string?),
           object(name: string, git: git),
         ))
 
         base(
-          dependencies: dependencies,
-          gems: dependencies, # alias
+          dependencies: ruby_deps,
+          gems: ruby_deps, # alias
           **fields,
         )
       end
 
       def cplusplus(**fields)
         base(
-          dependencies: array?(enum(string, dependency)),
+          dependencies: dependencies,
           apt: one_or_more_strings?, # deprecated
           'include-path': one_or_more_strings?,
           **fields,
@@ -49,7 +53,7 @@ module Runners
 
       def npm(**fields)
         base(
-          dependencies: array?(enum(string, dependency)),
+          dependencies: dependencies,
           npm_install: enum?(boolean, literal('development'), literal('production')),
           **fields,
         )
@@ -57,7 +61,7 @@ module Runners
 
       def java(**fields)
         base(
-          dependencies: array?(enum(string, dependency)),
+          dependencies: dependencies,
           jvm_deps: array?(array(enum(string, number))), # deprecated
           **fields,
         )

--- a/sig/runners/schema/config.rbs
+++ b/sig/runners/schema/config.rbs
@@ -6,6 +6,7 @@ module Runners
       def one_or_more_strings?: () -> StrongJSON::Type::Optional[untyped]
       def target: () -> StrongJSON::Type::Optional[untyped]
       def dependency: (**untyped) -> StrongJSON::Type::Object[untyped]
+      def dependencies: () -> StrongJSON::Type::Optional[untyped]
       def base: (**untyped) -> StrongJSON::Type::Object[untyped]
       def ruby: (**untyped) -> StrongJSON::Type::Object[untyped]
       def cplusplus: (**untyped) -> StrongJSON::Type::Object[untyped]


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This refactoring aims to reduce duplication in the `Runners::Schema::Config` class.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
