### PR TITLE
[Metrics File Info] Improve text files extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Misc:
 - Add the documentation URL to `Metrics Code Clone`, `Metrics Complexity` and `Metrics File Info` [#2498](https://github.com/sider/runners/pull/2498)
 - **Cppcheck** Optimize installation [#2513](https://github.com/sider/runners/pull/2513)
 - **Querly** Report syntax error as warning [#2516](https://github.com/sider/runners/pull/2516)
+- **Metrics File Info** Improve text files extraction [#2519](https://github.com/sider/runners/pull/2519)
 
 ## 0.50.6
 

--- a/sig/runners/processor/metrics_fileinfo.rbs
+++ b/sig/runners/processor/metrics_fileinfo.rbs
@@ -39,9 +39,7 @@ module Runners
 
     def commit_summary_within: (*String) -> commit_summary
 
-    def text_files: () -> Set[Pathname]
-
-    def text_file?: (Pathname) -> bool
+    def extract_text_files: (Array[Pathname]) -> Set[Pathname]
 
     def git: (*Shell::command_argument) -> [String, String]
   end


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

Git partial cloning has been enabled by PR #2495, but that change makes git-ls-files(1) too slow.
This change aims to improve the speed of git-ls-files(1).

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Ref: #2495 

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
