### PR TITLE
Remove unused `meowcop` dependency and RuboCop configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Misc:
 - **PHPMD** Provide new recommended configuration [#2473](https://github.com/sider/runners/pull/2473)
 - Add exit status constants [#2492](https://github.com/sider/runners/pull/2492)
 - Use git-clone(1) and git-sparse-checkout(1) for faster download [#2495](https://github.com/sider/runners/pull/2495)
+- Remove unused `meowcop` dependency and RuboCop configuration files [#2497](https://github.com/sider/runners/pull/2497)
 
 ## 0.50.5
 

--- a/images/haml_lint/Gemfile
+++ b/images/haml_lint/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
 gem 'haml_lint', '0.37.1'
-gem 'meowcop'

--- a/images/haml_lint/default_rubocop.yml
+++ b/images/haml_lint/default_rubocop.yml
@@ -1,3 +1,0 @@
-inherit_gem:
-  meowcop:
-    - config/rubocop.yml

--- a/images/rubocop/Gemfile
+++ b/images/rubocop/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
 gem 'rubocop', '1.18.1'
-gem 'meowcop'

--- a/images/rubocop/default_rubocop.yml
+++ b/images/rubocop/default_rubocop.yml
@@ -1,3 +1,0 @@
-inherit_gem:
-  meowcop:
-    - config/rubocop.yml

--- a/images/slim_lint/Gemfile
+++ b/images/slim_lint/Gemfile
@@ -2,4 +2,3 @@ source "https://rubygems.org"
 
 gem "slim_lint", "0.21.1"
 gem "sassc", "2.4.0"
-gem "meowcop"

--- a/images/slim_lint/default_rubocop.yml
+++ b/images/slim_lint/default_rubocop.yml
@@ -1,3 +1,0 @@
-inherit_gem:
-  meowcop:
-    - config/rubocop.yml

--- a/lib/runners/processor/haml_lint.rb
+++ b/lib/runners/processor/haml_lint.rb
@@ -58,13 +58,9 @@ module Runners
 
     def setup
       setup_haml_lint_config
+      setup_default_rubocop_config
 
       default_gems = default_gem_specs(GEM_NAME, *REQUIRED_GEM_NAMES)
-      if setup_default_rubocop_config
-        # NOTE: See rubocop.rb about no versions.
-        default_gems << GemInstaller::Spec.new("meowcop")
-      end
-
       optionals = official_rubocop_plugins + third_party_rubocop_plugins
       install_gems(default_gems, optionals: optionals, constraints: CONSTRAINTS) { yield }
     rescue InstallGemsFailure => exn

--- a/lib/runners/processor/rubocop.rb
+++ b/lib/runners/processor/rubocop.rb
@@ -38,15 +38,9 @@ module Runners
     end
 
     def setup
-      default_gems = default_gem_specs(GEM_NAME)
-      if !rubocop_config_file && setup_default_rubocop_config
-        # NOTE: The latest MeowCop requires usually the latest RuboCop.
-        #       (e.g. MeowCop 2.4.0 requires RuboCop 0.75.0+)
-        #       So, MeowCop versions must be unspecified because the installation will fail when a user's RuboCop is 0.60.0.
-        #       Bundler will select an appropriate version automatically unless versions.
-        default_gems << GemInstaller::Spec.new("meowcop")
-      end
+      setup_default_rubocop_config unless rubocop_config_file
 
+      default_gems = default_gem_specs(GEM_NAME)
       optionals = official_rubocop_plugins + third_party_rubocop_plugins
       install_gems(default_gems, optionals: optionals, constraints: CONSTRAINTS) { yield }
     rescue InstallGemsFailure => exn

--- a/lib/runners/processor/slim_lint.rb
+++ b/lib/runners/processor/slim_lint.rb
@@ -49,14 +49,9 @@ module Runners
 
     def setup
       setup_slim_lint_config
+      setup_default_rubocop_config
 
       default_gems = default_gem_specs(GEM_NAME, *REQUIRED_GEM_NAMES)
-
-      if setup_default_rubocop_config
-        # NOTE: See `Processor::RuboCop` about no versions.
-        default_gems << GemInstaller::Spec.new("meowcop")
-      end
-
       optionals = official_rubocop_plugins + third_party_rubocop_plugins + OPTIONAL_GEMS
       install_gems(default_gems, optionals: optionals, constraints: CONSTRAINTS) { yield }
     rescue InstallGemsFailure => exn


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This change removes:

- default `meowcop` dependencies
- unused `default_rubocop.yml` files

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Fix #2388

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
