### PR TITLE
[Secret Scan] Fix `NotImplementedError` with `Runners::ConfigGenerator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/sider/runners/compare/0.50.1...HEAD)
 
+- **Secret Scan** Fix `NotImplementedError` with `Runners::ConfigGenerator` [#2462](https://github.com/sider/runners/pull/2462)
+
 ## 0.50.1
 
 [Full diff](https://github.com/sider/runners/compare/0.50.0...0.50.1)
 
-- [Secret Scan] Add doc URL [#2455](https://github.com/sider/runners/pull/2455)
+- **Secret Scan** Add doc URL [#2455](https://github.com/sider/runners/pull/2455)
 
 ## 0.50.0
 

--- a/lib/runners/config_generator.rb
+++ b/lib/runners/config_generator.rb
@@ -8,15 +8,18 @@ module Runners
     private
 
     def load_template(tools)
+      tools_and_examples = tools.each_with_object({}) do |tool, hash|
+        example_lines = Processor.children.fetch(tool).config_example.strip.lines(chomp: true)
+        hash[tool] = example_lines unless example_lines.empty?
+      end
+
       filename = __FILE__.gsub(/\.rb\Z/, ".yml.erb")
       erb = ERB.new(File.read(filename), trim_mode: "-")
       erb.filename = filename
       erb.result_with_hash({
-        tools: tools.sort,
+        tools: tools_and_examples.keys.sort,
         analyzers: Analyzers.new,
-        tool_examples: tools.each_with_object({}) do |tool, examples|
-          examples[tool] = Processor.children.fetch(tool).config_example.strip.lines(chomp: true)
-        end
+        tool_examples: tools_and_examples,
       })
     end
 

--- a/lib/runners/processor.rb
+++ b/lib/runners/processor.rb
@@ -20,7 +20,7 @@ module Runners
     end
 
     def self.config_example
-      raise NotImplementedError, name
+      raise NotImplementedError, "#{name} needs to implement `.#{__method__}`"
     end
 
     attr_reader :guid, :working_dir, :config, :shell, :trace_writer, :warnings, :options

--- a/lib/runners/processor/secret_scan.rb
+++ b/lib/runners/processor/secret_scan.rb
@@ -8,6 +8,10 @@ module Runners
       )
     end
 
+    def self.config_example
+      ""
+    end
+
     def analyzer_bin
       "goodcheck"
     end

--- a/test/config_generator_test.rb
+++ b/test/config_generator_test.rb
@@ -11,24 +11,35 @@ class ConfigGeneratorTest < Minitest::Test
 
   def test_generate_with_tools
     # NOTE: Use all the tools to check schema for the whole example.
+    not_implemented_classes = [
+      Runners::Processor::MetricsCodeClone,
+      Runners::Processor::MetricsComplexity,
+      Runners::Processor::MetricsFileInfo,
+      Runners::Processor::ScssLint,
+      Runners::Processor::Tslint,
+    ]
     tools = Runners::Processor.children.filter_map do |id, klass|
-      begin
-        klass.config_example
-        id
-      rescue NotImplementedError
-        nil
-      end
+      next if not_implemented_classes.include?(klass)
+      id
     end
 
     end_line = 416
     assert_yaml "test_generate_with_tools.yml",
                 tools: tools,
-                comment_out_lines: [9..end_line, (end_line + 3)..(end_line + 7), (end_line + 10)..(end_line + 14)]
+                comment_out_lines: [9..end_line, (end_line + 3)..(end_line + 7), (end_line + 10)..(end_line + 14)],
+                assert_config: ->(config) {
+                  assert_equal [:brakeman, :checkstyle, :clang_tidy, :code_sniffer, :coffeelint, :cppcheck, :cpplint, :detekt,
+                                :eslint, :flake8, :fxcop, :golangci_lint, :goodcheck, :hadolint, :haml_lint, :javasee, :jshint,
+                                :ktlint, :languagetool, :misspell, :phinder, :phpmd, :pmd_cpd, :pmd_java, :pylint, :querly,
+                                :rails_best_practices, :reek, :remark_lint, :rubocop, :scss_lint, :shellcheck, :slim_lint,
+                                :stylelint, :swiftlint, :tslint, :tyscan],
+                               config.content[:linter].keys.sort, config.inspect
+                }
   end
 
   private
 
-  def assert_yaml(expected_filename, tools:, comment_out_lines:)
+  def assert_yaml(expected_filename, tools:, comment_out_lines:, assert_config: ->(config) {  })
     actual = Runners::ConfigGenerator.new.generate(tools: tools)
 
     assert_equal data(expected_filename).read, actual
@@ -46,10 +57,6 @@ class ConfigGeneratorTest < Minitest::Test
     assert_equal ["*.pdf", "*.mp4", "*.min.*", "images/**"], config.content[:ignore], content
     assert_equal ["master", "development", "/^release-.*$/"], config.content[:branches][:exclude], content
 
-    unless tools.empty?
-      linters = config.content[:linter]
-      tools.each { |tool| assert_instance_of Hash, linters[tool] }
-      assert_equal linters.keys.sort, (tools + %i[scss_lint tslint]).sort
-    end
+    assert_config.call(config)
   end
 end

--- a/test/config_generator_test.rb
+++ b/test/config_generator_test.rb
@@ -19,6 +19,7 @@ class ConfigGeneratorTest < Minitest::Test
       Runners::Processor::Tslint,
     ]
     tools = Runners::Processor.children.filter_map do |id, klass|
+      next unless klass.name.start_with?("Runners::Processor::") # exclude test processor classes
       next if not_implemented_classes.include?(klass)
       id
     end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change aims to prevent the following error:

```ruby
Runners::ConfigGenerator.new.generate(tools: [:secret_scan])
#=> NotImplementedError occurs!
```

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
