### PR TITLE
[Rails Best Practices] Mark deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Misc:
 - **ESLint** Re-provide new recommended configuration [#2157](https://github.com/sider/runners/pull/2150)
 - **PMD Java** Provide new recommended configuration [#2296](https://github.com/sider/runners/pull/2296)
 - **Slim-Lint** Support Sass by default [#2297](https://github.com/sider/runners/pull/2297)
+- **Rails Best Practices** Mark deprecated [#2357](https://github.com/sider/runners/pull/2357)
 - **RuboCop** Provide new recommended configuration [#2266](https://github.com/sider/runners/pull/2266)
 - **Metrics Complexity** Add workarounds for lizard's bug [#2249](https://github.com/sider/runners/pull/2249)
 - Show the tool's default version on setup [#2313](https://github.com/sider/runners/pull/2313)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ All **40** analyzers are provided as a Docker image:
 | PMD Java | [docker](https://hub.docker.com/r/sider/runner_pmd_java), [source](https://github.com/pmd/pmd), [doc](https://help.sider.review/tools/java/pmd), [website](https://pmd.github.io) | ✅ |
 | Pylint | [docker](https://hub.docker.com/r/sider/runner_pylint), [source](https://github.com/PyCQA/pylint), [doc](https://help.sider.review/tools/python/pylint), [website](https://pylint.pycqa.org) | ✅ *beta* |
 | Querly | [docker](https://hub.docker.com/r/sider/runner_querly), [source](https://github.com/soutaro/querly), [doc](https://help.sider.review/tools/ruby/querly) | ✅ |
-| Rails Best Practices | [docker](https://hub.docker.com/r/sider/runner_rails_best_practices), [source](https://github.com/flyerhzm/rails_best_practices), [doc](https://help.sider.review/tools/ruby/rails-best-practices), [website](https://rails-bestpractices.com) | ✅ |
+| Rails Best Practices | [docker](https://hub.docker.com/r/sider/runner_rails_best_practices), [source](https://github.com/flyerhzm/rails_best_practices), [doc](https://help.sider.review/tools/ruby/rails-best-practices), [website](https://rails-bestpractices.com) | ⚠️ *deprecated* |
 | Reek | [docker](https://hub.docker.com/r/sider/runner_reek), [source](https://github.com/troessner/reek), [doc](https://help.sider.review/tools/ruby/reek) | ✅ |
 | remark-lint | [docker](https://hub.docker.com/r/sider/runner_remark_lint), [source](https://github.com/remarkjs/remark-lint), [doc](https://help.sider.review/tools/markdown/remark-lint) | ✅ |
 | RuboCop | [docker](https://hub.docker.com/r/sider/runner_rubocop), [source](https://github.com/rubocop/rubocop), [doc](https://help.sider.review/tools/ruby/rubocop), [website](https://rubocop.org) | ✅ |

--- a/analyzers.yml
+++ b/analyzers.yml
@@ -154,6 +154,7 @@ analyzers:
     github: flyerhzm/rails_best_practices
     doc: tools/ruby/rails-best-practices
     website: https://rails-bestpractices.com
+    deprecated: true
   reek:
     name: Reek
     github: troessner/reek

--- a/lib/runners/processor/rails_best_practices.rb
+++ b/lib/runners/processor/rails_best_practices.rb
@@ -50,6 +50,12 @@ module Runners
     end
 
     def setup
+      warnings.add_warning_for_deprecated_linter(
+        old: analyzer_name,
+        new: "#{analyzers.name(:rubocop)}, #{analyzers.name(:haml_lint)}, or #{analyzers.name(:slim_lint)}",
+        deadline: Time.new(2021, 9, 30),
+      )
+
       prepare_config
       install_gems(default_gem_specs(GEM_NAME), optionals: OPTIONAL_GEMS, constraints: CONSTRAINTS) { yield }
     rescue InstallGemsFailure => exn

--- a/test/smokes/rails_best_practices/expectations.rb
+++ b/test/smokes/rails_best_practices/expectations.rb
@@ -2,6 +2,11 @@ s = Runners::Testing::Smoke
 
 default_version = "1.20.0"
 
+deprecated_warning = {
+  message: "The support for Rails Best Practices is deprecated and will be removed on September 30, 2021. Please migrate to RuboCop, HAML-Lint, or Slim-Lint.",
+  file: nil
+}
+
 s.add_test(
   "sandbox_rails",
   type: "success",
@@ -51,7 +56,8 @@ s.add_test(
       }
     }
   ],
-  analyzer: { name: "Rails Best Practices", version: default_version }
+  analyzer: { name: "Rails Best Practices", version: default_version },
+  warnings: [deprecated_warning]
 )
 
 s.add_test(
@@ -77,7 +83,8 @@ s.add_test(
         commit: :_, line_hash: "447fdabd4b419ac0393028c89e4f596d888c3600", original_line: 5, final_line: 5
       }
     }
-  ]
+  ],
+  warnings: [deprecated_warning]
 )
 
 s.add_test(
@@ -118,7 +125,8 @@ s.add_test(
         commit: :_, line_hash: "61c189f0538de4fecb11e837da23a468287153e4", original_line: 2, final_line: 2
       }
     }
-  ]
+  ],
+  warnings: [deprecated_warning]
 )
 
 s.add_test(
@@ -137,7 +145,8 @@ s.add_test(
         commit: :_, line_hash: "447fdabd4b419ac0393028c89e4f596d888c3600", original_line: 5, final_line: 5
       }
     }
-  ]
+  ],
+  warnings: [deprecated_warning]
 )
 
 s.add_test(
@@ -167,7 +176,8 @@ s.add_test(
         commit: :_, line_hash: "ad616b1216619ed7daec388fdd0c2f0d890f6ffb", original_line: 2, final_line: 2
       }
     }
-  ]
+  ],
+  warnings: [deprecated_warning]
 )
 
 s.add_test(
@@ -186,7 +196,8 @@ s.add_test(
         commit: :_, line_hash: "61c189f0538de4fecb11e837da23a468287153e4", original_line: 2, final_line: 2
       }
     }
