### PR TITLE
Bump devon_rex images from 2.43.3 to 2.44.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Features:
 
 Updated environments:
 
-- **devon_rex** 2.43.2 -> 2.43.3 [#2417](https://github.com/sider/runners/pull/2417) ([diff](https://github.com/sider/devon_rex/compare/2.43.2...2.43.3))
+- **devon_rex** 2.43.2 -> 2.44.1 [#2417](https://github.com/sider/runners/pull/2417) [#2428](https://github.com/sider/runners/pull/2428) ([diff](https://github.com/sider/devon_rex/compare/2.43.2...2.44.1))
 - **Bundler** 2.2.18 -> 2.2.19 [#2417](https://github.com/sider/runners/pull/2417)
 
 Misc:

--- a/images/Dockerfile.java.erb
+++ b/images/Dockerfile.java.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_java:2.43.3
+FROM sider/devon_rex_java:2.44.1
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 

--- a/images/Dockerfile.npm.erb
+++ b/images/Dockerfile.npm.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_npm:2.43.3
+FROM sider/devon_rex_npm:2.44.1
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 

--- a/images/Dockerfile.php.erb
+++ b/images/Dockerfile.php.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_php:2.43.3
+FROM sider/devon_rex_php:2.44.1
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 

--- a/images/Dockerfile.python.erb
+++ b/images/Dockerfile.python.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_python:2.43.3
+FROM sider/devon_rex_python:2.44.1
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 

--- a/images/Dockerfile.ruby.erb
+++ b/images/Dockerfile.ruby.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_ruby:2.43.3
+FROM sider/devon_rex_ruby:2.44.1
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 

--- a/images/brakeman/Dockerfile
+++ b/images/brakeman/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.43.3
+FROM sider/devon_rex_ruby:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/checkstyle/Dockerfile
+++ b/images/checkstyle/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:2.43.3
+FROM sider/devon_rex_java:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/clang_tidy/Dockerfile
+++ b/images/clang_tidy/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_base:2.43.3
+FROM sider/devon_rex_base:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/clang_tidy/Dockerfile.erb
+++ b/images/clang_tidy/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_base:2.43.3
+FROM sider/devon_rex_base:2.44.1
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 

--- a/images/code_sniffer/Dockerfile
+++ b/images/code_sniffer/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_php:2.43.3
+FROM sider/devon_rex_php:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/coffeelint/Dockerfile
+++ b/images/coffeelint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.43.3
+FROM sider/devon_rex_npm:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/cppcheck/Dockerfile
+++ b/images/cppcheck/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_python:2.43.3
+FROM sider/devon_rex_python:2.44.1
 
 # NOTE: The reason using Python image: when setting `MATCHCOMPILER=yes`, Python is used to optimise cppcheck.
 #

--- a/images/cppcheck/Dockerfile.erb
+++ b/images/cppcheck/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_python:2.43.3
+FROM sider/devon_rex_python:2.44.1
 
 # NOTE: The reason using Python image: when setting `MATCHCOMPILER=yes`, Python is used to optimise cppcheck.
 #

--- a/images/cpplint/Dockerfile
+++ b/images/cpplint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_python:2.43.3
+FROM sider/devon_rex_python:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/detekt/Dockerfile
+++ b/images/detekt/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:2.43.3
+FROM sider/devon_rex_java:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/eslint/Dockerfile
+++ b/images/eslint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.43.3
+FROM sider/devon_rex_npm:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/flake8/Dockerfile
+++ b/images/flake8/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_python:2.43.3
+FROM sider/devon_rex_python:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/fxcop/Dockerfile
+++ b/images/fxcop/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_dotnet:2.43.3
+FROM sider/devon_rex_dotnet:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/fxcop/Dockerfile.erb
+++ b/images/fxcop/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_dotnet:2.43.3
+FROM sider/devon_rex_dotnet:2.44.1
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 

--- a/images/golangci_lint/Dockerfile
+++ b/images/golangci_lint/Dockerfile
@@ -4,7 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM golangci/golangci-lint:v1.40.0 as golangci-lint
 
-FROM sider/devon_rex_go:2.43.3
+FROM sider/devon_rex_go:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/golangci_lint/Dockerfile.erb
+++ b/images/golangci_lint/Dockerfile.erb
@@ -1,6 +1,6 @@
 FROM golangci/golangci-lint:v1.40.0 as golangci-lint
 
-FROM sider/devon_rex_go:2.43.3
+FROM sider/devon_rex_go:2.44.1
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 

--- a/images/goodcheck/Dockerfile
+++ b/images/goodcheck/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.43.3
+FROM sider/devon_rex_ruby:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/hadolint/Dockerfile
+++ b/images/hadolint/Dockerfile
@@ -4,7 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM hadolint/hadolint:v2.4.0-debian as hadolint
 
-FROM sider/devon_rex_base:2.43.3
+FROM sider/devon_rex_base:2.44.1
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} --from=hadolint /bin/hadolint ${RUNNER_USER_BIN}/
 

--- a/images/hadolint/Dockerfile.erb
+++ b/images/hadolint/Dockerfile.erb
@@ -1,6 +1,6 @@
 FROM hadolint/hadolint:v2.4.0-debian as hadolint
 
-FROM sider/devon_rex_base:2.43.3
+FROM sider/devon_rex_base:2.44.1
 
 COPY --chown=<%= chown %> --from=hadolint /bin/hadolint ${RUNNER_USER_BIN}/
 

--- a/images/haml_lint/Dockerfile
+++ b/images/haml_lint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.43.3
+FROM sider/devon_rex_ruby:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/javasee/Dockerfile
+++ b/images/javasee/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:2.43.3
+FROM sider/devon_rex_java:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/javasee/Dockerfile.erb
+++ b/images/javasee/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_java:2.43.3
+FROM sider/devon_rex_java:2.44.1
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 

--- a/images/jshint/Dockerfile
+++ b/images/jshint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.43.3
+FROM sider/devon_rex_npm:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/ktlint/Dockerfile
+++ b/images/ktlint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:2.43.3
+FROM sider/devon_rex_java:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/languagetool/Dockerfile
+++ b/images/languagetool/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:2.43.3
+FROM sider/devon_rex_java:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/languagetool/Dockerfile.erb
+++ b/images/languagetool/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_java:2.43.3
+FROM sider/devon_rex_java:2.44.1
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 

--- a/images/metrics_codeclone/Dockerfile
+++ b/images/metrics_codeclone/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:2.43.3
+FROM sider/devon_rex_java:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/metrics_complexity/Dockerfile
+++ b/images/metrics_complexity/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_python:2.43.3
+FROM sider/devon_rex_python:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/metrics_fileinfo/Dockerfile
+++ b/images/metrics_fileinfo/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_base:2.43.3
+FROM sider/devon_rex_base:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/metrics_fileinfo/Dockerfile.erb
+++ b/images/metrics_fileinfo/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_base:2.43.3
+FROM sider/devon_rex_base:2.44.1
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 <%= render_erb 'images/Dockerfile.end.erb' %>

--- a/images/misspell/Dockerfile
+++ b/images/misspell/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_base:2.43.3
+FROM sider/devon_rex_base:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/misspell/Dockerfile.erb
+++ b/images/misspell/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_base:2.43.3
+FROM sider/devon_rex_base:2.44.1
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 

--- a/images/phinder/Dockerfile
+++ b/images/phinder/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_php:2.43.3
+FROM sider/devon_rex_php:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/phpmd/Dockerfile
+++ b/images/phpmd/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_php:2.43.3
+FROM sider/devon_rex_php:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/pmd_cpd/Dockerfile
+++ b/images/pmd_cpd/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:2.43.3
+FROM sider/devon_rex_java:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/pmd_java/Dockerfile
+++ b/images/pmd_java/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_java:2.43.3
+FROM sider/devon_rex_java:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/pylint/Dockerfile
+++ b/images/pylint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_python:2.43.3
+FROM sider/devon_rex_python:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/querly/Dockerfile
+++ b/images/querly/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.43.3
+FROM sider/devon_rex_ruby:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/rails_best_practices/Dockerfile
+++ b/images/rails_best_practices/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.43.3
+FROM sider/devon_rex_ruby:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/reek/Dockerfile
+++ b/images/reek/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.43.3
+FROM sider/devon_rex_ruby:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/remark_lint/Dockerfile
+++ b/images/remark_lint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.43.3
+FROM sider/devon_rex_npm:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/rubocop/Dockerfile
+++ b/images/rubocop/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.43.3
+FROM sider/devon_rex_ruby:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/scss_lint/Dockerfile
+++ b/images/scss_lint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.43.3
+FROM sider/devon_rex_ruby:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/secret_scan/Dockerfile
+++ b/images/secret_scan/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.43.3
+FROM sider/devon_rex_ruby:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/shellcheck/Dockerfile
+++ b/images/shellcheck/Dockerfile
@@ -4,7 +4,7 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 FROM koalaman/shellcheck:v0.7.2 as shellcheck
 
-FROM sider/devon_rex_base:2.43.3
+FROM sider/devon_rex_base:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/shellcheck/Dockerfile.erb
+++ b/images/shellcheck/Dockerfile.erb
@@ -1,6 +1,6 @@
 FROM koalaman/shellcheck:v0.7.2 as shellcheck
 
-FROM sider/devon_rex_base:2.43.3
+FROM sider/devon_rex_base:2.44.1
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 

--- a/images/slim_lint/Dockerfile
+++ b/images/slim_lint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_ruby:2.43.3
+FROM sider/devon_rex_ruby:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/stylelint/Dockerfile
+++ b/images/stylelint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.43.3
+FROM sider/devon_rex_npm:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/swiftlint/Dockerfile
+++ b/images/swiftlint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_swift:2.43.3
+FROM sider/devon_rex_swift:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/swiftlint/Dockerfile.erb
+++ b/images/swiftlint/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_swift:2.43.3
+FROM sider/devon_rex_swift:2.44.1
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 

--- a/images/tslint/Dockerfile
+++ b/images/tslint/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.43.3
+FROM sider/devon_rex_npm:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/images/tyscan/Dockerfile
+++ b/images/tyscan/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_npm:2.43.3
+FROM sider/devon_rex_npm:2.44.1
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies

--- a/lib/runners/ignoring.rb
+++ b/lib/runners/ignoring.rb
@@ -14,7 +14,7 @@ module Runners
 
         # @see https://git-scm.com/docs/git-ls-files
         ignored_files, _ = workspace.shell.capture3!(
-          "git", "ls-files", "--ignored", "--exclude-from", gitignore.path,
+          "git", "ls-files", "--ignored", "--cached", "--exclude-from", gitignore.path,
           trace_stdout: false,
         )
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change is created by:
```
$ bundle exec rake bump:devon_rex'[2.44.1]'
```

See also:
- https://github.com/sider/devon_rex/releases/tag/2.44.1
- https://github.com/sider/devon_rex/blob/2.44.1/CHANGELOG.md

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
