### PR TITLE
[PHPMD] Replace XML reporter with JSON one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Misc:
 - Fix metrics doc links on README [#2423](https://github.com/sider/runners/pull/2423)
 - Drop support for JCenter repository [#2429](https://github.com/sider/runners/pull/2429)
 - **JSHint** Enhance JSHint runner [#2430](https://github.com/sider/runners/pull/2430)
+- **PHPMD** Replace XML reporter with JSON one [#2435](https://github.com/sider/runners/pull/2435)
 
 ## 0.49.1
 

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -82,7 +82,7 @@ module Runners
       _stdout, stderr, status = capture3(
         analyzer_bin,
         target_dirs,
-        "xml",
+        "json",
         rule,
         "--ignore-violations-on-exit",
         "--ignore-errors-on-exit",
@@ -103,39 +103,30 @@ module Runners
         end
       end
 
-      begin
-        xml_root = read_report_xml
-      rescue InvalidXML => exn
-        return Results::Failure.new(guid: guid, analyzer: analyzer, message: exn.message)
-      end
-
-      raise "XML must not be empty" unless xml_root
+      json = read_report_json
 
       Results::Success.new(guid: guid, analyzer: analyzer).tap do |result|
         # Note: See below to view the XML schema:
         #
-        # @see https://github.com/phpmd/phpmd/blob/2.9.1/src/main/php/PHPMD/Renderer/XMLRenderer.php
+        # @see https://github.com/phpmd/phpmd/blob/2.10.1/src/main/php/PHPMD/Renderer/JSONRenderer.php
 
-        xml_root.each_element('file') do |file|
-          filename = file[:name] or raise "Filename must be present: #{file.inspect}"
-          path = relative_path(filename)
+        json.fetch(:files, []).each do |file|
+          path = relative_path(file.fetch(:file))
 
-          file.each_element('violation') do |violation|
-            message = violation.text or raise "Message must be present: #{violation.inspect}"
-
+          file.fetch(:violations).each do |violation|
             result.add_issue Issue.new(
               path: path,
-              location: Location.new(start_line: violation[:beginline], end_line: violation[:endline]),
-              id: violation[:rule],
-              message: message.strip,
-              links: violation[:externalInfoUrl].then { |url| url ? [url] : [] },
+              location: Location.new(start_line: violation.fetch(:beginLine), end_line: violation.fetch(:endLine)),
+              id: violation.fetch(:rule),
+              message: violation.fetch(:description),
+              links: Array(violation.fetch(:externalInfoUrl)).reject(&:empty?),
             )
           end
         end
 
-        xml_root.each_element('error') do |error|
-          filename = error[:filename] or raise "Filename must be present: #{error.inspect}"
-          message = error[:msg] or raise "Message must be present: #{error.inspect}"
+        json.fetch(:errors, []).each do |error|
+          filename = error.fetch(:fileName)
+          message = error.fetch(:message)
 
           if filename.empty?
             add_warning message

--- a/lib/runners/processor/phpmd.rb
+++ b/lib/runners/processor/phpmd.rb
@@ -119,7 +119,9 @@ module Runners
               location: Location.new(start_line: violation.fetch(:beginLine), end_line: violation.fetch(:endLine)),
               id: violation.fetch(:rule),
               message: violation.fetch(:description),
-              links: Array(violation.fetch(:externalInfoUrl)).reject(&:empty?),
+              links: violation.fetch(:externalInfoUrl).then do |link|
+                (link.nil? || link.empty?) ? [] : [link]
+              end,
             )
           end
         end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Parsing XML is hard because:
- slow
- unstable
- dependent on a library (REXML vs Nokogiri)

The PHPMD's XML reporter implementation seems flaky because it uses string concatenation.
On the other hand, its JSON reporter uses the built-in function [`json_encode()`](https://www.php.net/manual/en/function.json-encode.php), which seems more reilable.

See also:
- https://github.com/phpmd/phpmd/blob/2.10.1/src/main/php/PHPMD/Renderer/JSONRenderer.php
- https://github.com/phpmd/phpmd/blob/2.10.1/src/main/php/PHPMD/Renderer/XMLRenderer.php

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Related to #2427 

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
