### PR TITLE
Fix RuboCopUtilsTest

### DIFF
--- a/test/rubocop_utils_test.rb
+++ b/test/rubocop_utils_test.rb
@@ -76,8 +76,8 @@ class RuboCopUtilsTest < Minitest::Test
       ], "Jekyll/NoPAllowed"
       assert_links.call %w[
         https://www.rubydoc.info/gems/rubocop-rake/RuboCop/Cop/Rake/Desc
-        https://github.com/rubocop-hq/rubocop-rake
-      ], "Rake/Desc", additional_statuses: [301] # TODO: Remove `additional_statuses`
+        https://github.com/rubocop/rubocop-rake
+      ], "Rake/Desc"
       assert_links.call %w[
         https://www.rubydoc.info/gems/rubocop-rubycw/RuboCop/Cop/Rubycw/Rubycw
         https://github.com/rubocop/rubocop-rubycw


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Now <https://github.com/rubocop/rubocop-rake> is public.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
