### PR TITLE
Fix metrics doc links on README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Updated environments:
 Misc:
 
 - `Runners::Analyzers#github` may return `nil` [#2420](https://github.com/sider/runners/pull/2420)
+- Fix metrics doc links on README [#2423](https://github.com/sider/runners/pull/2423)
 
 ## 0.49.1
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ All **41** analyzers are provided as a Docker image:
 | JSHint | [docker](https://hub.docker.com/r/sider/runner_jshint), [source](https://github.com/jshint/jshint), [doc](https://help.sider.review/tools/javascript/jshint), [website](https://jshint.com) | ✅ |
 | ktlint | [docker](https://hub.docker.com/r/sider/runner_ktlint), [source](https://github.com/pinterest/ktlint), [doc](https://help.sider.review/tools/kotlin/ktlint), [website](https://ktlint.github.io) | 🔨 |
 | LanguageTool | [docker](https://hub.docker.com/r/sider/runner_languagetool), [source](https://github.com/languagetool-org/languagetool), [doc](https://help.sider.review/tools/others/languagetool), [website](https://languagetool.org) | 🔨 |
-| Metrics Code Clone | [docker](https://hub.docker.com/r/sider/runner_metrics_codeclone), [source](https://github.com/pmd/pmd), [doc](https://help.sider.review/tools/metrics/codeclone) | 🔨 |
-| Metrics Complexity | [docker](https://hub.docker.com/r/sider/runner_metrics_complexity), [source](https://github.com/terryyin/lizard), [doc](https://help.sider.review/tools/metrics/complexity) | 🔨 |
-| Metrics File Info | [docker](https://hub.docker.com/r/sider/runner_metrics_fileinfo), [source](https://github.com/coreutils/coreutils), [doc](https://help.sider.review/tools/metrics/fileinfo) | 🔨 |
+| Metrics Code Clone | [docker](https://hub.docker.com/r/sider/runner_metrics_codeclone), [source](https://github.com/pmd/pmd), [doc](https://help.sider.review/) | 🔨 |
+| Metrics Complexity | [docker](https://hub.docker.com/r/sider/runner_metrics_complexity), [source](https://github.com/terryyin/lizard), [doc](https://help.sider.review/) | 🔨 |
+| Metrics File Info | [docker](https://hub.docker.com/r/sider/runner_metrics_fileinfo), [source](https://github.com/coreutils/coreutils), [doc](https://help.sider.review/) | 🔨 |
 | Misspell | [docker](https://hub.docker.com/r/sider/runner_misspell), [source](https://github.com/client9/misspell), [doc](https://help.sider.review/tools/others/misspell) | ✅ |
 | Phinder | [docker](https://hub.docker.com/r/sider/runner_phinder), [source](https://github.com/sider/phinder), [doc](https://help.sider.review/tools/php/phinder) | ✅ |
 | PHP_CodeSniffer | [docker](https://hub.docker.com/r/sider/runner_code_sniffer), [source](https://github.com/squizlabs/PHP_CodeSniffer), [doc](https://help.sider.review/tools/php/code-sniffer) | ✅ |

--- a/analyzers.yml
+++ b/analyzers.yml
@@ -102,17 +102,17 @@ analyzers:
   metrics_codeclone:
     name: Metrics Code Clone
     github: pmd/pmd
-    doc: tools/metrics/codeclone
+    doc: ""
     beta: true
   metrics_complexity:
     name: Metrics Complexity
     github: terryyin/lizard
-    doc: tools/metrics/complexity
+    doc: ""
     beta: true
   metrics_fileinfo:
     name: Metrics File Info
     github: coreutils/coreutils
-    doc: tools/metrics/fileinfo
+    doc: ""
     beta: true
   misspell:
     name: Misspell


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to fix the 404 error for metrics links.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
