### PR TITLE
[RuboCop] Fix smoke test due to Ruby 2.7.3

### DIFF
--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -210,7 +210,12 @@ s.add_test(
 s.add_test(
   "exit2",
   type: "failure",
-  message: "Error: Cops cannot be both enabled by default and disabled by default",
+  message: <<~MSG.strip,
+    warning: parser/current is loading parser/ruby27, which recognizes
+    warning: 2.7.3-compliant syntax, but you are running 2.7.2.
+    warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
+    Error: Cops cannot be both enabled by default and disabled by default
+  MSG
   analyzer: { name: "RuboCop", version: default_version }
 )
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Ruby 2.7.3 has been released on 2021-04-05, but RuboCop does not support the version yet.
See <https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-7-3-released/>

This change fixes just an error message of RuboCop.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
