### PR TITLE
Add exit status constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Updated tools:
 Misc:
 
 - **PHPMD** Provide new recommended configuration [#2473](https://github.com/sider/runners/pull/2473)
+- Add exit status constants [#2492](https://github.com/sider/runners/pull/2492)
 
 ## 0.50.5
 

--- a/Steepfile
+++ b/Steepfile
@@ -2,6 +2,7 @@ target :lib do
   signature "sig"
   repo_path "vendor/rbs/gem_rbs_collection/gems"
 
+  check "exe/*"
   check "lib"
 
   library "pathname"

--- a/exe/runners
+++ b/exe/runners
@@ -5,11 +5,9 @@ $LOAD_PATH.prepend File.join(__dir__, "..", "lib")
 require "runners"
 require "runners/cli"
 
-EXIT_STATUS_FOR_SIGTERM = 126
-
 trap('SIGTERM') do
   Bugsnag.notify(Runners::TimeoutError.new)
-  exit(EXIT_STATUS_FOR_SIGTERM)
+  exit Runners::Exitstatus::SIGTERM
 end
 
 trap('SIGUSR2') do

--- a/exe/runners
+++ b/exe/runners
@@ -1,16 +1,16 @@
 #!/usr/bin/env ruby
 
-$LOAD_PATH.prepend File.join(__dir__, "..", "lib")
+$LOAD_PATH.prepend File.join(__dir__.to_s, "..", "lib")
 
 require "runners"
 require "runners/cli"
 
-trap('SIGTERM') do
+Signal.trap('SIGTERM') do
   Bugsnag.notify(Runners::TimeoutError.new)
   exit Runners::Exitstatus::SIGTERM
 end
 
-trap('SIGUSR2') do
+Signal.trap('SIGUSR2') do
   Bugsnag.notify(Runners::TimeoutError.new)
 end
 

--- a/lib/runners.rb
+++ b/lib/runners.rb
@@ -27,6 +27,7 @@ require "parallel"
 
 # application
 require "runners/version"
+require "runners/exitstatus"
 require "runners/errors"
 require "runners/tmpdir"
 require "runners/config"

--- a/lib/runners/exitstatus.rb
+++ b/lib/runners/exitstatus.rb
@@ -1,0 +1,7 @@
+module Runners
+  module Exitstatus
+    SUCCESS = 0
+    TIMEOUT = 124  # See timeout(1) manual.
+    SIGTERM = 126
+  end
+end

--- a/sig/runners/exitstatus.rbs
+++ b/sig/runners/exitstatus.rbs
@@ -1,0 +1,7 @@
+module Runners
+  module Exitstatus
+    SUCCESS: Integer
+    TIMEOUT: Integer
+    SIGTERM: Integer
+  end
+end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Exposing the exit statuses will be helpful for this gem’s clients.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
