### PR TITLE
Bump aufgaben from 0.7.1 to 0.8.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :development do
   gem 'rbs', require: false
   gem 'steep', require: false
-  gem 'aufgaben', git: 'https://github.com/ybiquitous/aufgaben.git', tag: '0.7.1', require: false
+  gem 'aufgaben', require: false
   gem 'lefthook', require: false
   gem 'rubocop', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/ybiquitous/aufgaben.git
-  revision: da96337a89168a878ea85e0e8eed795af1deb982
-  tag: 0.7.1
-  specs:
-    aufgaben (0.7.1)
-
 PATH
   remote: .
   specs:
@@ -37,6 +30,7 @@ GEM
       zeitwerk (~> 2.3)
     amazing_print (1.3.0)
     ast (2.4.2)
+    aufgaben (0.8.2)
     aws-eventstream (1.1.1)
     aws-partitions (1.474.0)
     aws-sdk-core (3.115.0)
@@ -136,7 +130,7 @@ PLATFORMS
 
 DEPENDENCIES
   amazing_print
-  aufgaben!
+  aufgaben
   lefthook
   minitest
   rainbow


### PR DESCRIPTION
> Explain a summary, purpose, or background for this change.

This gem is now available on RubyGems.org.

- https://github.com/ybiquitous/aufgaben/releases/tag/0.8.2
- https://github.com/ybiquitous/aufgaben/blob/0.8.2/CHANGELOG.md

> Refer related issues or pull requests (e.g. `Close #123` or `None`).

None.

> Check the following if needed.

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
