### PR TITLE
[RuboCop] Fix links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Misc:
 - **PMD CPD** Suppress STDOUT logging [#2356](https://github.com/sider/runners/pull/2356)
 - Specify max heap size for Java tools [#2366](https://github.com/sider/runners/pull/2366)
 - **RuboCop** Add 3rd-party plugins [#2370](https://github.com/sider/runners/pull/2370)
+- **RuboCop** Fix links [#2371](https://github.com/sider/runners/pull/2371)
 
 ## 0.47.0
 

--- a/lib/runners/issue.rb
+++ b/lib/runners/issue.rb
@@ -22,7 +22,7 @@ module Runners
       @missing_id = id.to_s.empty?
       @id = missing_id? ? Digest::SHA1.hexdigest(message) : id
       @message = message
-      @links = links
+      @links = links.uniq
       @object = object
       @git_blame_info = nil
     end

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -179,7 +179,7 @@ module Runners
       return [] if issue_id.nil? || issue_id == "Syntax"
 
       links = ["#{analyzer_github}/blob/v#{analyzer_version}/lib/haml_lint/linter##{issue_id.downcase}"]
-      cop_name ? links + build_rubocop_links(cop_name) : links
+      cop_name ? build_rubocop_links(cop_name) + links : links
     end
 
     # NOTE: HAML-Lint exits successfully even if RuboCop fails.

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -110,7 +110,7 @@ module Runners
               location: loc,
               id: offense[:cop_name],
               message: normalize_message(offense[:message], links, offense[:cop_name]),
-              links: links + build_rubocop_links(offense[:cop_name]),
+              links: build_rubocop_links(offense[:cop_name]) + links,
               object: {
                 severity: offense[:severity],
                 corrected: offense[:corrected],

--- a/lib/runners/processor/slim_lint.rb
+++ b/lib/runners/processor/slim_lint.rb
@@ -146,9 +146,9 @@ module Runners
         []
       when /\ARuboCop:/
         cop_name = id.delete_prefix("RuboCop:")
-        ["#{analyzer_github}/blob/v#{analyzer_version}/lib/slim_lint/linter/README.md#rubocop"] + build_rubocop_links(cop_name)
+        build_rubocop_links(cop_name) + ["#{analyzer_github}/blob/v#{analyzer_version}/lib/slim_lint/linter#rubocop"]
       else
-        ["#{analyzer_github}/blob/v#{analyzer_version}/lib/slim_lint/linter/README.md##{id.downcase}"]
+        ["#{analyzer_github}/blob/v#{analyzer_version}/lib/slim_lint/linter##{id.downcase}"]
       end
     end
   end

--- a/test/smokes/haml_lint/expectations.rb
+++ b/test/smokes/haml_lint/expectations.rb
@@ -59,8 +59,8 @@ s.add_test(
     {
       message: "Lint/UselessAssignment: Useless assignment to variable - `unused_variable`.",
       links: %W[
-        https://github.com/sds/haml-lint/blob/v#{default_version}/lib/haml_lint/linter#rubocop
         https://docs.rubocop.org/rubocop/cops_lint.html#lintuselessassignment
+        https://github.com/sds/haml-lint/blob/v#{default_version}/lib/haml_lint/linter#rubocop
       ],
       id: "RuboCop:Lint/UselessAssignment",
       path: "test.haml",
@@ -114,8 +114,8 @@ s.add_test(
       id: "RuboCop:Performance/FlatMap",
       message: "Performance/FlatMap: Use `flat_map` instead of `map...flatten`.",
       links: %W[
-        https://github.com/sds/haml-lint/blob/v#{default_version}/lib/haml_lint/linter#rubocop
         https://docs.rubocop.org/rubocop-performance/cops_performance.html#performanceflatmap
+        https://github.com/sds/haml-lint/blob/v#{default_version}/lib/haml_lint/linter#rubocop
       ],
       object: { severity: "warning" },
       git_blame_info: {

--- a/test/smokes/rubocop/expectations.rb
+++ b/test/smokes/rubocop/expectations.rb
@@ -31,8 +31,8 @@ s.add_test(
     {
       message: "Useless assignment to variable - `v`.",
       links: %w[
-        https://rubystyle.guide#underscore-unused-vars
         https://docs.rubocop.org/rubocop/cops_lint.html#lintuselessassignment
+        https://rubystyle.guide#underscore-unused-vars
       ],
       id: "Lint/UselessAssignment",
       path: "app/controllers/users_controller.rb",
@@ -45,8 +45,8 @@ s.add_test(
     {
       message: "Prefer symbols instead of strings as hash keys.",
       links: %w[
-        https://rubystyle.guide#symbols-as-keys
         https://docs.rubocop.org/rubocop/cops_style.html#stylestringhashkeys
+        https://rubystyle.guide#symbols-as-keys
       ],
       id: "Style/StringHashKeys",
       path: "config/environments/development.rb",
@@ -59,8 +59,8 @@ s.add_test(
     {
       message: "Prefer symbols instead of strings as hash keys.",
       links: %w[
-        https://rubystyle.guide#symbols-as-keys
         https://docs.rubocop.org/rubocop/cops_style.html#stylestringhashkeys
+        https://rubystyle.guide#symbols-as-keys
       ],
       id: "Style/StringHashKeys",
       path: "config/environments/test.rb",
@@ -92,8 +92,8 @@ s.add_test(
     {
       message: "Put empty method definitions on a single line.",
       links: %w[
-        https://rubystyle.guide#no-single-line-methods
         https://docs.rubocop.org/rubocop/cops_style.html#styleemptymethod
+        https://rubystyle.guide#no-single-line-methods
       ],
       id: "Style/EmptyMethod",
       path: "app.rb",
@@ -114,8 +114,8 @@ s.add_test(
     {
       message: "Use 2 (not 1) spaces for indentation.",
       links: %w[
-        https://rubystyle.guide#spaces-indentation
         https://docs.rubocop.org/rubocop/cops_layout.html#layoutindentationwidth
+        https://rubystyle.guide#spaces-indentation
       ],
       id: "Layout/IndentationWidth",
       path: "test.rb",
@@ -128,8 +128,8 @@ s.add_test(
     {
       message: "Tab detected.",
       links: %w[
-        https://rubystyle.guide#spaces-indentation
         https://docs.rubocop.org/rubocop/cops_layout.html#layouttab
+        https://rubystyle.guide#spaces-indentation
       ],
       id: "Layout/Tab",
       path: "test.rb",
@@ -173,8 +173,8 @@ s.add_test(
     {
       message: "Line is too long. [218/200]",
       links: %w[
-        https://rubystyle.guide#80-character-limits
         https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinelength
+        https://rubystyle.guide#80-character-limits
       ],
       id: "Layout/LineLength",
       path: "cat.rb",
@@ -264,8 +264,8 @@ s.add_test(
     {
       message: "Line is too long. [218/200]",
       links: %w[
-        https://github.com/rubocop-hq/ruby-style-guide#80-character-limits
         https://docs.rubocop.org/rubocop/cops_metrics.html#metricslinelength
+        https://github.com/rubocop-hq/ruby-style-guide#80-character-limits
       ],
       id: "Metrics/LineLength",
       path: "cat.rb",
@@ -292,8 +292,8 @@ s.add_test(
     {
       message: "Line is too long. [218/200]",
       links: %w[
-        https://rubystyle.guide#80-character-limits
         https://docs.rubocop.org/rubocop/cops_metrics.html#metricslinelength
+        https://rubystyle.guide#80-character-limits
       ],
       id: "Metrics/LineLength",
       path: "cat.rb",
@@ -314,8 +314,8 @@ s.add_test(
     {
       message: "Line is too long. [218/200]",
       links: %w[
-        https://rubystyle.guide#80-character-limits
         https://docs.rubocop.org/rubocop/cops_metrics.html#metricslinelength
+        https://rubystyle.guide#80-character-limits
       ],
       id: "Metrics/LineLength",
       path: "cat.rb",

--- a/test/smokes/slim_lint/expectations.rb
+++ b/test/smokes/slim_lint/expectations.rb
@@ -11,7 +11,7 @@ s.add_test(
       location: { start_line: 1 },
       id: "ControlStatementSpacing",
       message: "Please add a space before and after the `=`",
-      links: %W[https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter/README.md#controlstatementspacing],
+      links: %W[https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter#controlstatementspacing],
       object: { severity: "warning" },
       git_blame_info: {
         commit: :_, line_hash: "42229b3500c3d16a805161cc7725da5ec6508be4", original_line: 1, final_line: 1
@@ -22,7 +22,7 @@ s.add_test(
       location: { start_line: 4 },
       id: "LineLength",
       message: "Line is too long. [81/80]",
-      links: %W[https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter/README.md#linelength],
+      links: %W[https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter#linelength],
       object: { severity: "warning" },
       git_blame_info: {
         commit: :_, line_hash: "84a61674282e916a3d2fb186f5909cbaeb1245f8", original_line: 4, final_line: 4
@@ -34,8 +34,8 @@ s.add_test(
       id: "RuboCop:Lint/UselessAssignment",
       message: "Useless assignment to variable - `unused_variable`.",
       links: %W[
-        https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter/README.md#rubocop
         https://docs.rubocop.org/rubocop/cops_lint.html#lintuselessassignment
+        https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter#rubocop
       ],
       object: { severity: "warning" },
       git_blame_info: {
@@ -66,7 +66,7 @@ s.add_test(
       location: { start_line: 2 },
       id: "RuboCop",
       message: "Useless assignment to variable - `unused_variable`.",
-      links: %W[https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter/README.md#rubocop],
+      links: %W[https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter#rubocop],
       object: { severity: "warning" },
       git_blame_info: {
         commit: :_, line_hash: "d5c5462372be75aeed8a878e413ce34e69e38e58", original_line: 2, final_line: 2
@@ -85,7 +85,7 @@ s.add_test(
       location: { start_line: 1 },
       id: "LineLength",
       message: "Line is too long. [14/10]",
-      links: %W[https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter/README.md#linelength],
+      links: %W[https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter#linelength],
       object: { severity: "warning" },
       git_blame_info: {
         commit: :_, line_hash: "42229b3500c3d16a805161cc7725da5ec6508be4", original_line: 1, final_line: 1
@@ -96,7 +96,7 @@ s.add_test(
       location: { start_line: 1 },
       id: "LineLength",
       message: "Line is too long. [14/10]",
-      links: %W[https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter/README.md#linelength],
+      links: %W[https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter#linelength],
       object: { severity: "warning" },
       git_blame_info: {
         commit: :_, line_hash: "42229b3500c3d16a805161cc7725da5ec6508be4", original_line: 1, final_line: 1
@@ -136,7 +136,7 @@ s.add_test(
       location: { start_line: 2 },
       id: "LineLength",
       message: "Line is too long. [201/200]",
-      links: %W[https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter/README.md#linelength],
+      links: %W[https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter#linelength],
       object: { severity: "warning" },
       git_blame_info: {
         commit: :_, line_hash: "d626bb1e60255b6036c470a4818cf804988c4329", original_line: 2, final_line: 2
@@ -155,7 +155,7 @@ s.add_test(
       location: { start_line: 1 },
       id: "ControlStatementSpacing",
       message: "Please add a space before and after the `=`",
-      links: %W[https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter/README.md#controlstatementspacing],
+      links: %W[https://github.com/sds/slim-lint/blob/v#{default_version}/lib/slim_lint/linter#controlstatementspacing],
       object: { severity: "warning" },
       git_blame_info: {
         commit: :_, line_hash: "a745aa127a65767383c35e96e2ea3e5dde882cef", original_line: 1, final_line: 1


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to prefer cop links over style guide links because the former is more stable.
(also for HAML-Lint and Slim-Lint)

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
