### PR TITLE
Address too long warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.48.1...HEAD)
 
+- Address too long warning message [#2377](https://github.com/sider/runners/pull/2377)
+
 ## 0.48.1
 
 [Full diff](https://github.com/sider/runners/compare/0.48.0...0.48.1)

--- a/lib/runners/warnings.rb
+++ b/lib/runners/warnings.rb
@@ -7,10 +7,10 @@ module Runners
       @trace_writer = trace_writer
     end
 
-    def add(message, file: nil)
+    def add(message, file: nil, limit: 1000)
       message = message.strip
       trace_writer&.warning(message, file: file)
-      new_warning = { message: message, file: file }
+      new_warning = { message: truncate_message(message, limit), file: file }
       @list << new_warning unless @list.include? new_warning
     end
 
@@ -50,6 +50,13 @@ module Runners
 
     def deadline_text(time)
       time&.strftime("on %B %-d, %Y") || "soon"
+    end
+
+    def truncate_message(message, limit)
+      if message.size > limit
+        message = message.slice(0, limit).to_s + "\n...(truncated)"
+      end
+      message
     end
   end
 end

--- a/sig/runners/warnings.rbs
+++ b/sig/runners/warnings.rbs
@@ -6,7 +6,7 @@ module Runners
 
     def initialize: (?trace_writer: TraceWriter?) -> void
 
-    def add: (String, ?file: String?) -> void
+    def add: (String, ?file: String?, ?limit: Integer) -> void
 
     def add_warning_if_deprecated_version: (String, current: String, minimum: String, ?deadline: Time?) -> void
 
@@ -24,5 +24,7 @@ module Runners
     private
 
     def deadline_text: (Time?) -> String
+
+    def truncate_message: (String, Integer) -> String
   end
 end

--- a/test/warnings_test.rb
+++ b/test/warnings_test.rb
@@ -16,6 +16,12 @@ class WarningsTest < Minitest::Test
                      { message: "baz", file: "a.yml" }]
   end
 
+  def test_add_with_truncated_message
+    warnings.add "0123456789_", limit: 10
+
+    assert_warnings [{ message: "0123456789\n...(truncated)", file: nil }]
+  end
+
   def test_add_with_trace_writer
     trace_writer = new_trace_writer
     warnings = Runners::Warnings.new(trace_writer: trace_writer)


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Some analyzers can produce too long warning messages. We cannot save such messages in our database.
So, this change truncates too long messages in the `Runners::Warnings` class.

For example:
https://github.com/sider/runners/blob/c9bbe93e82dd44b6d73446b0b70749cf2dec8284/lib/runners/processor/phpmd.rb#L141

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
