### PR TITLE
[PMD CPD] Add a debug code

### DIFF
--- a/images/pmd_cpd/pmd_cpd
+++ b/images/pmd_cpd/pmd_cpd
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec java net.sourceforge.pmd.cpd.CPD "$@"
+exec java -Xmx8G net.sourceforge.pmd.cpd.CPD "$@"


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

We have faced several analysis errors `pmdcpd` saying `OutOfMemory` in Java VM context. (https://github.com/sider/sideci/issues/10979) We have not identify the cause yet. There are two possibilities. One is `pmdcpd`'s bug. The other is inappropriate heap size limitation. This PR adds an extra option expanding maximum heap size of Java VM. 

I'll revert the code after this debug process.

NOTE: The default maximum heap size is 1/4 of the total memory. It is 4GB at Sider production service.
