### PR TITLE
Drop support for JCenter repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Misc:
 
 - `Runners::Analyzers#github` may return `nil` [#2420](https://github.com/sider/runners/pull/2420)
 - Fix metrics doc links on README [#2423](https://github.com/sider/runners/pull/2423)
+- Drop support for JCenter repository [#2429](https://github.com/sider/runners/pull/2429)
 
 ## 0.49.1
 

--- a/lib/runners/java.rb
+++ b/lib/runners/java.rb
@@ -91,7 +91,8 @@ module Runners
       filename = "build.gradle"
 
       # @see https://docs.gradle.org/current/userguide/declaring_repositories.html
-      repos = ["mavenCentral()", "jcenter()", "google()"].map { |repo| "  #{repo}" }.join("\n")
+      # @see https://blog.gradle.org/jcenter-shutdown
+      repos = ["mavenCentral()", "google()"].map { |repo| "  #{repo}" }.join("\n")
 
       trace_writer.message "Generating #{filename}..." do
         deps = config_jvm_deps.map { |dep| "  implementation '#{dep}'" }.join("\n")

--- a/test/java_test.rb
+++ b/test/java_test.rb
@@ -22,7 +22,6 @@ class JavaTest < Minitest::Test
         }
         repositories {
           mavenCentral()
-          jcenter()
           google()
         }
         dependencies {


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The JCenter repository is now deprecated. See <https://blog.gradle.org/jcenter-shutdown>.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Fix #2227

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
