### PR TITLE
Bump pmd-dist from 6.34.0 to 6.35.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,8 @@ updates:
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
     labels: ["dependencies", "language: java"]
+    allow:
+      - dependency-name: "*pmd-dist*"
 
   - package-ecosystem: gradle
     directory: "/images/pmd_java"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Updated tools:
 - **GolangCI-Lint** 1.40.0 -> 1.40.1 [#2379](https://github.com/sider/runners/pull/2379)
 - **hadolint** 2.4.0 -> 2.4.1 [#2380](https://github.com/sider/runners/pull/2380)
 - **JSHint** 2.12.0 -> 2.13.0 [#2402](https://github.com/sider/runners/pull/2402)
+- **PMD CPD** 6.34.0 -> 6.35.0 [#2440](https://github.com/sider/runners/pull/2440)
 - **PMD Java** 6.34.0 -> 6.35.0 [#2406](https://github.com/sider/runners/pull/2406)
 - **Pylint** 2.8.2 -> 2.8.3 [#2425](https://github.com/sider/runners/pull/2425)
 - **RuboCop** 1.14.0 -> 1.16.1 [#2416](https://github.com/sider/runners/pull/2416) [#2436](https://github.com/sider/runners/pull/2436)

--- a/images/pmd_cpd/build.gradle
+++ b/images/pmd_cpd/build.gradle
@@ -7,10 +7,11 @@ repositories {
 }
 
 dependencies {
-    implementation "net.sourceforge.pmd:pmd-dist:6.34.0"
+    implementation "net.sourceforge.pmd:pmd-dist:6.35.0"
 
     // Additional languages not included in `pmd-dist`
-    implementation "net.sourceforge.pmd:pmd-apex:6.34.0"
-    implementation "net.sourceforge.pmd:pmd-scala_2.13:6.34.0"
-    implementation "net.sourceforge.pmd:pmd-visualforce:6.34.0"
+    implementation "net.sourceforge.pmd:pmd-apex:6.35.0"
+    implementation "net.sourceforge.pmd:pmd-javascript:6.35.0"
+    implementation "net.sourceforge.pmd:pmd-scala_2.13:6.35.0"
+    implementation "net.sourceforge.pmd:pmd-visualforce:6.35.0"
 }

--- a/test/smokes/metrics_codeclone/expectations.rb
+++ b/test/smokes/metrics_codeclone/expectations.rb
@@ -1,6 +1,6 @@
 s = Runners::Testing::Smoke
 
-default_version = "6.34.0"
+default_version = "6.35.0"
 
 s.add_test(
   "success",

--- a/test/smokes/pmd_cpd/expectations.rb
+++ b/test/smokes/pmd_cpd/expectations.rb
@@ -1,6 +1,6 @@
 s = Runners::Testing::Smoke
 
-default_version = "6.34.0"
+default_version = "6.35.0"
 
 s.add_test(
   "success",


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

See https://github.com/pmd/pmd/releases/tag/pmd_releases%2F6.35.0

Note: JavaScript module has not been bundled by default, so `pmd-javascript` is necessary.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Re-challenge of #2405

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