-  ]
+  ],
+  warnings: [deprecated_warning]
 )
 
 s.add_test(
@@ -207,6 +218,7 @@ s.add_test(
     }
   ],
   warnings: [
+    deprecated_warning,
     {
       message: <<~MESSAGE.strip,
         `rails_best_practices = #{default_version}` will be installed instead of `1.16.0` in your `Gemfile.lock`.
@@ -237,7 +249,8 @@ s.add_test(
         commit: :_, line_hash: "e9e0a3f0be9cd433b81aaef2ab5775fedb5832cf", original_line: 3, final_line: 3
       }
     }
-  ]
+  ],
+  warnings: [deprecated_warning]
 )
 
 s.add_test(
@@ -278,7 +291,8 @@ s.add_test(
         commit: :_, line_hash: "e9e0a3f0be9cd433b81aaef2ab5775fedb5832cf", original_line: 3, final_line: 3
       }
     }
-  ]
+  ],
+  warnings: [deprecated_warning]
 )
 
 s.add_test(
@@ -297,7 +311,8 @@ s.add_test(
         commit: :_, line_hash: "e9e0a3f0be9cd433b81aaef2ab5775fedb5832cf", original_line: 3, final_line: 3
       }
     }
-  ]
+  ],
+  warnings: [deprecated_warning]
 )
 
 s.add_test(
@@ -349,12 +364,14 @@ s.add_test(
         commit: :_, line_hash: "599ff60112099528b8b997ccc1075dc439b789ec", original_line: 13, final_line: 13
       }
     }
-  ]
+  ],
+  warnings: [deprecated_warning]
 )
 
 s.add_test(
   "no_issues",
   type: "success",
   analyzer: { name: "Rails Best Practices", version: default_version },
-  issues: []
+  issues: [],
+  warnings: [deprecated_warning]
 )


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change marks **Rails Best Practices** as deprecated.

We will update the document page later:
https://help.sider.review/tools/ruby/rails-best-practices

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Part of #2320

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
