### PR TITLE
[remark-lint] Fix empty output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.48.0...HEAD)
 
+- **remark-lint** Fix empty output [#2376](https://github.com/sider/runners/pull/2376)
+
 ## 0.48.0
 
 [Full diff](https://github.com/sider/runners/compare/0.47.0...0.48.0)

--- a/lib/runners/processor/remark_lint.rb
+++ b/lib/runners/processor/remark_lint.rb
@@ -77,9 +77,7 @@ module Runners
       issues, errors = parse_result(stderr)
 
       if errors.empty?
-        Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
-          issues.each { |i| result.add_issue(i) }
-        end
+        Results::Success.new(guid: guid, analyzer: analyzer, issues: issues)
       else
         errors.each { |e| trace_writer.error(e) }
 
@@ -144,6 +142,8 @@ module Runners
     def parse_result(output)
       issues = []
       errors = []
+
+      output = "[]" if output.empty?
 
       JSON.parse(output, symbolize_names: true).each do |file|
         path = relative_path(file[:path])


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

For some reason, remark-lint outputs an empty string (not `[]`), so this change addresses the case to avoid `JSON::ParserError`.
(I could not find the reproduction, though.)

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
