### PR TITLE
Replace `devon_rex_haskell` in test data

### DIFF
--- a/test/smokes/hadolint/config_option/Dockerfile
+++ b/test/smokes/hadolint/config_option/Dockerfile
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_haskell:2.4.0
+FROM sider/devon_rex_base:2.4.0
 
 USER root
 RUN cd ..

--- a/test/smokes/hadolint/default/src/Dockerfile
+++ b/test/smokes/hadolint/default/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_haskell:2.4.0
+FROM sider/devon_rex_base:2.4.0
 
 USER root
 RUN cd ..

--- a/test/smokes/hadolint/multi_dockerfile/1/Dockerfile
+++ b/test/smokes/hadolint/multi_dockerfile/1/Dockerfile
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_haskell:2.4.0
+FROM sider/devon_rex_base:2.4.0
 
 USER root
 RUN git clone https://github.com/hadolint/hadolint

--- a/test/smokes/hadolint/multi_dockerfile/2/Dockerfile
+++ b/test/smokes/hadolint/multi_dockerfile/2/Dockerfile
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_haskell:2.4.0
+FROM sider/devon_rex_base:2.4.0
 
 USER root
 RUN git clone https://github.com/hadolint/hadolint

--- a/test/smokes/hadolint/multi_dockerfile/Dockerfile.erb
+++ b/test/smokes/hadolint/multi_dockerfile/Dockerfile.erb
@@ -1,3 +1,3 @@
-FROM sider/devon_rex_haskell:2.4.0
+FROM sider/devon_rex_base:2.4.0
 
 USER root

--- a/test/smokes/hadolint/multi_dockerfile/Dockerfile.production
+++ b/test/smokes/hadolint/multi_dockerfile/Dockerfile.production
@@ -1,3 +1,3 @@
-FROM sider/devon_rex_haskell:2.4.0
+FROM sider/devon_rex_base:2.4.0
 
 USER root

--- a/test/smokes/hadolint/multi_dockerfile/Dockerfile.production.erb
+++ b/test/smokes/hadolint/multi_dockerfile/Dockerfile.production.erb
@@ -1,3 +1,3 @@
-FROM sider/devon_rex_haskell:2.4.0
+FROM sider/devon_rex_base:2.4.0
 
 USER root

--- a/test/smokes/hadolint/multi_dockerfile/Dockerfile.production.txt
+++ b/test/smokes/hadolint/multi_dockerfile/Dockerfile.production.txt
@@ -1,3 +1,3 @@
-FROM sider/devon_rex_haskell:2.4.0
+FROM sider/devon_rex_base:2.4.0
 
 USER root

--- a/test/smokes/hadolint/multi_dockerfile/Dockerfile.txt
+++ b/test/smokes/hadolint/multi_dockerfile/Dockerfile.txt
@@ -1,3 +1,3 @@
-FROM sider/devon_rex_haskell:2.4.0
+FROM sider/devon_rex_base:2.4.0
 
 USER root

--- a/test/smokes/hadolint/option_ignore/Dockerfile
+++ b/test/smokes/hadolint/option_ignore/Dockerfile
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_haskell:2.4.0
+FROM sider/devon_rex_base:2.4.0
 
 USER root
 RUN git clone https://github.com/hadolint/hadolint

--- a/test/smokes/hadolint/option_ignore_multi/Dockerfile
+++ b/test/smokes/hadolint/option_ignore_multi/Dockerfile
@@ -1,4 +1,4 @@
-FROM sider/devon_rex_haskell:2.4.0
+FROM sider/devon_rex_base:2.4.0
 
 USER root
 RUN cd ..


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

The `sider/devon_rex_haskell` image is not used actually.
This change aims to reduce our confusion.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
