### PR TITLE
[Metrics File Info] Improve `git log --numstat` speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Misc:
 - **Cppcheck** Optimize installation [#2513](https://github.com/sider/runners/pull/2513)
 - **Querly** Report syntax error as warning [#2516](https://github.com/sider/runners/pull/2516) [#2520](https://github.com/sider/runners/pull/2520) [#2521](https://github.com/sider/runners/pull/2521)
 - **Metrics File Info** Improve text files extraction [#2519](https://github.com/sider/runners/pull/2519)
+- **Metrics File Info** Improve `git log --numstat` speed [#2522](https://github.com/sider/runners/pull/2522)
 
 ## 0.50.6
 

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -31,7 +31,12 @@ module Runners
     def run
       ensure_result do
         workspace = Workspace.prepare(options: options, working_dir: working_dir, trace_writer: trace_writer)
-        workspace.open do |git_ssh_path, changes|
+
+        # HACK: MetricsFileInfo needs all Git blob objects to calculate code churn.
+        #       This code is so ugly, but I could not find a good way.
+        fast = processor_class != Processor::MetricsFileInfo
+
+        workspace.open(fast: fast) do |git_ssh_path, changes|
           @config = conf = workspace.config
 
           begin

--- a/lib/runners/workspace.rb
+++ b/lib/runners/workspace.rb
@@ -15,12 +15,12 @@ module Runners
       @shell = Shell.new(current_dir: working_dir, trace_writer: trace_writer, env_hash: {})
     end
 
-    def open
+    def open(fast: true)
       prepare_ssh do |git_ssh_path|
         trace_writer.header "Set up source code"
 
         trace_writer.message "Preparing head commit tree..."
-        prepare_head_source
+        prepare_head_source(fast: fast)
 
         changes =
           if options.source.base
@@ -39,7 +39,7 @@ module Runners
       []
     end
 
-    def prepare_head_source
+    def prepare_head_source(fast: true)
       raise NotImplementedError
     end
 

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -22,8 +22,8 @@ module Runners
       raise BlameFailed, "git-blame failed: #{exn.stderr_str}"
     end
 
-    def prepare_head_source
-      git_clone
+    def prepare_head_source(fast: true)
+      git_clone(fast: fast)
       git_setup
 
       # Fetch a pull request if specified (including a forked repository).
@@ -86,14 +86,14 @@ module Runners
 
     # @see https://git-scm.com/docs/git-clone
     # @see https://git-scm.com/docs/partial-clone
-    def git_clone
+    def git_clone(fast:)
       options = %w[
-        --filter=blob:none
         --no-checkout
         --no-recurse-submodules
         --no-tags
         --quiet
       ]
+      options << "--filter=blob:none" if fast
       shell.capture3_with_retry!("git", "clone", *options, "--", remote_url, ".", tries: try_count, sleep: sleep_lambda)
     rescue Shell::ExecError => exn
       raise CloneFailed, "git-clone failed: #{exn.stderr_str}"

--- a/sig/runners/workspace.rbs
+++ b/sig/runners/workspace.rbs
@@ -11,11 +11,11 @@ module Runners
 
     def initialize: (options: Options, working_dir: Pathname, trace_writer: TraceWriter) -> void
 
-    def open: [X] () { (Pathname?, Changes) -> X } -> X
+    def open: [X] (?fast: bool) { (Pathname?, Changes) -> X } -> X
 
     def range_git_blame_info: (String, Integer, Integer, ?trace: bool) -> Array[GitBlameInfo]
 
-    def prepare_head_source: () -> void
+    def prepare_head_source: (?fast: bool) -> void
 
     def patches: () -> GitDiffParser::Patches
 

--- a/sig/runners/workspace/git.rbs
+++ b/sig/runners/workspace/git.rbs
@@ -24,7 +24,7 @@ module Runners
 
     def git_setup: () -> void
 
-    def git_clone: () -> void
+    def git_clone: (fast: bool) -> void
 
     def git_fetch: (Array[String]) -> void
 


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

`git clone --filter=blob:none` makes `git log --numstat` too slow because each blob object is downloaded on demand.

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

Related to #2519

> Check the following if needed.

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
