### PR TITLE
[PMD CPD, Metrics CodeClone] Suppress STDOUT logging 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Misc:
 - **RuboCop** Provide new recommended configuration [#2266](https://github.com/sider/runners/pull/2266)
 - **Metrics Complexity** Add workarounds for lizard's bug [#2249](https://github.com/sider/runners/pull/2249)
 - Show the tool's default version on setup [#2313](https://github.com/sider/runners/pull/2313)
+- **PMD CPD** Suppress STDOUT logging [#2356](https://github.com/sider/runners/pull/2356)
 
 ## 0.47.0
 

--- a/lib/runners/processor/pmd_cpd.rb
+++ b/lib/runners/processor/pmd_cpd.rb
@@ -100,7 +100,7 @@ module Runners
       issues = []
 
       languages.each do |language|
-        stdout, stderr = capture3!(analyzer_bin, *cli_options(language))
+        stdout, stderr = capture3!(analyzer_bin, *cli_options(language), trace_stdout: false)
         raise_warnings(stderr)
         construct_result(stdout) { |issue| issues << issue }
       end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

`pmd_cpd` runnner (`metrics_codeclone` runner) write result data to `STDOUT`. It create huge runner log file when there are many code clones with current implementation. In some case, the output process consumes time more than 20 min. This is PR to suppress such logging.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
