### PR TITLE
[WIP][Metrics] Filter out vendor/** from being analyzed by default

### DIFF
--- a/lib/runners.rb
+++ b/lib/runners.rb
@@ -71,6 +71,7 @@ require "runners/schema/options"
 require "runners/schema/trace"
 require "runners/schema/config"
 require "runners/schema/result"
+require "runners/schema/metrics"
 
 # processors
 require "runners/processor"

--- a/lib/runners/config.rb
+++ b/lib/runners/config.rb
@@ -58,6 +58,10 @@ module Runners
       end
     end
 
+    def self.invert_patterns(patterns)
+      patterns.map { |pat| pat.start_with?('!') ? pat.delete_prefix('!') : "!#{pat}" }
+    end
+
     attr_reader :path, :raw_content
 
     def initialize(path:, raw_content:)
@@ -99,6 +103,10 @@ module Runners
 
     def ignore_patterns
       @ignore_patterns ||= Array(content[:ignore])
+    end
+
+    def metrics_ignore_patterns
+      @metrics_ignore_patterns || Array(content.dig(:linter, :metrics, :ignore))
     end
 
     def linter(id)

--- a/lib/runners/harness.rb
+++ b/lib/runners/harness.rb
@@ -35,8 +35,9 @@ module Runners
         # HACK: MetricsFileInfo needs all Git blob objects to calculate code churn.
         #       This code is so ugly, but I could not find a good way.
         fast = processor_class != Processor::MetricsFileInfo
+        run_metrics = [Processor::MetricsCodeClone, Processor::MetricsComplexity, Processor::MetricsFileInfo].include?(processor_class)
 
-        workspace.open(fast: fast) do |git_ssh_path, changes|
+        workspace.open(fast: fast, run_metrics: run_metrics) do |git_ssh_path, changes|
           @config = conf = workspace.config
 
           begin

--- a/lib/runners/schema/metrics.rb
+++ b/lib/runners/schema/metrics.rb
@@ -1,0 +1,14 @@
+module Runners
+  module Schema
+    Metrics = _ = StrongJSON.new do
+      extend ConfigTypes
+      # @type self: MetricsClass
+
+      let :config, object?(
+        ignore: one_or_more_strings?,
+      )
+    end
+
+    Config.register(name: :metrics, schema: Metrics.config)
+  end
+end

--- a/lib/runners/workspace.rb
+++ b/lib/runners/workspace.rb
@@ -15,12 +15,12 @@ module Runners
       @shell = Shell.new(current_dir: working_dir, trace_writer: trace_writer, env_hash: {})
     end
 
-    def open(fast: true)
+    def open(fast: true, run_metrics: false)
       prepare_ssh do |git_ssh_path|
         trace_writer.header "Set up source code"
 
         trace_writer.message "Preparing head commit tree..."
-        prepare_head_source(fast: fast)
+        prepare_head_source(fast: fast, run_metrics: run_metrics)
 
         changes =
           if options.source.base
@@ -39,7 +39,7 @@ module Runners
       []
     end
 
-    def prepare_head_source(fast: true)
+    def prepare_head_source(fast: true, run_metrics: false)
       raise NotImplementedError
     end
 

--- a/lib/runners/workspace/git.rb
+++ b/lib/runners/workspace/git.rb
@@ -22,7 +22,7 @@ module Runners
       raise BlameFailed, "git-blame failed: #{exn.stderr_str}"
     end
 
-    def prepare_head_source(fast: true)
+    def prepare_head_source(fast: true, run_metrics: false)
       git_clone(fast: fast)
       git_setup
 
@@ -34,7 +34,8 @@ module Runners
       git_checkout
 
       # Next, fetch remaining files except for *ignored* files.
-      git_sparse_checkout_set "/**", *config.ignore_patterns.map { |pat| "!#{pat}" }
+      patterns = (run_metrics ? config.metrics_ignore_patterns : []) + config.ignore_patterns
+      git_sparse_checkout_set "/**", *Config.invert_patterns(patterns)
       git_checkout
     end
 

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -14,6 +14,10 @@ class ConfigTest < Minitest::Test
     end
   end
 
+  def test_invert_patterns
+    assert_equal ["foo.txt", "!bar/baz/**", "qux/**"], Runners::Config.invert_patterns(["!foo.txt", "bar/baz/**", "!qux/**"])
+  end
+
   def test_content_without_sider_yml
     assert_equal({}, Runners::Config.new(path: nil, raw_content: nil).content)
   end
@@ -68,6 +72,7 @@ class ConfigTest < Minitest::Test
           jshint: nil,
           ktlint: nil,
           languagetool: nil,
+          metrics: nil,
           misspell: nil,
           phinder: nil,
           phpmd: nil,


### PR DESCRIPTION
### Summary or Background

<!-- Explain a summary, purpose, or background for this change. -->
This aims to reduce analysis duration, meaningless issues and unexpected analysis errors caused by files coming from various third party sources. The common `vendor` directory gets ignored by default.

### Issues or Pull Requests

<!-- Refer related issues or pull requests (e.g. `Close #123` or `None`). -->
None.

### Checklist

<!-- Check the following if needed. -->

- [ ] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
