### PR TITLE
Revert "Improve installation of npm dependencies via `sider.yml`"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ Misc:
 - **RuboCop** Provide new recommended configuration [#2266](https://github.com/sider/runners/pull/2266)
 - **Metrics Complexity** Add workarounds for lizard's bug [#2249](https://github.com/sider/runners/pull/2249)
 - Show the tool's default version on setup [#2313](https://github.com/sider/runners/pull/2313)
-- Improve installation of npm dependencies via `sider.yml` [#2316](https://github.com/sider/runners/pull/2316)
 
 ## 0.47.0
 

--- a/images/Dockerfile.base.erb
+++ b/images/Dockerfile.base.erb
@@ -1,13 +1,11 @@
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=<%= chown %> Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=<%= chown %> lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/brakeman/Dockerfile
+++ b/images/brakeman/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_ruby:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/checkstyle/Dockerfile
+++ b/images/checkstyle/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_java:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/clang_tidy/Dockerfile
+++ b/images/clang_tidy/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_base:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/code_sniffer/Dockerfile
+++ b/images/code_sniffer/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_php:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/coffeelint/Dockerfile
+++ b/images/coffeelint/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_npm:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/cppcheck/Dockerfile
+++ b/images/cppcheck/Dockerfile
@@ -10,15 +10,13 @@ FROM sider/devon_rex_python:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/cpplint/Dockerfile
+++ b/images/cpplint/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_python:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/detekt/Dockerfile
+++ b/images/detekt/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_java:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/eslint/Dockerfile
+++ b/images/eslint/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_npm:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/flake8/Dockerfile
+++ b/images/flake8/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_python:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/fxcop/Dockerfile
+++ b/images/fxcop/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_dotnet:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/golangci_lint/Dockerfile
+++ b/images/golangci_lint/Dockerfile
@@ -8,15 +8,13 @@ FROM sider/devon_rex_go:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/goodcheck/Dockerfile
+++ b/images/goodcheck/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_ruby:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/hadolint/Dockerfile
+++ b/images/hadolint/Dockerfile
@@ -10,15 +10,13 @@ COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} --from=hadolint /bin/hadolint ${RUNN
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/haml_lint/Dockerfile
+++ b/images/haml_lint/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_ruby:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/javasee/Dockerfile
+++ b/images/javasee/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_java:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/jshint/Dockerfile
+++ b/images/jshint/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_npm:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/ktlint/Dockerfile
+++ b/images/ktlint/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_java:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/languagetool/Dockerfile
+++ b/images/languagetool/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_java:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/metrics_codeclone/Dockerfile
+++ b/images/metrics_codeclone/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_java:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/metrics_complexity/Dockerfile
+++ b/images/metrics_complexity/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_python:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/metrics_fileinfo/Dockerfile
+++ b/images/metrics_fileinfo/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_base:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/misspell/Dockerfile
+++ b/images/misspell/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_base:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/phinder/Dockerfile
+++ b/images/phinder/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_php:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/phpmd/Dockerfile
+++ b/images/phpmd/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_php:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/pmd_cpd/Dockerfile
+++ b/images/pmd_cpd/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_java:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/pmd_java/Dockerfile
+++ b/images/pmd_java/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_java:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/pylint/Dockerfile
+++ b/images/pylint/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_python:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/querly/Dockerfile
+++ b/images/querly/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_ruby:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/rails_best_practices/Dockerfile
+++ b/images/rails_best_practices/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_ruby:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/reek/Dockerfile
+++ b/images/reek/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_ruby:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/remark_lint/Dockerfile
+++ b/images/remark_lint/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_npm:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/rubocop/Dockerfile
+++ b/images/rubocop/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_ruby:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/scss_lint/Dockerfile
+++ b/images/scss_lint/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_ruby:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/shellcheck/Dockerfile
+++ b/images/shellcheck/Dockerfile
@@ -8,15 +8,13 @@ FROM sider/devon_rex_base:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/slim_lint/Dockerfile
+++ b/images/slim_lint/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_ruby:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/stylelint/Dockerfile
+++ b/images/stylelint/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_npm:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/swiftlint/Dockerfile
+++ b/images/swiftlint/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_swift:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/tslint/Dockerfile
+++ b/images/tslint/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_npm:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/images/tyscan/Dockerfile
+++ b/images/tyscan/Dockerfile
@@ -6,15 +6,13 @@ FROM sider/devon_rex_npm:master
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
-ENV RUNNERS_USER_DEPS_DIR ${RUNNER_USER_HOME}/user_dependencies
 ARG RUNNERS_DIR=${RUNNER_USER_HOME}/runners
 
 # Install required gems first (due to slow download)
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} Gemfile Gemfile.lock runners.gemspec analyzers.yml ${RUNNERS_DIR}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} lib/runners/version.rb ${RUNNERS_DIR}/lib/runners/
 
-RUN mkdir -p "${RUNNERS_DEPS_DIR}" "${RUNNERS_USER_DEPS_DIR}" && \
-    cd "${RUNNERS_DIR}" && \
+RUN cd "${RUNNERS_DIR}" && \
     bundle config set --global jobs 4 && \
     bundle config set --global retry 3 && \
     bundle config && \

--- a/lib/runners/shell.rb
+++ b/lib/runners/shell.rb
@@ -53,7 +53,7 @@ module Runners
 
     def chdir(dir)
       backup = @current_dir
-      Dir.chdir(dir.to_s) do |path|
+      Dir.chdir(dir.to_path) do |path|
         @current_dir = Pathname(path)
         yield @current_dir
       end

