### PR TITLE
Refactor getting PMD version

### DIFF
--- a/images/metrics_codeclone/Dockerfile
+++ b/images/metrics_codeclone/Dockerfile
@@ -34,13 +34,6 @@ RUN cd "${RUNNERS_DIR}" && \
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_cpd/pmd_cpd ${RUNNER_USER_BIN}/
 
-# NOTE: PMD does not have a CLI option to show its version.
-COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_java/ShowPMDVersion.java ${RUNNER_USER_BIN}/
-COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_java/show_pmd_version ${RUNNER_USER_BIN}/
-RUN cd "${RUNNER_USER_BIN}" && \
-    javac ShowPMDVersion.java && \
-    rm ShowPMDVersion.java
-
 
 # Copy the main source code
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} exe ${RUNNERS_DIR}/exe

--- a/images/pmd_cpd/Dockerfile
+++ b/images/pmd_cpd/Dockerfile
@@ -34,13 +34,6 @@ RUN cd "${RUNNERS_DIR}" && \
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_cpd/pmd_cpd ${RUNNER_USER_BIN}/
 
-# NOTE: PMD does not have a CLI option to show its version.
-COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_java/ShowPMDVersion.java ${RUNNER_USER_BIN}/
-COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_java/show_pmd_version ${RUNNER_USER_BIN}/
-RUN cd "${RUNNER_USER_BIN}" && \
-    javac ShowPMDVersion.java && \
-    rm ShowPMDVersion.java
-
 
 # Copy the main source code
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} exe ${RUNNERS_DIR}/exe

--- a/images/pmd_cpd/Dockerfile.erb
+++ b/images/pmd_cpd/Dockerfile.erb
@@ -3,11 +3,4 @@
 
 COPY --chown=<%= chown %> images/pmd_cpd/pmd_cpd ${RUNNER_USER_BIN}/
 
-# NOTE: PMD does not have a CLI option to show its version.
-COPY --chown=<%= chown %> images/pmd_java/ShowPMDVersion.java ${RUNNER_USER_BIN}/
-COPY --chown=<%= chown %> images/pmd_java/show_pmd_version ${RUNNER_USER_BIN}/
-RUN cd "${RUNNER_USER_BIN}" && \
-    javac ShowPMDVersion.java && \
-    rm ShowPMDVersion.java
-
 <%= render_erb 'images/Dockerfile.end.erb' %>

--- a/images/pmd_java/Dockerfile
+++ b/images/pmd_java/Dockerfile
@@ -35,13 +35,6 @@ RUN cd "${RUNNERS_DIR}" && \
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_java/pmd ${RUNNER_USER_BIN}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_java/default-ruleset.xml ${RUNNER_USER_HOME}/
 
-# NOTE: PMD does not have a CLI option to show its version.
-COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_java/ShowPMDVersion.java ${RUNNER_USER_BIN}/
-COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_java/show_pmd_version ${RUNNER_USER_BIN}/
-RUN cd "${RUNNER_USER_BIN}" && \
-    javac ShowPMDVersion.java && \
-    rm ShowPMDVersion.java
-
 
 # Copy the main source code
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} exe ${RUNNERS_DIR}/exe

--- a/images/pmd_java/Dockerfile.erb
+++ b/images/pmd_java/Dockerfile.erb
@@ -4,11 +4,4 @@
 COPY --chown=<%= chown %> images/<%= analyzer %>/pmd ${RUNNER_USER_BIN}/
 COPY --chown=<%= chown %> images/<%= analyzer %>/default-ruleset.xml ${RUNNER_USER_HOME}/
 
-# NOTE: PMD does not have a CLI option to show its version.
-COPY --chown=<%= chown %> images/<%= analyzer %>/ShowPMDVersion.java ${RUNNER_USER_BIN}/
-COPY --chown=<%= chown %> images/<%= analyzer %>/show_pmd_version ${RUNNER_USER_BIN}/
-RUN cd "${RUNNER_USER_BIN}" && \
-    javac ShowPMDVersion.java && \
-    rm ShowPMDVersion.java
-
 <%= render_erb 'images/Dockerfile.end.erb' %>

--- a/images/pmd_java/ShowPMDVersion.java
+++ b/images/pmd_java/ShowPMDVersion.java
@@ -1,5 +1,0 @@
-public class ShowPMDVersion {
-    public static void main(String[] args) {
-        System.out.println(net.sourceforge.pmd.PMDVersion.VERSION);
-    }
-}

--- a/images/pmd_java/show_pmd_version
+++ b/images/pmd_java/show_pmd_version
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-basedir=$(dirname "$0")
-exec java -classpath "${basedir}:${CLASSPATH}" ShowPMDVersion

--- a/lib/runners/java.rb
+++ b/lib/runners/java.rb
@@ -31,6 +31,13 @@ module Runners
       end
     end
 
+    # NOTE: PMD does not provide a CLI option to show its version.
+    def pmd_version
+      @pmd_version ||= capture3(analyzer_bin, "-help", trace_stdout: false).then do |stdout, _, _|
+        stdout.match(%r{pmd-bin-([\d.]+)/bin/}) { |m| m.captures.first } or raise "No version in:\n#{stdout}"
+      end
+    end
+
     private
 
     def fetch_deps_via_gradle!

--- a/lib/runners/processor/pmd_cpd.rb
+++ b/lib/runners/processor/pmd_cpd.rb
@@ -93,7 +93,7 @@ module Runners
     attr_accessor :force_option_skip_lexical_errors
 
     def analyzer_version
-      @analyzer_version ||= capture3!("show_pmd_version").yield_self { |stdout,| stdout.strip }
+      pmd_version
     end
 
     def analyze(_changes)

--- a/lib/runners/processor/pmd_java.rb
+++ b/lib/runners/processor/pmd_java.rb
@@ -40,7 +40,7 @@ module Runners
     end
 
     def analyzer_version
-      @analyzer_version ||= capture3!("show_pmd_version").yield_self { |stdout,| stdout.strip }
+      pmd_version
     end
 
     def analyzer_bin

--- a/sig/runners/java.rbs
+++ b/sig/runners/java.rbs
@@ -5,6 +5,8 @@ module Runners
 
     def install_jvm_deps: (?to: Pathname) -> void
 
+    def pmd_version: () -> String
+
     private
 
     def fetch_deps_via_gradle!: () -> void


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Since PMD does not have a CLI option to show its version, this change uses the `-help` option to do it.

By this, we can remove `ShowPMDVersion.java` and the compilation.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
