### PR TITLE
PMD CPD performance tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Misc:
 - **JSHint** Enhance JSHint runner [#2430](https://github.com/sider/runners/pull/2430)
 - **PMD CPD** Fix supported languages [#2432](https://github.com/sider/runners/pull/2432)
 - Change XML parser from `REXML` to `Nokogiri` [#2427](https://github.com/sider/runners/pull/2427)
+- **PMD CPD** Performance tuning [#2447](https://github.com/sider/runners/pull/2447)
 
 ## 0.49.1
 

--- a/sig/runners/processor/pmd_cpd.rbs
+++ b/sig/runners/processor/pmd_cpd.rbs
@@ -29,7 +29,7 @@ module Runners
 
     def to_fileinfo: (Nokogiri::XML::Node) -> fileinfo
 
-    def create_issue_object: (Nokogiri::XML::Node, Array[fileinfo]) -> Hash[Symbol, untyped]
+    def create_file_objects: (Array[fileinfo]) -> Array[untyped]
 
     def option_files: () -> Array[String]
 

--- a/sig/runners/processor/pmd_cpd.rbs
+++ b/sig/runners/processor/pmd_cpd.rbs
@@ -27,9 +27,11 @@ module Runners
 
     type fileinfo = { id: String, path: Pathname, location: Location }
 
+    def create_files_and_codefragment: (Nokogiri::XML::Node) -> [Array[fileinfo], String]
+
     def to_fileinfo: (Nokogiri::XML::Node) -> fileinfo
 
-    def create_file_objects: (Array[fileinfo]) -> Array[untyped]
+    def create_duplicated_files: (Array[fileinfo]) -> Array[untyped]
 
     def option_files: () -> Array[String]
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This PR has two refactorings for performance tuning of `PMC CPD`.

- move out the logic not related loop from the loop
- not use the `search(xpath)`

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