--- a/sig/runners/nodejs.rbs
+++ b/sig/runners/nodejs.rbs
@@ -43,9 +43,9 @@ module Runners
 
     def nodejs_analyzer_locally_installed?: () -> bool
 
-    def npm_install: (Array[String], ?subcommand: String, ?flags: Array[String]) -> void
+    def nodejs_analyzer_local_version: () -> String
 
-    def check_installed_npm_deps: (constraints) -> bool
+    def npm_install: (*String, ?subcommand: String, ?flags: Array[String]) -> void
 
     def list_installed_npm_deps_with: (names: Array[String]) -> Hash[String, { name: String, version: String }]
 

--- a/sig/runners/processor.rbs
+++ b/sig/runners/processor.rbs
@@ -20,7 +20,7 @@ module Runners
     def initialize: (guid: String, working_dir: Pathname, config: Config, shell: Shell, trace_writer: TraceWriter) -> void
 
     def current_dir: () -> Pathname
-    def chdir: [X] (Pathname | String) { (Pathname) -> X } -> X
+    def chdir: [X] (Pathname) { (Pathname) -> X } -> X
     def push_env_hash: [X] (Hash[String, String?]) { () -> X } -> X
     def env_hash: () -> Hash[String, String?]
     def capture3: (String, *Shell::command_argument, **untyped) -> [String, String, Process::Status]

--- a/sig/runners/shell.rbs
+++ b/sig/runners/shell.rbs
@@ -30,7 +30,7 @@ module Runners
                      trace_writer: TraceWriter,
                      ?env_hash: Hash[String, String?]) -> void
 
-    def chdir: [X] (Pathname | String) { (Pathname) -> X } -> X
+    def chdir: [X] (Pathname) { (Pathname) -> X } -> X
 
     def push_env_hash: [X] (Hash[String, String?]) { () -> X } -> X
 

--- a/test/nodejs_test.rb
+++ b/test/nodejs_test.rb
@@ -95,6 +95,28 @@ class NodejsTest < Minitest::Test
     end
   end
 
+  def test_analyzer_version_with_global
+    with_workspace do |workspace|
+      new_processor(workspace: workspace)
+
+      processor.stub :nodejs_analyzer_locally_installed?, false do
+        assert_equal "7.0.0", processor.analyzer_version
+      end
+    end
+  end
+
+  def test_analyzer_version_with_local
+    with_workspace do |workspace|
+      new_processor(workspace: workspace)
+
+      processor.stub :nodejs_analyzer_locally_installed?, true do
+        processor.stub :nodejs_analyzer_local_version, "2.0.0" do
+          assert_equal "2.0.0", processor.analyzer_version
+        end
+      end
+    end
+  end
+
   def test_install_nodejs_deps
     with_workspace do |workspace|
       new_processor(workspace: workspace)
@@ -434,28 +456,22 @@ class NodejsTest < Minitest::Test
     with_workspace do |workspace|
       new_processor(workspace: workspace)
 
-      processor.package_json_path.write({ dependencies: { "is-string": "1.0.0", "eslint": "7.0.0" } }.to_json)
+      processor.package_json_path.write({ dependencies: { "is-string": "1.0.0" } }.to_json)
 
-      deps_dir = mktmpdir.to_path
+      processor.install_nodejs_deps(
+        constraints: {},
+        dependencies: ["classcat", "is-string@1.0.5", { name: "is-nan-x", version: "2.1.0" }],
+        install_option: INSTALL_OPTION_ALL,
+      )
 
-      with_stubbed_env({ "RUNNERS_USER_DEPS_DIR" => deps_dir }) do
-        processor.install_nodejs_deps(
-          constraints: {},
-          dependencies: ["classcat", "is-string@1.0.5", { name: "is-nan-x", version: "2.1.0" }],
-          install_option: INSTALL_OPTION_ALL,
-        )
-      end
-
-      installed_versions_output = trace_writer.writer.find { |e| e[:trace] == :stdout && e[:string].include?(deps_dir) }.fetch(:string)
-      assert_match %r{classcat@\d+\.\d+\.\d+}, installed_versions_output
-      assert_match "is-string@1.0.5", installed_versions_output
-      assert_match "is-nan-x@2.1.0", installed_versions_output
+      assert_match %r{^\d+\.\d+\.\d+$}, package_version("classcat")
+      assert_equal "1.0.5", package_version("is-string")
+      assert_equal "2.1.0", package_version("is-nan-x")
       assert_empty processor.warnings
       refute_empty actual_commands
       assert_empty actual_errors
-      assert_equal({ dependencies: { "is-string": "1.0.0", "eslint": "7.0.0" } }.to_json, processor.package_json_path.read)
+      assert_equal({ dependencies: { "is-string": "1.0.0" } }.to_json, processor.package_json_path.read)
       refute_path_exists processor.package_lock_json_path
-      refute_path_exists processor.node_modules_path
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,12 +12,12 @@ module TestHelper
     Pathname(__dir__).join("data", file)
   end
 
-  def with_stubbed_env(new_env)
-    backup = ENV.slice(*new_env.keys)
-    ENV.update(new_env)
+  def with_stubbed_env(name, value)
+    backup = ENV[name]
+    ENV[name] = value
     yield
   ensure
-    ENV.update(backup)
+    ENV[name] = backup
   end
 
   def new_source(**source)


### PR DESCRIPTION
Reverts sider/runners#2316

This change does not work expectedly. For example, `eslint-plugin-jest` requires the `jest` package.