### PR TITLE
Support `linter.<id>.dependencies` for Python tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.46.1...HEAD)
 
+- Support `linter.<id>.dependencies` for Python tools [#2280](https://github.com/sider/runners/pull/2280)
+
 ## 0.46.1
 
 [Full diff](https://github.com/sider/runners/compare/0.46.0...0.46.1)

--- a/lib/runners/python.rb
+++ b/lib/runners/python.rb
@@ -13,6 +13,7 @@ module Runners
     def pip_install(dependencies = Array(config_linter[:dependencies]))
       return if dependencies.empty?
 
+      # @type var dependencies: Array[String | { name: String, version: String }]
       deps = dependencies.map do |dep|
         case dep
         when Hash

--- a/lib/runners/python.rb
+++ b/lib/runners/python.rb
@@ -10,19 +10,28 @@ module Runners
 
     # @see https://pip.pypa.io/en/stable/reference/pip_install
     # @see https://pip.pypa.io/en/stable/reference/pip_list
-    def pip_install(*packages)
-      unless packages.empty?
-        options = %w[--disable-pip-version-check]
+    def pip_install(dependencies = Array(config_linter[:dependencies]))
+      return if dependencies.empty?
 
-        begin
-          # NOTE: Use `--only-binary` to prevent malicious dependency's code execution.
-          capture3! "pip", "install", "--quiet", "--only-binary", ":all:", *options, *packages
-        rescue Runners::Shell::ExecError
-          raise PipInstallFailed, "Install failed: #{packages.join(', ')}"
+      deps = dependencies.map do |dep|
+        case dep
+        when Hash
+          dep.fetch(:name) + dep.fetch(:version)
+        else
+          dep
         end
-
-        capture3! "pip", "list", "--verbose", *options
       end
+
+      options = %w[--disable-pip-version-check]
+      begin
+        # NOTE: Use `--only-binary` to prevent malicious dependency's code execution.
+        capture3! "pip", "install", "--quiet", "--only-binary", ":all:", *options, *deps
+      rescue Runners::Shell::ExecError
+        msg = deps.map { |dep| "`#{dep}`" }.join(", ")
+        raise PipInstallFailed, "`pip install` failed: #{msg}"
+      end
+
+      capture3! "pip", "list", "--verbose", *options
     end
   end
 end

--- a/lib/runners/schema/config.rb
+++ b/lib/runners/schema/config.rb
@@ -66,6 +66,13 @@ module Runners
           **fields,
         )
       end
+
+      def python(**fields)
+        base(
+          dependencies: dependencies,
+          **fields,
+        )
+      end
     end
 
     Config = _ = StrongJSON.new do

--- a/sig/runners/processor/flake8.rbs
+++ b/sig/runners/processor/flake8.rbs
@@ -17,8 +17,6 @@ module Runners
 
     def prepare_config: () -> void
 
-    def prepare_plugins: () -> void
-
     def parse_result: (String) -> Array[Issue]
   end
 end

--- a/sig/runners/python.rbs
+++ b/sig/runners/python.rbs
@@ -3,6 +3,6 @@ module Runners
     class PipInstallFailed < UserError
     end
 
-    def pip_install: (*String) -> void
+    def pip_install: (?Array[String]) -> void
   end
 end

--- a/sig/runners/schema/config.rbs
+++ b/sig/runners/schema/config.rbs
@@ -12,6 +12,7 @@ module Runners
       def cplusplus: (**untyped) -> StrongJSON::Type::Object[untyped]
       def npm: (**untyped) -> StrongJSON::Type::Object[untyped]
       def java: (**untyped) -> StrongJSON::Type::Object[untyped]
+      def python: (**untyped) -> StrongJSON::Type::Object[untyped]
     end
 
     class ConfigClass < StrongJSON

--- a/test/data/test_generate_with_tools.yml
+++ b/test/data/test_generate_with_tools.yml
@@ -120,13 +120,13 @@ linter:
 #   # Flake8 example. See https://help.sider.review/tools/python/flake8
 #   flake8:
 #     root_dir: project/
+#     dependencies:
+#       - flake8-bugbear
+#       - flake8-builtins==1.4.1
+#       - git+https://github.com/PyCQA/flake8-import-order.git@51e16f33065512afa1a85a20b2c2d3be768f78ea
+#       - { name: "flake8-docstrings", version: "==1.6.0" }
 #     target: src/
 #     config: config/.flake8
-#     plugins:
-#       - flake8-bandit
-#       - flake8-builtins==1.4.1
-#       - flake8-docstrings>=1.4.0
-#       - git+https://github.com/PyCQA/flake8-import-order.git@51e16f33065512afa1a85a20b2c2d3be768f78ea
 #     parallel: false
 
 #   # FxCop example. See https://help.sider.review/tools/csharp/fxcop

--- a/test/python_test.rb
+++ b/test/python_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+class PythonTest < Minitest::Test
+  include TestHelper
+
+  def test_pip_install
+    with_workspace do |workspace|
+      processor = new_processor(workspace, yaml: <<~YAML)
+        linter:
+          flake8:
+            dependencies:
+              - flake8-bugbear
+              - flake8-builtins==1.4.1
+              - git+https://github.com/PyCQA/flake8-import-order.git@51e16f33065512afa1a85a20b2c2d3be768f78ea
+              - { name: "flake8-docstrings", version: "==1.6.0" }
+      YAML
+
+      args_list = []
+      processor.stub :capture3!, ->(*args) { args_list << args } do
+        processor.pip_install
+      end
+      assert_equal [%w[pip install --quiet --only-binary :all: --disable-pip-version-check flake8-bugbear flake8-builtins==1.4.1 git+https://github.com/PyCQA/flake8-import-order.git@51e16f33065512afa1a85a20b2c2d3be768f78ea flake8-docstrings==1.6.0],
+                    %w[pip list --verbose --disable-pip-version-check]],
+                   args_list
+    end
+  end
+
+  def test_pip_install_failure
+    with_workspace do |workspace|
+      processor = new_processor(workspace)
+
+      exec_error = begin
+        processor.capture3! "rmdir", "unknown dir"
+      rescue => exn
+        exn
+      end
+
+      error = assert_raises Runners::Python::PipInstallFailed do
+        processor.stub :capture3!, ->(*) { raise exec_error } do
+          processor.pip_install ["foo", "bar"]
+        end
+      end
+      assert_equal "`pip install` failed: `foo`, `bar`", error.message
+    end
+  end
+
+  private
+
+  def processor_class
+    @processor_class ||= Class.new(Runners::Processor) do
+      include Runners::Python
+
+      def analyzer_id; :flake8; end
+      def analyzer_bin; "flake8"; end
+      def analyzer_name; "Flake8"; end
+    end
+  end
+
+  def trace_writer
+    @trace_writer ||= new_trace_writer
+  end
+
+  def new_processor(workspace, yaml: "")
+    processor_class.new(
+      guid: "test-guid",
+      working_dir: workspace.working_dir,
+      config: config(yaml),
+      shell: Runners::Shell.new(current_dir: workspace.working_dir, trace_writer: trace_writer),
+      trace_writer: trace_writer,
+    )
+  end
+end

--- a/test/smokes/flake8/broken_sideci_yml/sideci.yml
+++ b/test/smokes/flake8/broken_sideci_yml/sideci.yml
@@ -2,4 +2,4 @@ linter:
   flake8:
     plugins:
       - name: 'flake8-builtins'
-        version: '1.4.1'
+        ver: '1.4.1'

--- a/test/smokes/flake8/expectations.rb
+++ b/test/smokes/flake8/expectations.rb
@@ -202,7 +202,7 @@ s.add_test(
 s.add_test(
   "with_plugins_failed",
   type: "failure",
-  message: "Install failed: mysqlclient==2.0.0, flake8-builtins==1.4.1",
+  message: "`pip install` failed: `mysqlclient==2.0.0`, `flake8-builtins==1.4.1`",
   analyzer: :_
 )
 
@@ -261,7 +261,7 @@ s.add_test(
 s.add_test(
   "broken_sideci_yml",
   type: "failure",
-  message: "`linter.flake8.plugins` value in `sideci.yml` is invalid",
+  message: "`linter.flake8.plugins[0]` value in `sideci.yml` is invalid",
   analyzer: :_
 )
 
@@ -366,6 +366,58 @@ s.add_test(
       object: nil,
       git_blame_info: {
         commit: :_, line_hash: "2195b5c8fadfde3b82ab9aecaf510b7dc1112d91", original_line: 2, final_line: 2
+      }
+    }
+  ],
+  analyzer: { name: "Flake8", version: default_version }
+)
+
+s.add_test(
+  "option_dependencies",
+  type: "success",
+  issues: [
+    {
+      message: '"list" is used as an argument and thus shadows a python builtin, consider renaming the argument',
+      links: [],
+      id: "A002",
+      path: "foo.py",
+      location: { start_line: 5, start_column: 12 },
+      object: nil,
+      git_blame_info: {
+        commit: :_, line_hash: "4be917d92efca2fc5335e7d1d2434ffb3166ebef", original_line: 5, final_line: 5
+      }
+    },
+    {
+      message: "Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.",
+      links: [],
+      id: "B006",
+      path: "foo.py",
+      location: { start_line: 5, start_column: 17 },
+      object: nil,
+      git_blame_info: {
+        commit: :_, line_hash: "4be917d92efca2fc5335e7d1d2434ffb3166ebef", original_line: 5, final_line: 5
+      }
+    },
+    {
+      message: "Missing docstring in public module",
+      links: [],
+      id: "D100",
+      path: "foo.py",
+      location: { start_line: 1, start_column: 1 },
+      object: nil,
+      git_blame_info: {
+        commit: :_, line_hash: "83d8e9e427df3deb280a3b972592bbf4c6fc0816", original_line: 1, final_line: 1
+      }
+    },
+    {
+      message: "Import statements are in the wrong order. 'import math' should be before 'import sys'",
+      links: [],
+      id: "I100",
+      path: "foo.py",
+      location: { start_line: 2, start_column: 1 },
+      object: nil,
+      git_blame_info: {
+        commit: :_, line_hash: "8bd3f84ddc47cd773045286339aceffb22dce4cd", original_line: 2, final_line: 2
       }
     }
   ],

--- a/test/smokes/flake8/option_dependencies/.flake8
+++ b/test/smokes/flake8/option_dependencies/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = F401

--- a/test/smokes/flake8/option_dependencies/foo.py
+++ b/test/smokes/flake8/option_dependencies/foo.py
@@ -1,0 +1,7 @@
+import sys
+import math
+
+
+def add(a, list=[]):
+    """Add."""
+    return a + list

--- a/test/smokes/flake8/option_dependencies/sider.yml
+++ b/test/smokes/flake8/option_dependencies/sider.yml
@@ -1,0 +1,7 @@
+linter:
+  flake8:
+    dependencies:
+      - flake8-bugbear
+      - flake8-builtins==1.4.1
+      - git+https://github.com/PyCQA/flake8-import-order.git@51e16f33065512afa1a85a20b2c2d3be768f78ea
+      - { name: "flake8-docstrings", version: "==1.6.0" }


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- `linter.flake8.plugins` now supports a `{ name: "...", version: "..." }` format
- `linter.flake8.plugins` becomes an alias for `linter.flake8.dependencies`

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Close #2262

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
