### PR TITLE
Bump nodejs from 14 to 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: sudo npm install --global npm@7
+      - run: sudo npm install --global npm@8
       - run: bundle exec rake test
         env:
           TESTOPTS: --verbose

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "repository": "github:sider/runners",
   "engines": {
-    "node": "14",
-    "npm": "7"
+    "node": "16",
+    "npm": "8"
   }
 }


### PR DESCRIPTION
Update nodejs and npm version. 

## Background
The default nodejs version of GitHub Actions ubuntu images was changed to `16`. 
https://github.com/actions/virtual-environments/issues/4446