### PR TITLE
Add document URL to metrics runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Misc:
 - Add exit status constants [#2492](https://github.com/sider/runners/pull/2492)
 - Use git-clone(1) and git-sparse-checkout(1) for faster download [#2495](https://github.com/sider/runners/pull/2495)
 - Remove unused `meowcop` dependency and RuboCop configuration files [#2497](https://github.com/sider/runners/pull/2497)
+- Add the documentation URL to `Metrics Code Clone`, `Metrics Complexity` and `Metrics File Info` [#2498](https://github.com/sider/runners/pull/2498)
 
 ## 0.50.5
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ All **41** analyzers are provided as a Docker image:
 | JSHint | [docker](https://hub.docker.com/r/sider/runner_jshint), [source](https://github.com/jshint/jshint), [doc](https://help.sider.review/tools/javascript/jshint), [website](https://jshint.com) | ✅ |
 | ktlint | [docker](https://hub.docker.com/r/sider/runner_ktlint), [source](https://github.com/pinterest/ktlint), [doc](https://help.sider.review/tools/kotlin/ktlint), [website](https://ktlint.github.io) | 🔨 |
 | LanguageTool | [docker](https://hub.docker.com/r/sider/runner_languagetool), [source](https://github.com/languagetool-org/languagetool), [doc](https://help.sider.review/tools/others/languagetool), [website](https://languagetool.org) | 🔨 |
-| Metrics Code Clone | [docker](https://hub.docker.com/r/sider/runner_metrics_codeclone), [source](https://github.com/pmd/pmd), [doc](https://help.sider.review/) | 🔨 |
-| Metrics Complexity | [docker](https://hub.docker.com/r/sider/runner_metrics_complexity), [source](https://github.com/terryyin/lizard), [doc](https://help.sider.review/) | 🔨 |
-| Metrics File Info | [docker](https://hub.docker.com/r/sider/runner_metrics_fileinfo), [source](https://github.com/coreutils/coreutils), [doc](https://help.sider.review/) | 🔨 |
+| Metrics Code Clone | [docker](https://hub.docker.com/r/sider/runner_metrics_codeclone), [source](https://github.com/pmd/pmd), [doc](https://help.sider.review/getting-started/code-quality) | 🔨 |
+| Metrics Complexity | [docker](https://hub.docker.com/r/sider/runner_metrics_complexity), [source](https://github.com/terryyin/lizard), [doc](https://help.sider.review/getting-started/code-quality) | 🔨 |
+| Metrics File Info | [docker](https://hub.docker.com/r/sider/runner_metrics_fileinfo), [source](https://github.com/coreutils/coreutils), [doc](https://help.sider.review/getting-started/code-quality) | 🔨 |
 | Misspell | [docker](https://hub.docker.com/r/sider/runner_misspell), [source](https://github.com/client9/misspell), [doc](https://help.sider.review/tools/others/misspell) | ✅ |
 | Phinder | [docker](https://hub.docker.com/r/sider/runner_phinder), [source](https://github.com/sider/phinder), [doc](https://help.sider.review/tools/php/phinder) | ✅ |
 | PHP_CodeSniffer | [docker](https://hub.docker.com/r/sider/runner_code_sniffer), [source](https://github.com/squizlabs/PHP_CodeSniffer), [doc](https://help.sider.review/tools/php/code-sniffer) | ✅ |

--- a/analyzers.yml
+++ b/analyzers.yml
@@ -102,17 +102,17 @@ analyzers:
   metrics_codeclone:
     name: Metrics Code Clone
     github: pmd/pmd
-    doc: ""
+    doc: getting-started/code-quality
     beta: true
   metrics_complexity:
     name: Metrics Complexity
     github: terryyin/lizard
-    doc: ""
+    doc: getting-started/code-quality
     beta: true
   metrics_fileinfo:
     name: Metrics File Info
     github: coreutils/coreutils
-    doc: ""
+    doc: getting-started/code-quality
     beta: true
   misspell:
     name: Misspell


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

We've written the documentation about metrics runners(`Metrics Code Clone`, `Metrics Complexity` and `Metrics File Info`) on [Sider Documentation](https://help.sider.review/getting-started/code-quality).

So, I added the documentation URL to the metrics runners.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

https://github.com/sider/sider-docs/issues/613

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
