### PR TITLE
Fix broken links on ChangeLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-[Full diff](/0.53.1...HEAD)
+[Full diff](https://github.com/sider/runners/compare/0.53.1...HEAD)
+
+Misc:
+
+- Fix broken links on ChangeLog [#2567](https://github.com/sider/runners/pull/2567)
 
 ## 0.53.1
 
-[Full diff](https://github.com/sider/runners/compare/0.53.0...HEAD)
+[Full diff](https://github.com/sider/runners/compare/0.53.0...0.53.1)
 
 Misc:
 


### PR DESCRIPTION
### Summary or Background

When I released `runners`, the link was broken on `ChangeLog`. So, I fixed them

### Issues or Pull Requests

`None`

### Checklist

<!-- Check the following if needed. -->

- [x] Add a new entry to [CHANGELOG.md](https://github.com/sider/runners/blob/master/CHANGELOG.md) if this change is notable.
