### PR TITLE
[Slim-Lint] Support Sass by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Misc:
 
 - **ESLint** Re-provide new recommended configuration [#2157](https://github.com/sider/runners/pull/2150)
 - **PMD Java** Provide new recommended configuration [#2296](https://github.com/sider/runners/pull/2296)
+- **Slim-Lint** Support Sass by default [#2297](https://github.com/sider/runners/pull/2297)
 
 ## 0.47.0
 

--- a/lib/runners/processor/slim_lint.rb
+++ b/lib/runners/processor/slim_lint.rb
@@ -28,6 +28,11 @@ module Runners
     DEFAULT_CONFIG_FILE = (Pathname(Dir.home) / "sider_recommended_slim_lint.yml").to_path.freeze
     MISSING_ID = "missing-ID".freeze
 
+    # NOTE: Sass is often used with Slim.
+    OPTIONAL_GEMS = [
+      GemInstaller::Spec.new("sassc"),
+    ].freeze
+
     def self.config_example
       <<~'YAML'
         root_dir: project/
@@ -52,7 +57,7 @@ module Runners
         default_gems << GemInstaller::Spec.new("meowcop")
       end
 
-      optionals = official_rubocop_plugins + third_party_rubocop_plugins
+      optionals = official_rubocop_plugins + third_party_rubocop_plugins + OPTIONAL_GEMS
       install_gems(default_gems, optionals: optionals, constraints: CONSTRAINTS) { yield }
     rescue InstallGemsFailure => exn
       trace_writer.error exn.message

--- a/sig/runners/processor/slim_lint.rbs
+++ b/sig/runners/processor/slim_lint.rbs
@@ -17,6 +17,7 @@ module Runners
     DEFAULT_TARGET: String
     DEFAULT_CONFIG_FILE: String
     MISSING_ID: String
+    OPTIONAL_GEMS: Array[Ruby::GemInstaller::Spec]
 
     private
 

--- a/test/smokes/slim_lint/expectations.rb
+++ b/test/smokes/slim_lint/expectations.rb
@@ -145,3 +145,22 @@ s.add_test(
   ],
   analyzer: { name: "Slim-Lint", version: default_version }
 )
+
+s.add_test(
+  "optional_gems",
+  type: "success",
+  issues: [
+    {
+      path: "foo.slim",
+      location: { start_line: 1 },
+      id: "ControlStatementSpacing",
+      message: "Please add a space before and after the `=`",
+      links: %W[https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter/README.md#controlstatementspacing],
+      object: { severity: "warning" },
+      git_blame_info: {
+        commit: :_, line_hash: "a745aa127a65767383c35e96e2ea3e5dde882cef", original_line: 1, final_line: 1
+      }
+    }
+  ],
+  analyzer: { name: "Slim-Lint", version: default_version }
+)

--- a/test/smokes/slim_lint/optional_gems/Gemfile
+++ b/test/smokes/slim_lint/optional_gems/Gemfile
@@ -1,5 +1,2 @@
 source "https://rubygems.org"
-
-gem "slim_lint", "0.20.2"
 gem "sassc", "2.4.0"
-gem "meowcop"

--- a/test/smokes/slim_lint/optional_gems/foo.slim
+++ b/test/smokes/slim_lint/optional_gems/foo.slim
@@ -1,0 +1,6 @@
+.foo="Hi"
+
+sass:
+  $color: #f00
+  .foo
+    color: $color


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Slim is often used with Sass (e.g., Rails), making sense to support Sass by default.
Without this change, users would need to add a Sass gem to `sider.yml` by themselves.

See also:
- https://rubygems.org/gems/sassc

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
