### PR TITLE
Improve the use of emojis on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,45 +15,47 @@ All **41** analyzers are provided as a Docker image:
 |:-----|:------|:------:|
 | Brakeman | [docker](https://hub.docker.com/r/sider/runner_brakeman), [source](https://github.com/presidentbeef/brakeman), [doc](https://help.sider.review/tools/ruby/brakeman), [website](https://brakemanscanner.org) | ✅ |
 | Checkstyle | [docker](https://hub.docker.com/r/sider/runner_checkstyle), [source](https://github.com/checkstyle/checkstyle), [doc](https://help.sider.review/tools/java/checkstyle), [website](https://checkstyle.org) | ✅ |
-| Clang-Tidy | [docker](https://hub.docker.com/r/sider/runner_clang_tidy), [source](https://github.com/llvm/llvm-project), [doc](https://help.sider.review/tools/cplusplus/clang-tidy), [website](https://clang.llvm.org/extra/clang-tidy) | ✅ *beta* |
+| Clang-Tidy | [docker](https://hub.docker.com/r/sider/runner_clang_tidy), [source](https://github.com/llvm/llvm-project), [doc](https://help.sider.review/tools/cplusplus/clang-tidy), [website](https://clang.llvm.org/extra/clang-tidy) | 🔨 |
 | CoffeeLint | [docker](https://hub.docker.com/r/sider/runner_coffeelint), [source](https://github.com/coffeelint/coffeelint), [doc](https://help.sider.review/tools/javascript/coffeelint), [website](https://coffeelint.github.io) | ✅ |
 | Cppcheck | [docker](https://hub.docker.com/r/sider/runner_cppcheck), [source](https://github.com/danmar/cppcheck), [doc](https://help.sider.review/tools/cplusplus/cppcheck), [website](http://cppcheck.sourceforge.net) | ✅ |
 | cpplint | [docker](https://hub.docker.com/r/sider/runner_cpplint), [source](https://github.com/cpplint/cpplint), [doc](https://help.sider.review/tools/cplusplus/cpplint) | ✅ |
-| detekt | [docker](https://hub.docker.com/r/sider/runner_detekt), [source](https://github.com/detekt/detekt), [doc](https://help.sider.review/tools/kotlin/detekt), [website](https://detekt.github.io/detekt) | ✅ *beta* |
+| detekt | [docker](https://hub.docker.com/r/sider/runner_detekt), [source](https://github.com/detekt/detekt), [doc](https://help.sider.review/tools/kotlin/detekt), [website](https://detekt.github.io/detekt) | 🔨 |
 | ESLint | [docker](https://hub.docker.com/r/sider/runner_eslint), [source](https://github.com/eslint/eslint), [doc](https://help.sider.review/tools/javascript/eslint), [website](https://eslint.org) | ✅ |
 | Flake8 | [docker](https://hub.docker.com/r/sider/runner_flake8), [source](https://github.com/PyCQA/flake8), [doc](https://help.sider.review/tools/python/flake8), [website](https://flake8.pycqa.org) | ✅ |
-| FxCop | [docker](https://hub.docker.com/r/sider/runner_fxcop), [source](https://github.com/dotnet/roslyn-analyzers), [doc](https://help.sider.review/tools/csharp/fxcop), [website](https://docs.microsoft.com/en-us/visualstudio/code-quality/static-code-analysis-for-managed-code-overview) | ✅ *beta* |
+| FxCop | [docker](https://hub.docker.com/r/sider/runner_fxcop), [source](https://github.com/dotnet/roslyn-analyzers), [doc](https://help.sider.review/tools/csharp/fxcop), [website](https://docs.microsoft.com/en-us/visualstudio/code-quality/static-code-analysis-for-managed-code-overview) | 🔨 |
 | GolangCI-Lint | [docker](https://hub.docker.com/r/sider/runner_golangci_lint), [source](https://github.com/golangci/golangci-lint), [doc](https://help.sider.review/tools/go/golangci-lint), [website](https://golangci-lint.run) | ✅ |
 | Goodcheck | [docker](https://hub.docker.com/r/sider/runner_goodcheck), [source](https://github.com/sider/goodcheck), [doc](https://help.sider.review/tools/others/goodcheck), [website](https://sider.github.io/goodcheck) | ✅ |
 | hadolint | [docker](https://hub.docker.com/r/sider/runner_hadolint), [source](https://github.com/hadolint/hadolint), [doc](https://help.sider.review/tools/dockerfile/hadolint) | ✅ |
 | HAML-Lint | [docker](https://hub.docker.com/r/sider/runner_haml_lint), [source](https://github.com/sds/haml-lint), [doc](https://help.sider.review/tools/ruby/haml-lint) | ✅ |
 | JavaSee | [docker](https://hub.docker.com/r/sider/runner_javasee), [source](https://github.com/sider/JavaSee), [doc](https://help.sider.review/tools/java/javasee) | ✅ |
 | JSHint | [docker](https://hub.docker.com/r/sider/runner_jshint), [source](https://github.com/jshint/jshint), [doc](https://help.sider.review/tools/javascript/jshint), [website](https://jshint.com) | ✅ |
-| ktlint | [docker](https://hub.docker.com/r/sider/runner_ktlint), [source](https://github.com/pinterest/ktlint), [doc](https://help.sider.review/tools/kotlin/ktlint), [website](https://ktlint.github.io) | ✅ *beta* |
-| LanguageTool | [docker](https://hub.docker.com/r/sider/runner_languagetool), [source](https://github.com/languagetool-org/languagetool), [doc](https://help.sider.review/tools/others/languagetool), [website](https://languagetool.org) | ✅ *beta* |
-| Metrics Code Clone | [docker](https://hub.docker.com/r/sider/runner_metrics_codeclone), [source](https://github.com/pmd/pmd), [doc](https://help.sider.review/tools/metrics/codeclone) | ✅ *beta* |
-| Metrics Complexity | [docker](https://hub.docker.com/r/sider/runner_metrics_complexity), [source](https://github.com/terryyin/lizard), [doc](https://help.sider.review/tools/metrics/complexity) | ✅ *beta* |
-| Metrics File Info | [docker](https://hub.docker.com/r/sider/runner_metrics_fileinfo), [source](https://github.com/coreutils/coreutils), [doc](https://help.sider.review/tools/metrics/fileinfo) | ✅ *beta* |
+| ktlint | [docker](https://hub.docker.com/r/sider/runner_ktlint), [source](https://github.com/pinterest/ktlint), [doc](https://help.sider.review/tools/kotlin/ktlint), [website](https://ktlint.github.io) | 🔨 |
+| LanguageTool | [docker](https://hub.docker.com/r/sider/runner_languagetool), [source](https://github.com/languagetool-org/languagetool), [doc](https://help.sider.review/tools/others/languagetool), [website](https://languagetool.org) | 🔨 |
+| Metrics Code Clone | [docker](https://hub.docker.com/r/sider/runner_metrics_codeclone), [source](https://github.com/pmd/pmd), [doc](https://help.sider.review/tools/metrics/codeclone) | 🔨 |
+| Metrics Complexity | [docker](https://hub.docker.com/r/sider/runner_metrics_complexity), [source](https://github.com/terryyin/lizard), [doc](https://help.sider.review/tools/metrics/complexity) | 🔨 |
+| Metrics File Info | [docker](https://hub.docker.com/r/sider/runner_metrics_fileinfo), [source](https://github.com/coreutils/coreutils), [doc](https://help.sider.review/tools/metrics/fileinfo) | 🔨 |
 | Misspell | [docker](https://hub.docker.com/r/sider/runner_misspell), [source](https://github.com/client9/misspell), [doc](https://help.sider.review/tools/others/misspell) | ✅ |
 | Phinder | [docker](https://hub.docker.com/r/sider/runner_phinder), [source](https://github.com/sider/phinder), [doc](https://help.sider.review/tools/php/phinder) | ✅ |
 | PHP_CodeSniffer | [docker](https://hub.docker.com/r/sider/runner_code_sniffer), [source](https://github.com/squizlabs/PHP_CodeSniffer), [doc](https://help.sider.review/tools/php/code-sniffer) | ✅ |
 | PHPMD | [docker](https://hub.docker.com/r/sider/runner_phpmd), [source](https://github.com/phpmd/phpmd), [doc](https://help.sider.review/tools/php/phpmd), [website](https://phpmd.org) | ✅ |
-| PMD CPD | [docker](https://hub.docker.com/r/sider/runner_pmd_cpd), [source](https://github.com/pmd/pmd), [doc](https://help.sider.review/tools/others/pmd-cpd), [website](https://pmd.github.io) | ✅ *beta* |
+| PMD CPD | [docker](https://hub.docker.com/r/sider/runner_pmd_cpd), [source](https://github.com/pmd/pmd), [doc](https://help.sider.review/tools/others/pmd-cpd), [website](https://pmd.github.io) | 🔨 |
 | PMD Java | [docker](https://hub.docker.com/r/sider/runner_pmd_java), [source](https://github.com/pmd/pmd), [doc](https://help.sider.review/tools/java/pmd), [website](https://pmd.github.io) | ✅ |
-| Pylint | [docker](https://hub.docker.com/r/sider/runner_pylint), [source](https://github.com/PyCQA/pylint), [doc](https://help.sider.review/tools/python/pylint), [website](https://pylint.pycqa.org) | ✅ *beta* |
+| Pylint | [docker](https://hub.docker.com/r/sider/runner_pylint), [source](https://github.com/PyCQA/pylint), [doc](https://help.sider.review/tools/python/pylint), [website](https://pylint.pycqa.org) | 🔨 |
 | Querly | [docker](https://hub.docker.com/r/sider/runner_querly), [source](https://github.com/soutaro/querly), [doc](https://help.sider.review/tools/ruby/querly) | ✅ |
-| Rails Best Practices | [docker](https://hub.docker.com/r/sider/runner_rails_best_practices), [source](https://github.com/flyerhzm/rails_best_practices), [doc](https://help.sider.review/tools/ruby/rails-best-practices), [website](https://rails-bestpractices.com) | ⚠️ *deprecated* |
+| Rails Best Practices | [docker](https://hub.docker.com/r/sider/runner_rails_best_practices), [source](https://github.com/flyerhzm/rails_best_practices), [doc](https://help.sider.review/tools/ruby/rails-best-practices), [website](https://rails-bestpractices.com) | ⚠️ |
 | Reek | [docker](https://hub.docker.com/r/sider/runner_reek), [source](https://github.com/troessner/reek), [doc](https://help.sider.review/tools/ruby/reek) | ✅ |
 | remark-lint | [docker](https://hub.docker.com/r/sider/runner_remark_lint), [source](https://github.com/remarkjs/remark-lint), [doc](https://help.sider.review/tools/markdown/remark-lint) | ✅ |
 | RuboCop | [docker](https://hub.docker.com/r/sider/runner_rubocop), [source](https://github.com/rubocop/rubocop), [doc](https://help.sider.review/tools/ruby/rubocop), [website](https://rubocop.org) | ✅ |
-| SCSS-Lint | [docker](https://hub.docker.com/r/sider/runner_scss_lint), [source](https://github.com/sds/scss-lint), [doc](https://help.sider.review/tools/css/scss-lint) | ⚠️ *deprecated* |
-| Secret Scan | [docker](https://hub.docker.com/r/sider/runner_secret_scan), [doc](https://help.sider.review/) | ✅ *beta* |
+| SCSS-Lint | [docker](https://hub.docker.com/r/sider/runner_scss_lint), [source](https://github.com/sds/scss-lint), [doc](https://help.sider.review/tools/css/scss-lint) | ⚠️ |
+| Secret Scan | [docker](https://hub.docker.com/r/sider/runner_secret_scan), [doc](https://help.sider.review/) | 🔨 |
 | ShellCheck | [docker](https://hub.docker.com/r/sider/runner_shellcheck), [source](https://github.com/koalaman/shellcheck), [doc](https://help.sider.review/tools/shellscript/shellcheck), [website](https://www.shellcheck.net) | ✅ |
-| Slim-Lint | [docker](https://hub.docker.com/r/sider/runner_slim_lint), [source](https://github.com/sds/slim-lint), [doc](https://help.sider.review/tools/ruby/slim-lint) | ✅ *beta* |
+| Slim-Lint | [docker](https://hub.docker.com/r/sider/runner_slim_lint), [source](https://github.com/sds/slim-lint), [doc](https://help.sider.review/tools/ruby/slim-lint) | 🔨 |
 | stylelint | [docker](https://hub.docker.com/r/sider/runner_stylelint), [source](https://github.com/stylelint/stylelint), [doc](https://help.sider.review/tools/css/stylelint), [website](https://stylelint.io) | ✅ |
 | SwiftLint | [docker](https://hub.docker.com/r/sider/runner_swiftlint), [source](https://github.com/realm/SwiftLint), [doc](https://help.sider.review/tools/swift/swiftlint), [website](https://realm.github.io/SwiftLint) | ✅ |
-| TSLint | [docker](https://hub.docker.com/r/sider/runner_tslint), [source](https://github.com/palantir/tslint), [doc](https://help.sider.review/tools/javascript/tslint), [website](https://palantir.github.io/tslint) | ⚠️ *deprecated* |
+| TSLint | [docker](https://hub.docker.com/r/sider/runner_tslint), [source](https://github.com/palantir/tslint), [doc](https://help.sider.review/tools/javascript/tslint), [website](https://palantir.github.io/tslint) | ⚠️ |
 | TyScan | [docker](https://hub.docker.com/r/sider/runner_tyscan), [source](https://github.com/sider/TyScan), [doc](https://help.sider.review/tools/javascript/tyscan) | ✅ |
+
+✅ - active, ⚠️ - deprecated, 🔨 - beta
 <!-- AUTO-GENERATED-CONTENT:END (analyzers) -->
 
 ## Developer guide

--- a/tasks/readme/generate.rake
+++ b/tasks/readme/generate.rake
@@ -1,9 +1,12 @@
 require "runners/analyzers"
+require "ostruct"
 
 namespace :readme do
   desc "Generate README file"
   task :generate do
     analyzers = Runners::Analyzers.new
+
+    emoji = OpenStruct.new(active: "✅", deprecated: "⚠️", beta: "🔨").freeze
 
     list = analyzers.map do |id, analyzer|
       links = ["[docker](#{analyzers.docker(id)})"]
@@ -20,11 +23,11 @@ namespace :readme do
       ]
       items << case
                when analyzers.deprecated?(id)
-                 "⚠️ *deprecated*"
+                 emoji.deprecated
                when analyzers.beta?(id)
-                 "✅ *beta*"
+                 emoji.beta
                else
-                 "✅"
+                 emoji.active
                end
 
       "| #{items.join(' | ')} |"
@@ -36,6 +39,8 @@ namespace :readme do
       | Name | Links | Status |
       |:-----|:------|:------:|
       #{list.sort_by(&:downcase).join("\n")}
+
+      #{emoji.active} - active, #{emoji.deprecated} - deprecated, #{emoji.beta} - beta
     MARKDOWN
 
     start_tag = "<!-- AUTO-GENERATED-CONTENT:START (analyzers) -->"


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to make the tools table more readable.

- Use the only emojis for the statuses, not using text.
- Add a legend for the emojis below the table.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
