### PR TITLE
Show the tool's default version on setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Misc:
 - **Slim-Lint** Support Sass by default [#2297](https://github.com/sider/runners/pull/2297)
 - **RuboCop** Provide new recommended configuration [#2266](https://github.com/sider/runners/pull/2266)
 - **Metrics Complexity** Add workarounds for lizard's bug [#2249](https://github.com/sider/runners/pull/2249)
+- Show the tool's default version on setup [#2313](https://github.com/sider/runners/pull/2313)
 
 ## 0.47.0
 

--- a/lib/runners/go.rb
+++ b/lib/runners/go.rb
@@ -2,6 +2,7 @@ module Runners
   module Go
     def show_runtime_versions
       capture3! "go", "version"
+      super
     end
   end
 end

--- a/lib/runners/java.rb
+++ b/lib/runners/java.rb
@@ -15,6 +15,10 @@ module Runners
       super
     end
 
+    def analyzer_version
+      @analyzer_version || default_analyzer_version
+    end
+
     def install_jvm_deps(to: Pathname(Dir.home).join("dependencies"))
       return if config_jvm_deps.empty?
 
@@ -28,6 +32,8 @@ module Runners
             Successfully installed #{deps.size} #{deps.size == 1 ? 'dependency' : 'dependencies'}:
             #{deps.join("\n")}
           MSG
+
+          @analyzer_version = extract_version!(analyzer_bin)
         end
       end
     end

--- a/lib/runners/java.rb
+++ b/lib/runners/java.rb
@@ -40,8 +40,13 @@ module Runners
 
     # NOTE: PMD does not provide a CLI option to show its version.
     def pmd_version
-      @pmd_version ||= capture3(analyzer_bin, "-help", trace_stdout: false).then do |stdout, _, _|
-        stdout.match(%r{pmd-bin-([\d.]+)/bin/}) { |m| m.captures.first } or raise "No version in:\n#{stdout}"
+      stdout, _, _ = capture3(analyzer_bin, "-help", trace_stdout: false)
+      version = stdout.match(%r{pmd-bin-(?<version>[\d.]+)/bin/}) { |m| m[:version] }
+      if version
+        trace_writer.message "Version #{version}"
+        version
+      else
+        raise "No version in:\n#{stdout}"
       end
     end
 

--- a/lib/runners/java.rb
+++ b/lib/runners/java.rb
@@ -12,6 +12,7 @@ module Runners
     def show_runtime_versions
       capture3! "java", "-version"
       capture3! "gradle", "--version"
+      super
     end
 
     def install_jvm_deps(to: Pathname(Dir.home).join("dependencies"))

--- a/lib/runners/nodejs.rb
+++ b/lib/runners/nodejs.rb
@@ -26,7 +26,7 @@ module Runners
     end
 
     def analyzer_version
-      @analyzer_version ||= nodejs_use_local_version? ? nodejs_analyzer_local_version : nodejs_analyzer_global_version
+      @analyzer_version ||= nodejs_use_local_version? ? nodejs_analyzer_local_version : default_analyzer_version
     end
 
     # Return the actual file path of `package.json`.
@@ -90,17 +90,18 @@ module Runners
       case
       when !all_npm_deps_satisfied_constraint?(installed_deps, constraints)
         self.nodejs_force_default_version = true
-        trace_writer.message "All constraints are not satisfied. The default version `#{analyzer_version}` will be used instead."
+        trace_writer.message "All constraints are not satisfied. The default version `#{default_analyzer_version}` will be used instead."
       when nodejs_analyzer_locally_installed?
-        trace_writer.message "`#{nodejs_analyzer_local_command}` was successfully installed with the version `#{analyzer_version}`."
+        trace_writer.message "`#{analyzer_bin}@#{nodejs_analyzer_local_version}` was successfully installed."
       else
-        trace_writer.message "`#{nodejs_analyzer_local_command}` was not installed. The default version `#{analyzer_version}` will be used instead."
+        trace_writer.message "`#{analyzer_bin}` was not installed. The default version `#{default_analyzer_version}` will be used instead."
       end
     end
 
     def show_runtime_versions
       capture3! "node", "-v"
       capture3! "npm", "-v"
+      super
     end
 
     private
@@ -111,10 +112,6 @@ module Runners
 
     def nodejs_analyzer_locally_installed?
       (current_dir / nodejs_analyzer_local_command).exist?
-    end
-
-    def nodejs_analyzer_global_version
-      @nodejs_analyzer_global_version ||= extract_version!(analyzer_bin)
     end
 
     def nodejs_analyzer_local_version

--- a/lib/runners/php.rb
+++ b/lib/runners/php.rb
@@ -4,6 +4,7 @@ module Runners
       capture3! "php", "-version"
       capture3! "composer", "--version"
       capture3! "composer", "global", "info"
+      super
     end
   end
 end

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -102,8 +102,12 @@ module Runners
       analyzer_id.to_s
     end
 
+    def default_analyzer_version
+      @default_analyzer_version ||= extract_version! analyzer_bin
+    end
+
     def analyzer_version
-      @analyzer_version ||= extract_version! analyzer_bin
+      default_analyzer_version
     end
 
     def extract_version_option
@@ -189,7 +193,7 @@ module Runners
     end
 
     def show_runtime_versions
-      # noop by default
+      default_analyzer_version
     end
 
     def report_file

--- a/lib/runners/processor/coffeelint.rb
+++ b/lib/runners/processor/coffeelint.rb
@@ -19,6 +19,11 @@ module Runners
       "@coffeelint/cli" => Gem::Requirement.new(">= 4.0.0", "< 5.0.0").freeze,
     }.freeze
 
+    # TODO: Remove the old package after the deadline.
+    def npm_deps_satisfied_constraint?(installed_deps, constraints, _type)
+      super(installed_deps, constraints, :any)
+    end
+
     def self.config_example
       <<~'YAML'
         root_dir: project/

--- a/lib/runners/processor/fxcop.rb
+++ b/lib/runners/processor/fxcop.rb
@@ -21,7 +21,7 @@ module Runners
       YAML
     end
 
-    def analyzer_version
+    def default_analyzer_version
       ENV.fetch('FXCOP_VERSION')
     end
 

--- a/lib/runners/processor/metrics_fileinfo.rb
+++ b/lib/runners/processor/metrics_fileinfo.rb
@@ -22,7 +22,7 @@ module Runners
     CHURN_PERIOD_IN_DAYS = 90
     CHURN_COMMIT_COUNT = 100
 
-    def analyzer_version
+    def default_analyzer_version
       Runners::VERSION
     end
 

--- a/lib/runners/processor/pmd_cpd.rb
+++ b/lib/runners/processor/pmd_cpd.rb
@@ -92,7 +92,7 @@ module Runners
 
     attr_accessor :force_option_skip_lexical_errors
 
-    def default_analyzer_version
+    def extract_version!(*)
       pmd_version
     end
 

--- a/lib/runners/processor/pmd_cpd.rb
+++ b/lib/runners/processor/pmd_cpd.rb
@@ -92,7 +92,7 @@ module Runners
 
     attr_accessor :force_option_skip_lexical_errors
 
-    def analyzer_version
+    def default_analyzer_version
       pmd_version
     end
 

--- a/lib/runners/processor/pmd_java.rb
+++ b/lib/runners/processor/pmd_java.rb
@@ -39,7 +39,7 @@ module Runners
       YAML
     end
 
-    def analyzer_version
+    def default_analyzer_version
       pmd_version
     end
 

--- a/lib/runners/processor/pmd_java.rb
+++ b/lib/runners/processor/pmd_java.rb
@@ -39,7 +39,7 @@ module Runners
       YAML
     end
 
-    def default_analyzer_version
+    def extract_version!(*)
       pmd_version
     end
 

--- a/lib/runners/python.rb
+++ b/lib/runners/python.rb
@@ -6,6 +6,7 @@ module Runners
       capture3! "python", "--version"
       capture3! "pip", "--version"
       capture3! "pipenv", "--version"
+      super
     end
 
     # @see https://pip.pypa.io/en/stable/reference/pip_install

--- a/lib/runners/ruby.rb
+++ b/lib/runners/ruby.rb
@@ -70,6 +70,7 @@ module Runners
       capture3! "ruby", "-v"
       capture3! "gem", "-v"
       capture3! "bundle", "-v"
+      super
     end
 
     def ruby_analyzer_command(*args)

--- a/lib/runners/swift.rb
+++ b/lib/runners/swift.rb
@@ -2,6 +2,7 @@ module Runners
   module Swift
     def show_runtime_versions
       capture3! "swift", "--version"
+      super
     end
   end
 end

--- a/sig/runners/nodejs.rbs
+++ b/sig/runners/nodejs.rbs
@@ -43,8 +43,6 @@ module Runners
 
     def nodejs_analyzer_locally_installed?: () -> bool
 
-    def nodejs_analyzer_global_version: () -> String
-
     def nodejs_analyzer_local_version: () -> String
 
     def npm_install: (*String, ?subcommand: String, ?flags: Array[String]) -> void

--- a/sig/runners/nodejs.rbs
+++ b/sig/runners/nodejs.rbs
@@ -49,7 +49,7 @@ module Runners
 
     def list_installed_npm_deps_with: (names: Array[String]) -> Hash[String, { name: String, version: String }]
 
-    def all_npm_deps_satisfied_constraint?: (Hash[String, { name: String, version: String }], constraints) -> bool
+    def npm_deps_satisfied_constraint?: (Hash[String, { name: String, version: String }], constraints, (:all | :any)) -> bool
 
     def npm_constraint_format: (Gem::Requirement) -> String
 

--- a/sig/runners/processor.rbs
+++ b/sig/runners/processor.rbs
@@ -52,6 +52,8 @@ module Runners
 
     def analyzer_bin: () -> String
 
+    def default_analyzer_version: () -> String
+
     def analyzer_version: () -> String
 
     def extract_version_option: () -> String

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -150,10 +150,10 @@
   diagnostics:
   - range:
       start:
-        line: 119
+        line: 123
         character: 26
       end:
-        line: 119
+        line: 123
         character: 29
     severity: ERROR
     message: |-
@@ -165,10 +165,10 @@
     code: Ruby::ArgumentTypeMismatch
   - range:
       start:
-        line: 119
+        line: 123
         character: 31
       end:
-        line: 119
+        line: 123
         character: 40
     severity: ERROR
     message: |-
@@ -183,10 +183,10 @@
     code: Ruby::ArgumentTypeMismatch
   - range:
       start:
-        line: 251
+        line: 255
         character: 45
       end:
-        line: 251
+        line: 255
         character: 50
     severity: ERROR
     message: Type `(::String | ::Array[::String] | nil)` does not have method `split`

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -127,6 +127,32 @@
     severity: ERROR
     message: Type `bot` does not have method `size`
     code: Ruby::NoMethod
+- file: lib/runners/processor/pmd_cpd.rb
+  diagnostics:
+  - range:
+      start:
+        line: 95
+        character: 24
+      end:
+        line: 95
+        character: 27
+    severity: ERROR
+    message: 'Method parameters are incompatible with declaration `((::String | ::Array[::String]),
+      ?(::String | ::Array[::String]), ?pattern: ::Regexp) -> ::String`'
+    code: Ruby::MethodArityMismatch
+- file: lib/runners/processor/pmd_java.rb
+  diagnostics:
+  - range:
+      start:
+        line: 42
+        character: 24
+      end:
+        line: 42
+        character: 27
+    severity: ERROR
+    message: 'Method parameters are incompatible with declaration `((::String | ::Array[::String]),
+      ?(::String | ::Array[::String]), ?pattern: ::Regexp) -> ::String`'
+    code: Ruby::MethodArityMismatch
 - file: lib/runners/processor/shellcheck.rb
   diagnostics:
   - range:

--- a/test/harness_test.rb
+++ b/test/harness_test.rb
@@ -30,17 +30,9 @@ class HarnessTest < Minitest::Test
   end
 
   class TestProcessor < Processor
-    def analyzer_id
-      :test
-    end
-
-    def analyzer_name
-      "Test"
-    end
-
-    def analyzer_version
-      "0.1.3"
-    end
+    def analyzer_id; :test; end
+    def analyzer_name; "Test"; end
+    def default_analyzer_version; "0.1.3"; end
 
     def analyze(changes)
       Results::Success.new(guid: guid, analyzer: analyzer)
@@ -73,17 +65,9 @@ class HarnessTest < Minitest::Test
 
   def test_run_filters_issues
     processor_class = Class.new(Processor) do
-      def analyzer_id
-        :test
-      end
-
-      def analyzer_name
-        "Test"
-      end
-
-      def analyzer_version
-        "0.1.3"
-      end
+      def analyzer_id; :test; end
+      def analyzer_name; "Test"; end
+      def default_analyzer_version; "0.1.3"; end
 
       def analyze(changes)
         issues = [

--- a/test/java_test.rb
+++ b/test/java_test.rb
@@ -106,6 +106,9 @@ class JavaTest < Minitest::Test
       def fetch_deps_via_gradle!
         # noop
       end
+      def extract_version!(_)
+        "8.40.0"
+      end
     end
   end
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

I think it will be more useful for us to look into analyses if a tool's default version is always shown on logs.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
