### PR TITLE
Replace JAVA_TOOL_OPTIONS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Updated tools:
 
 Misc:
 
+- Replace `JAVA_TOOL_OPTIONS` [#2434](https://github.com/sider/runners/pull/2434)
 - `Runners::Analyzers#github` may return `nil` [#2420](https://github.com/sider/runners/pull/2420)
 - Fix metrics doc links on README [#2423](https://github.com/sider/runners/pull/2423)
 - Drop support for JCenter repository [#2429](https://github.com/sider/runners/pull/2429)

--- a/images/Dockerfile.java.erb
+++ b/images/Dockerfile.java.erb
@@ -2,6 +2,9 @@ FROM sider/devon_rex_java:2.44.1
 
 <%= render_erb 'images/Dockerfile.base.erb' %>
 
+# Copy wrapper script
+COPY --chown=<%= chown %> images/runjava ${RUNNER_USER_BIN}/
+
 # Install dependencies via Gradle
 COPY --chown=<%= chown %> images/<%= analyzer %>/build.gradle ${RUNNERS_DEPS_DIR}/
 RUN cd "${RUNNERS_DEPS_DIR}" && \
@@ -12,4 +15,3 @@ RUN cd "${RUNNERS_DEPS_DIR}" && \
     gradle --no-build-cache --parallel --quiet installDeps && \
     rm build.gradle
 ENV CLASSPATH ${RUNNERS_DEPS_DIR}/*:${CLASSPATH}
-ENV JAVA_TOOL_OPTIONS "-XX:MaxRAMPercentage=50"

--- a/images/checkstyle/Dockerfile
+++ b/images/checkstyle/Dockerfile
@@ -22,6 +22,9 @@ RUN cd "${RUNNERS_DIR}" && \
     lockfile_bundler_version=$(bundle exec ruby -e 'puts Bundler.locked_gems.bundler_version') && \
     bundle version | grep "Bundler version ${lockfile_bundler_version}"
 
+# Copy wrapper script
+COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/runjava ${RUNNER_USER_BIN}/
+
 # Install dependencies via Gradle
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/checkstyle/build.gradle ${RUNNERS_DEPS_DIR}/
 RUN cd "${RUNNERS_DEPS_DIR}" && \
@@ -32,7 +35,6 @@ RUN cd "${RUNNERS_DEPS_DIR}" && \
     gradle --no-build-cache --parallel --quiet installDeps && \
     rm build.gradle
 ENV CLASSPATH ${RUNNERS_DEPS_DIR}/*:${CLASSPATH}
-ENV JAVA_TOOL_OPTIONS "-XX:MaxRAMPercentage=50"
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/checkstyle/checkstyle ${RUNNER_USER_BIN}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/checkstyle/sider_recommended_checkstyle.xml ${RUNNER_USER_HOME}/

--- a/images/checkstyle/checkstyle
+++ b/images/checkstyle/checkstyle
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec java com.puppycrawl.tools.checkstyle.Main "$@"
+exec runjava com.puppycrawl.tools.checkstyle.Main "$@"

--- a/images/detekt/Dockerfile
+++ b/images/detekt/Dockerfile
@@ -22,6 +22,9 @@ RUN cd "${RUNNERS_DIR}" && \
     lockfile_bundler_version=$(bundle exec ruby -e 'puts Bundler.locked_gems.bundler_version') && \
     bundle version | grep "Bundler version ${lockfile_bundler_version}"
 
+# Copy wrapper script
+COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/runjava ${RUNNER_USER_BIN}/
+
 # Install dependencies via Gradle
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/detekt/build.gradle ${RUNNERS_DEPS_DIR}/
 RUN cd "${RUNNERS_DEPS_DIR}" && \
@@ -32,7 +35,6 @@ RUN cd "${RUNNERS_DEPS_DIR}" && \
     gradle --no-build-cache --parallel --quiet installDeps && \
     rm build.gradle
 ENV CLASSPATH ${RUNNERS_DEPS_DIR}/*:${CLASSPATH}
-ENV JAVA_TOOL_OPTIONS "-XX:MaxRAMPercentage=50"
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/detekt/detekt ${RUNNER_USER_BIN}/
 

--- a/images/detekt/detekt
+++ b/images/detekt/detekt
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec java io.gitlab.arturbosch.detekt.cli.Main "$@"
+exec runjava io.gitlab.arturbosch.detekt.cli.Main "$@"

--- a/images/ktlint/Dockerfile
+++ b/images/ktlint/Dockerfile
@@ -22,6 +22,9 @@ RUN cd "${RUNNERS_DIR}" && \
     lockfile_bundler_version=$(bundle exec ruby -e 'puts Bundler.locked_gems.bundler_version') && \
     bundle version | grep "Bundler version ${lockfile_bundler_version}"
 
+# Copy wrapper script
+COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/runjava ${RUNNER_USER_BIN}/
+
 # Install dependencies via Gradle
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/ktlint/build.gradle ${RUNNERS_DEPS_DIR}/
 RUN cd "${RUNNERS_DEPS_DIR}" && \
@@ -32,7 +35,6 @@ RUN cd "${RUNNERS_DEPS_DIR}" && \
     gradle --no-build-cache --parallel --quiet installDeps && \
     rm build.gradle
 ENV CLASSPATH ${RUNNERS_DEPS_DIR}/*:${CLASSPATH}
-ENV JAVA_TOOL_OPTIONS "-XX:MaxRAMPercentage=50"
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/ktlint/ktlint ${RUNNER_USER_BIN}/
 

--- a/images/ktlint/ktlint
+++ b/images/ktlint/ktlint
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec java com.pinterest.ktlint.Main "$@"
+exec runjava com.pinterest.ktlint.Main "$@"

--- a/images/languagetool/Dockerfile
+++ b/images/languagetool/Dockerfile
@@ -27,15 +27,11 @@ ARG LANGUAGETOOL_VERSION=5.3
 RUN cd "${RUNNER_USER_HOME}" && \
     curl -sSLO --compressed https://languagetool.org/download/LanguageTool-${LANGUAGETOOL_VERSION}.zip && \
     unzip -q LanguageTool-${LANGUAGETOOL_VERSION}.zip && \
-    rm LanguageTool-${LANGUAGETOOL_VERSION}.zip && \
-    mv LanguageTool-${LANGUAGETOOL_VERSION} LanguageTool
+    rm LanguageTool-${LANGUAGETOOL_VERSION}.zip
 
-ARG LANGUAGETOOL_HOME=${RUNNER_USER_HOME}/LanguageTool
+ENV CLASSPATH ${RUNNER_USER_HOME}/LanguageTool-${LANGUAGETOOL_VERSION}/*:${CLASSPATH}
 
-COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/languagetool/languagetool ${LANGUAGETOOL_HOME}/
-
-ENV CLASSPATH ${LANGUAGETOOL_HOME}/*:${CLASSPATH}
-ENV PATH ${LANGUAGETOOL_HOME}:${PATH}
+COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/languagetool/languagetool images/runjava ${RUNNER_USER_BIN}/
 
 
 # Copy the main source code

--- a/images/languagetool/Dockerfile.erb
+++ b/images/languagetool/Dockerfile.erb
@@ -7,14 +7,10 @@ ARG LANGUAGETOOL_VERSION=5.3
 RUN cd "${RUNNER_USER_HOME}" && \
     curl -sSLO --compressed https://languagetool.org/download/LanguageTool-${LANGUAGETOOL_VERSION}.zip && \
     unzip -q LanguageTool-${LANGUAGETOOL_VERSION}.zip && \
-    rm LanguageTool-${LANGUAGETOOL_VERSION}.zip && \
-    mv LanguageTool-${LANGUAGETOOL_VERSION} LanguageTool
+    rm LanguageTool-${LANGUAGETOOL_VERSION}.zip
 
-ARG LANGUAGETOOL_HOME=${RUNNER_USER_HOME}/LanguageTool
+ENV CLASSPATH ${RUNNER_USER_HOME}/LanguageTool-${LANGUAGETOOL_VERSION}/*:${CLASSPATH}
 
-COPY --chown=<%= chown %> images/<%= analyzer %>/languagetool ${LANGUAGETOOL_HOME}/
-
-ENV CLASSPATH ${LANGUAGETOOL_HOME}/*:${CLASSPATH}
-ENV PATH ${LANGUAGETOOL_HOME}:${PATH}
+COPY --chown=<%= chown %> images/<%= analyzer %>/languagetool images/runjava ${RUNNER_USER_BIN}/
 
 <%= render_erb 'images/Dockerfile.end.erb' %>

--- a/images/languagetool/languagetool
+++ b/images/languagetool/languagetool
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec java org.languagetool.commandline.Main "$@"
+exec runjava org.languagetool.commandline.Main "$@"

--- a/images/metrics_codeclone/Dockerfile
+++ b/images/metrics_codeclone/Dockerfile
@@ -22,6 +22,9 @@ RUN cd "${RUNNERS_DIR}" && \
     lockfile_bundler_version=$(bundle exec ruby -e 'puts Bundler.locked_gems.bundler_version') && \
     bundle version | grep "Bundler version ${lockfile_bundler_version}"
 
+# Copy wrapper script
+COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/runjava ${RUNNER_USER_BIN}/
+
 # Install dependencies via Gradle
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/metrics_codeclone/build.gradle ${RUNNERS_DEPS_DIR}/
 RUN cd "${RUNNERS_DEPS_DIR}" && \
@@ -32,7 +35,6 @@ RUN cd "${RUNNERS_DEPS_DIR}" && \
     gradle --no-build-cache --parallel --quiet installDeps && \
     rm build.gradle
 ENV CLASSPATH ${RUNNERS_DEPS_DIR}/*:${CLASSPATH}
-ENV JAVA_TOOL_OPTIONS "-XX:MaxRAMPercentage=50"
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_cpd/pmd_cpd ${RUNNER_USER_BIN}/
 

--- a/images/pmd_cpd/Dockerfile
+++ b/images/pmd_cpd/Dockerfile
@@ -22,6 +22,9 @@ RUN cd "${RUNNERS_DIR}" && \
     lockfile_bundler_version=$(bundle exec ruby -e 'puts Bundler.locked_gems.bundler_version') && \
     bundle version | grep "Bundler version ${lockfile_bundler_version}"
 
+# Copy wrapper script
+COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/runjava ${RUNNER_USER_BIN}/
+
 # Install dependencies via Gradle
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_cpd/build.gradle ${RUNNERS_DEPS_DIR}/
 RUN cd "${RUNNERS_DEPS_DIR}" && \
@@ -32,7 +35,6 @@ RUN cd "${RUNNERS_DEPS_DIR}" && \
     gradle --no-build-cache --parallel --quiet installDeps && \
     rm build.gradle
 ENV CLASSPATH ${RUNNERS_DEPS_DIR}/*:${CLASSPATH}
-ENV JAVA_TOOL_OPTIONS "-XX:MaxRAMPercentage=50"
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_cpd/pmd_cpd ${RUNNER_USER_BIN}/
 

--- a/images/pmd_cpd/pmd_cpd
+++ b/images/pmd_cpd/pmd_cpd
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec java net.sourceforge.pmd.cpd.CPD "$@"
+exec runjava net.sourceforge.pmd.cpd.CPD "$@"

--- a/images/pmd_java/Dockerfile
+++ b/images/pmd_java/Dockerfile
@@ -22,6 +22,9 @@ RUN cd "${RUNNERS_DIR}" && \
     lockfile_bundler_version=$(bundle exec ruby -e 'puts Bundler.locked_gems.bundler_version') && \
     bundle version | grep "Bundler version ${lockfile_bundler_version}"
 
+# Copy wrapper script
+COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/runjava ${RUNNER_USER_BIN}/
+
 # Install dependencies via Gradle
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_java/build.gradle ${RUNNERS_DEPS_DIR}/
 RUN cd "${RUNNERS_DEPS_DIR}" && \
@@ -32,7 +35,6 @@ RUN cd "${RUNNERS_DEPS_DIR}" && \
     gradle --no-build-cache --parallel --quiet installDeps && \
     rm build.gradle
 ENV CLASSPATH ${RUNNERS_DEPS_DIR}/*:${CLASSPATH}
-ENV JAVA_TOOL_OPTIONS "-XX:MaxRAMPercentage=50"
 
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_java/pmd ${RUNNER_USER_BIN}/
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/pmd_java/sider_recommended_pmd.xml ${RUNNER_USER_HOME}/

--- a/images/pmd_java/pmd
+++ b/images/pmd_java/pmd
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec java net.sourceforge.pmd.PMD "$@"
+exec runjava net.sourceforge.pmd.PMD "$@"

--- a/images/runjava
+++ b/images/runjava
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-java -XX:MaxRAMPercentage=50 "$@"
+exec java -XX:MaxRAMPercentage=50 "$@"

--- a/images/runjava
+++ b/images/runjava
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+java -XX:MaxRAMPercentage=50 "$@"


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change replaces the `JAVA_TOOL_OPTIONS` environment variable with the wrapper script `runjava`.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Fix #2391

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
