### PR TITLE
Specify max heap size for Java tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Misc:
 - **Metrics Complexity** Add workarounds for lizard's bug [#2249](https://github.com/sider/runners/pull/2249)
 - Show the tool's default version on setup [#2313](https://github.com/sider/runners/pull/2313)
 - **PMD CPD** Suppress STDOUT logging [#2356](https://github.com/sider/runners/pull/2356)
-- **PMD CPD** Increase max heap size [#2366](https://github.com/sider/runners/pull/2366)
+- Specify max heap size for Java tools [#2366](https://github.com/sider/runners/pull/2366)
 
 ## 0.47.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Misc:
 - **Metrics Complexity** Add workarounds for lizard's bug [#2249](https://github.com/sider/runners/pull/2249)
 - Show the tool's default version on setup [#2313](https://github.com/sider/runners/pull/2313)
 - **PMD CPD** Suppress STDOUT logging [#2356](https://github.com/sider/runners/pull/2356)
+- **PMD CPD** Increase max heap size [#2366](https://github.com/sider/runners/pull/2366)
 
 ## 0.47.0
 

--- a/images/Dockerfile.java.erb
+++ b/images/Dockerfile.java.erb
@@ -12,3 +12,4 @@ RUN cd "${RUNNERS_DEPS_DIR}" && \
     gradle --no-build-cache --parallel --quiet installDeps && \
     rm build.gradle
 ENV CLASSPATH ${RUNNERS_DEPS_DIR}/*:${CLASSPATH}
+ENV JAVA_TOOL_OPTIONS "-XX:MaxRAMPercentage=50"

--- a/images/checkstyle/Dockerfile
+++ b/images/checkstyle/Dockerfile
@@ -32,6 +32,7 @@ RUN cd "${RUNNERS_DEPS_DIR}" && \
     gradle --no-build-cache --parallel --quiet installDeps && \
     rm build.gradle
 ENV CLASSPATH ${RUNNERS_DEPS_DIR}/*:${CLASSPATH}
+ENV JAVA_TOOL_OPTIONS "-XX:MaxRAMPercentage=50"
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/checkstyle/checkstyle ${RUNNER_USER_BIN}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/checkstyle/sider_recommended_checkstyle.xml ${RUNNER_USER_HOME}/

--- a/images/detekt/Dockerfile
+++ b/images/detekt/Dockerfile
@@ -32,6 +32,7 @@ RUN cd "${RUNNERS_DEPS_DIR}" && \
     gradle --no-build-cache --parallel --quiet installDeps && \
     rm build.gradle
 ENV CLASSPATH ${RUNNERS_DEPS_DIR}/*:${CLASSPATH}
+ENV JAVA_TOOL_OPTIONS "-XX:MaxRAMPercentage=50"
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/detekt/detekt ${RUNNER_USER_BIN}/
 

--- a/images/ktlint/Dockerfile
+++ b/images/ktlint/Dockerfile
@@ -32,6 +32,7 @@ RUN cd "${RUNNERS_DEPS_DIR}" && \
     gradle --no-build-cache --parallel --quiet installDeps && \
     rm build.gradle
 ENV CLASSPATH ${RUNNERS_DEPS_DIR}/*:${CLASSPATH}
+ENV JAVA_TOOL_OPTIONS "-XX:MaxRAMPercentage=50"
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/ktlint/ktlint ${RUNNER_USER_BIN}/
 

--- a/images/metrics_codeclone/Dockerfile
+++ b/images/metrics_codeclone/Dockerfile
@@ -32,6 +32,7 @@ RUN cd "${RUNNERS_DEPS_DIR}" && \
     gradle --no-build-cache --parallel --quiet installDeps && \
     rm build.gradle
 ENV CLASSPATH ${RUNNERS_DEPS_DIR}/*:${CLASSPATH}
+ENV JAVA_TOOL_OPTIONS "-XX:MaxRAMPercentage=50"
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_cpd/pmd_cpd ${RUNNER_USER_BIN}/
 

--- a/images/pmd_cpd/Dockerfile
+++ b/images/pmd_cpd/Dockerfile
@@ -32,6 +32,7 @@ RUN cd "${RUNNERS_DEPS_DIR}" && \
     gradle --no-build-cache --parallel --quiet installDeps && \
     rm build.gradle
 ENV CLASSPATH ${RUNNERS_DEPS_DIR}/*:${CLASSPATH}
+ENV JAVA_TOOL_OPTIONS "-XX:MaxRAMPercentage=50"
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_cpd/pmd_cpd ${RUNNER_USER_BIN}/
 

--- a/images/pmd_cpd/pmd_cpd
+++ b/images/pmd_cpd/pmd_cpd
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec java net.sourceforge.pmd.cpd.CPD "$@"
+exec java -Xmx8G net.sourceforge.pmd.cpd.CPD "$@"

--- a/images/pmd_cpd/pmd_cpd
+++ b/images/pmd_cpd/pmd_cpd
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec java -XX:MaxRAMPercentage=50 net.sourceforge.pmd.cpd.CPD "$@"
+exec java net.sourceforge.pmd.cpd.CPD "$@"

--- a/images/pmd_cpd/pmd_cpd
+++ b/images/pmd_cpd/pmd_cpd
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec java -Xmx8G net.sourceforge.pmd.cpd.CPD "$@"
+exec java -XX:MaxRAMPercentage=50 net.sourceforge.pmd.cpd.CPD "$@"

--- a/images/pmd_java/Dockerfile
+++ b/images/pmd_java/Dockerfile
@@ -32,6 +32,7 @@ RUN cd "${RUNNERS_DEPS_DIR}" && \
     gradle --no-build-cache --parallel --quiet installDeps && \
     rm build.gradle
 ENV CLASSPATH ${RUNNERS_DEPS_DIR}/*:${CLASSPATH}
+ENV JAVA_TOOL_OPTIONS "-XX:MaxRAMPercentage=50"
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_java/pmd ${RUNNER_USER_BIN}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_java/default-ruleset.xml ${RUNNER_USER_HOME}/


### PR DESCRIPTION
This is a workaround for https://github.com/sider/sideci/issues/10979. This PR adds `-Xmx8G` option for java VM when it execute `pmd_cpd`. This means that `pmd_cpd` can consume memory as heap up to 8GB. (Now the limit value is 4GB in Sider production service).

The new limitation value is not the best value because it is depends on the target source code. We, however, overcome the existing problem with the parameter. 

NOTE: This is a just workaround. We need to discuss to how to pass the parameter and refactor `pmd_cpd` and `pmc_java` code. I've opened #2367.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

A experiment with debug code: https://github.com/sider/runners/pull/2349

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
