### PR TITLE
Do not enforce strict npm peer dependencies

### DIFF
--- a/images/Dockerfile.npm.erb
+++ b/images/Dockerfile.npm.erb
@@ -5,7 +5,7 @@ FROM sider/devon_rex_npm:2.45.11
 # Install the default version
 COPY --chown=<%= chown %> images/<%= analyzer %>/package.json ${RUNNERS_DEPS_DIR}/
 RUN cd "${RUNNERS_DEPS_DIR}" && \
-    npm install --strict-peer-deps --ignore-scripts --engine-strict --no-progress --no-save && \
+    npm install --ignore-scripts --engine-strict --no-progress --no-save && \
     rm package*.json && \
     # We can't use NODE_PATH
     # See the details here: https://github.com/sider/runners/issues/2636

--- a/images/coffeelint/Dockerfile
+++ b/images/coffeelint/Dockerfile
@@ -25,7 +25,7 @@ RUN cd "${RUNNERS_DIR}" && \
 # Install the default version
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/coffeelint/package.json ${RUNNERS_DEPS_DIR}/
 RUN cd "${RUNNERS_DEPS_DIR}" && \
-    npm install --strict-peer-deps --ignore-scripts --engine-strict --no-progress --no-save && \
+    npm install --ignore-scripts --engine-strict --no-progress --no-save && \
     rm package*.json && \
     # We can't use NODE_PATH
     # See the details here: https://github.com/sider/runners/issues/2636

--- a/images/eslint/Dockerfile
+++ b/images/eslint/Dockerfile
@@ -25,7 +25,7 @@ RUN cd "${RUNNERS_DIR}" && \
 # Install the default version
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/eslint/package.json ${RUNNERS_DEPS_DIR}/
 RUN cd "${RUNNERS_DEPS_DIR}" && \
-    npm install --strict-peer-deps --ignore-scripts --engine-strict --no-progress --no-save && \
+    npm install --ignore-scripts --engine-strict --no-progress --no-save && \
     rm package*.json && \
     # We can't use NODE_PATH
     # See the details here: https://github.com/sider/runners/issues/2636

--- a/images/jshint/Dockerfile
+++ b/images/jshint/Dockerfile
@@ -25,7 +25,7 @@ RUN cd "${RUNNERS_DIR}" && \
 # Install the default version
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/jshint/package.json ${RUNNERS_DEPS_DIR}/
 RUN cd "${RUNNERS_DEPS_DIR}" && \
-    npm install --strict-peer-deps --ignore-scripts --engine-strict --no-progress --no-save && \
+    npm install --ignore-scripts --engine-strict --no-progress --no-save && \
     rm package*.json && \
     # We can't use NODE_PATH
     # See the details here: https://github.com/sider/runners/issues/2636

--- a/images/remark_lint/Dockerfile
+++ b/images/remark_lint/Dockerfile
@@ -25,7 +25,7 @@ RUN cd "${RUNNERS_DIR}" && \
 # Install the default version
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/remark_lint/package.json ${RUNNERS_DEPS_DIR}/
 RUN cd "${RUNNERS_DEPS_DIR}" && \
-    npm install --strict-peer-deps --ignore-scripts --engine-strict --no-progress --no-save && \
+    npm install --ignore-scripts --engine-strict --no-progress --no-save && \
     rm package*.json && \
     # We can't use NODE_PATH
     # See the details here: https://github.com/sider/runners/issues/2636

--- a/images/stylelint/Dockerfile
+++ b/images/stylelint/Dockerfile
@@ -25,7 +25,7 @@ RUN cd "${RUNNERS_DIR}" && \
 # Install the default version
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/stylelint/package.json ${RUNNERS_DEPS_DIR}/
 RUN cd "${RUNNERS_DEPS_DIR}" && \
-    npm install --strict-peer-deps --ignore-scripts --engine-strict --no-progress --no-save && \
+    npm install --ignore-scripts --engine-strict --no-progress --no-save && \
     rm package*.json && \
     # We can't use NODE_PATH
     # See the details here: https://github.com/sider/runners/issues/2636

--- a/images/tyscan/Dockerfile
+++ b/images/tyscan/Dockerfile
@@ -25,7 +25,7 @@ RUN cd "${RUNNERS_DIR}" && \
 # Install the default version
 COPY --chown=${RUNNER_USER}:${RUNNER_GROUP} images/tyscan/package.json ${RUNNERS_DEPS_DIR}/
 RUN cd "${RUNNERS_DEPS_DIR}" && \
-    npm install --strict-peer-deps --ignore-scripts --engine-strict --no-progress --no-save && \
+    npm install --ignore-scripts --engine-strict --no-progress --no-save && \
     rm package*.json && \
     # We can't use NODE_PATH
     # See the details here: https://github.com/sider/runners/issues/2636


### PR DESCRIPTION
This commit removes the `--strict-peer-dependencies` switch in order to fix failing CI.

The npm install `--strict-peer-dependencies` switch was added in the commit fa6a5e95d8b1858079548187997204c127ad419c, however, possibly due to an [npm bug](https://github.com/npm/cli/issues/3666) building the ESLint image now fails.

Note that when the underlying issue has been resolved, we should probably restore this switch.

Relevant docs:
https://docs.npmjs.com/cli/v7/commands/npm-install#strict-peer-deps

> **strict-peer-deps**
> * Default: false
> * Type: Boolean
>
> If set to true, and --legacy-peer-deps is not set, then any conflicting peerDependencies will be treated as an install failure, even if npm could reasonably guess the appropriate resolution based on non-peer dependency relationships.
> 
> By default, conflicting peerDependencies deep in the dependency graph will be resolved using the nearest non-peer dependency specification, even if doing so will result in some packages receiving a peer dependency outside the range set in their package's peerDependencies object.
> 
> When such and override is performed, a warning is printed, explaining the conflict and the packages involved. If --strict-peer-deps is set, then this warning is treated as a failure.


Fixes: #2767
