### PR TITLE
[Cppcheck] Optimize installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Misc:
 - Use git-clone(1) and git-sparse-checkout(1) for faster download [#2495](https://github.com/sider/runners/pull/2495)
 - Remove unused `meowcop` dependency and RuboCop configuration files [#2497](https://github.com/sider/runners/pull/2497)
 - Add the documentation URL to `Metrics Code Clone`, `Metrics Complexity` and `Metrics File Info` [#2498](https://github.com/sider/runners/pull/2498)
+- **Cppcheck** Optimize installation [#2513](https://github.com/sider/runners/pull/2513)
 
 ## 0.50.6
 

--- a/images/cppcheck/Dockerfile
+++ b/images/cppcheck/Dockerfile
@@ -2,11 +2,38 @@
 # NOTE: DO *NOT* EDIT THIS FILE. IT IS GENERATED.
 # PLEASE UPDATE Dockerfile.erb INSTEAD OF THIS FILE.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-FROM sider/devon_rex_python:2.45.2
+FROM python:3-slim-buster AS cppcheck
 
 # NOTE: The reason using Python image: when setting `MATCHCOMPILER=yes`, Python is used to optimise cppcheck.
-#
-# See https://github.com/danmar/cppcheck#gnu-make
+#       See <https://github.com/danmar/cppcheck/blob/6cb8f877981a491465aba2f9ffb00d6142f6f852/readme.md#gnu-make>
+
+ARG CPPCHECK_VERSION=2.5
+
+# NOTE: A segmentation fault occurs with the latest version of libz3.
+ARG LIBZ3_VERSION=4.4.1-1~deb10u1
+
+RUN apt-get update && \
+    apt-get install -qq -y --no-install-recommends \
+      curl \
+      g++ \
+      make \
+      libpcre3-dev \
+      "libz3-dev=${LIBZ3_VERSION}" && \
+    rm -rf /var/lib/apt/lists/* && \
+    cd /tmp && \
+    curl -sSL --compressed "https://github.com/danmar/cppcheck/archive/${CPPCHECK_VERSION}.tar.gz" | tar -xz && \
+    cd "cppcheck-${CPPCHECK_VERSION}" && \
+    # NOTE: We cannot use the latest version due to a potential segmentation fault.
+    cp -v externals/z3_version_old.h externals/z3_version.h && \
+    make "-j$(nproc)" --silent install \
+      MATCHCOMPILER=yes \
+      PREFIX=/opt/cppcheck \
+      FILESDIR=/opt/cppcheck/share \
+      HAVE_RULES=yes \
+      USE_Z3=yes \
+      CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function"
+
+FROM sider/devon_rex_base:2.45.2
 
 
 ENV RUNNERS_DEPS_DIR ${RUNNER_USER_HOME}/dependencies
@@ -26,27 +53,16 @@ RUN cd "${RUNNERS_DIR}" && \
     lockfile_bundler_version=$(bundle exec ruby -e 'puts Bundler.locked_gems.bundler_version') && \
     bundle version | grep "Bundler version ${lockfile_bundler_version}"
 
-ARG CPPCHECK_VERSION=2.5
-
-# NOTE: A segmentation fault occurs with the latest version of libz3.
+# See above.
 ARG LIBZ3_VERSION=4.4.1-1~deb10u1
 
 USER root
 RUN apt-get update && \
-    apt-get install -qq -y --no-install-recommends "libz3-dev=${LIBZ3_VERSION}" && \
-    rm -rf /var/lib/apt/lists/* && \
-    cd /tmp && \
-    curl -sSL --compressed "https://github.com/danmar/cppcheck/archive/${CPPCHECK_VERSION}.tar.gz" | tar -xz && \
-    cd "cppcheck-${CPPCHECK_VERSION}" && \
-    # NOTE: We cannot use the latest version due to a potential segmentation fault.
-    cp -v externals/z3_version_old.h externals/z3_version.h && \
-    make install -s \
-      MATCHCOMPILER=yes \
-      FILESDIR=/usr/share/cppcheck \
-      HAVE_RULES=yes \
-      USE_Z3=yes \
-      CPPFLAGS="-DUSE_Z3 -Wno-deprecated-declarations -Wno-unused-function" && \
-    rm -rf "cppcheck-${CPPCHECK_VERSION}"
+    apt-get install -qq -y --no-install-recommends \
+      "libz3-dev=${LIBZ3_VERSION}" && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=cppcheck /opt/cppcheck /opt/cppcheck
+ENV PATH /opt/cppcheck/bin:${PATH}
 
 
 # Copy the main source code

--- a/images/cppcheck/Dockerfile.erb
+++ b/images/cppcheck/Dockerfile.erb
@@ -1,31 +1,47 @@
-FROM sider/devon_rex_python:2.45.2
+FROM python:3-slim-buster AS cppcheck
 
 # NOTE: The reason using Python image: when setting `MATCHCOMPILER=yes`, Python is used to optimise cppcheck.
-#
-# See https://github.com/danmar/cppcheck#gnu-make
-
-<%= render_erb 'images/Dockerfile.base.erb' %>
+#       See <https://github.com/danmar/cppcheck/blob/6cb8f877981a491465aba2f9ffb00d6142f6f852/readme.md#gnu-make>
 
 ARG CPPCHECK_VERSION=2.5
 
 # NOTE: A segmentation fault occurs with the latest version of libz3.
 ARG LIBZ3_VERSION=4.4.1-1~deb10u1
 
-USER root
 RUN apt-get update && \
-    apt-get install -qq -y --no-install-recommends "libz3-dev=${LIBZ3_VERSION}" && \
+    apt-get install -qq -y --no-install-recommends \
+      curl \
+      g++ \
+      make \
+      libpcre3-dev \
+      "libz3-dev=${LIBZ3_VERSION}" && \
     rm -rf /var/lib/apt/lists/* && \
     cd /tmp && \
     curl -sSL --compressed "https://github.com/danmar/cppcheck/archive/${CPPCHECK_VERSION}.tar.gz" | tar -xz && \
     cd "cppcheck-${CPPCHECK_VERSION}" && \
     # NOTE: We cannot use the latest version due to a potential segmentation fault.
     cp -v externals/z3_version_old.h externals/z3_version.h && \
-    make install -s \
+    make "-j$(nproc)" --silent install \
       MATCHCOMPILER=yes \
-      FILESDIR=/usr/share/cppcheck \
+      PREFIX=/opt/cppcheck \
+      FILESDIR=/opt/cppcheck/share \
       HAVE_RULES=yes \
       USE_Z3=yes \
-      CPPFLAGS="-DUSE_Z3 -Wno-deprecated-declarations -Wno-unused-function" && \
-    rm -rf "cppcheck-${CPPCHECK_VERSION}"
+      CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function"
+
+FROM sider/devon_rex_base:2.45.2
+
+<%= render_erb 'images/Dockerfile.base.erb' %>
+
+# See above.
+ARG LIBZ3_VERSION=4.4.1-1~deb10u1
+
+USER root
+RUN apt-get update && \
+    apt-get install -qq -y --no-install-recommends \
+      "libz3-dev=${LIBZ3_VERSION}" && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=cppcheck /opt/cppcheck /opt/cppcheck
+ENV PATH /opt/cppcheck/bin:${PATH}
 
 <%= render_erb 'images/Dockerfile.end.erb' %>


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

- Reduce the Docker image size: 1.3GB -> 856MB
- Update the compile options according to the latest document:
  See <https://github.com/danmar/cppcheck/blob/6cb8f877981a491465aba2f9ffb00d6142f6f852/readme.md#gnu-make>

```console
$ docker image ls sider/runner_cppcheck
REPOSITORY              TAG       IMAGE ID       CREATED         SIZE
sider/runner_cppcheck   dev       bb7e99970747   6 minutes ago   856MB
sider/runner_cppcheck   latest    e0c72dbd31ef   2 days ago      1.3GB
```

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
