### PR TITLE
Bump rubocop from 1.12.1 to 1.13.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     regexp_parser (2.1.1)
     retryable (3.0.5)
     rexml (3.2.5)
-    rubocop (1.12.1)
+    rubocop (1.13.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- https://github.com/rubocop/rubocop/releases/tag/v1.13.0
- https://my.diffend.io/gems/rubocop/1.12.1/1.13.0

Note: Dependabot cannot update it for some reason. 🤔 

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
