### PR TITLE
Use `docker/login-action`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,12 +84,15 @@ jobs:
           TAG: ${{ steps.define_vars.outputs.tag }}
           DEBUG: true
           RUNNERS_TIMEOUT: 3m
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Publish Docker image
         if: |
           steps.define_vars.outputs.tag == 'master' || startsWith(github.ref, 'refs/tags/')
-        run: |
-          echo '${{ secrets.DOCKER_PASSWORD }}' | docker login --username '${{ secrets.DOCKER_USER }}' --password-stdin
-          bundle exec rake docker:push
+        run: bundle exec rake docker:push
         env:
           ANALYZER: ${{ matrix.analyzer }}
           TAG: ${{ steps.define_vars.outputs.tag }}


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change introduces the official [`docker/login-action`](https://github.com/docker/login-action) action created by Docker.

This action supports automatic logout and 3rd-party registries like ECR.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
