### PR TITLE
[HAML-Lint] Fix smoke test due to RuboCop

### DIFF
--- a/test/smokes/haml_lint/plain-rubocop/.rubocop.yml
+++ b/test/smokes/haml_lint/plain-rubocop/.rubocop.yml
@@ -1,2 +1,2 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.7


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Error message:

> Error: RuboCop found unsupported Ruby version 2.4 in `TargetRubyVersion` parameter (in .rubocop.yml). 2.4-compatible analysis was dropped after version 1.12.\nSupported versions: 2.5, 2.6, 2.7, 3.0

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
